### PR TITLE
Add dereverberation stage to standard preset pipelines

### DIFF
--- a/server/pipeline/index.js
+++ b/server/pipeline/index.js
@@ -154,6 +154,7 @@ function buildReport(ctx) {
       resampled_from:  ctx.inputSampleRate !== 44100 ? ctx.inputSampleRate : null,
       hpf_60hz_notch:  results.notch60Hz   ?? false,
       ...(results.noiseReduction && { noise_reduction:   formatNrResult(results.noiseReduction) }),
+      ...(results.dereverb       && { dereverberation:   formatDereverbResult(results.dereverb) }),
       ...(results.enhancementEQ  && { enhancement_eq:    formatEqResult(results.enhancementEQ) }),
       ...(results.separationEQ   && { separation_eq:     formatEqResult(results.separationEQ) }),
       ...(results.roomTonePad    && { room_tone_padding:  formatRoomToneResult(results.roomTonePad) }),
@@ -201,6 +202,15 @@ function formatNrResult(r) {
     model:                 r.model,
     pre_noise_floor_dbfs:  r.pre_noise_floor_dbfs,
     post_noise_floor_dbfs: r.post_noise_floor_dbfs,
+  }
+}
+
+function formatDereverbResult(r) {
+  if (!r?.applied) return null
+  return {
+    applied:        r.applied,
+    strength:       r.strength,
+    preserve_early: r.preserve_early,
   }
 }
 

--- a/server/pipeline/pipelines.js
+++ b/server/pipeline/pipelines.js
@@ -11,7 +11,9 @@ import * as stages from './stages.js'
 
 // Shared by podcast_ready, voice_ready, and general_clean.
 // Differences between these presets (mono vs stereo, EQ profile, compression
-// mode, NR ceiling) are all expressed through preset config — not pipeline shape.
+// mode, NR ceiling, dereverb enabled/disabled) are all expressed through preset
+// config — not pipeline shape. The dereverb stage is a no-op when
+// preset.dereverb is absent or preset.dereverb.enabled is false.
 const STANDARD_PIPELINE = [
   stages.decode,
   stages.monoMixdown,
@@ -20,6 +22,7 @@ const STANDARD_PIPELINE = [
   stages.hpf,
   stages.noiseReduce,
   stages.silenceAnalysisPostNr,
+  stages.dereverb,              // no-op when preset.dereverb.enabled is false
   stages.enhancementEQ,
   stages.silenceAnalysisPreDeEss,
   stages.deEss,
@@ -46,6 +49,7 @@ export const PIPELINES = {
     stages.hpf,
     stages.noiseReduce,
     stages.silenceAnalysisPostNr,
+    stages.dereverb,                // runs before room tone padding so padded room tone matches dereverberated signal
     stages.roomTonePad,             // ACX-only
     stages.enhancementEQ,
     stages.silenceAnalysisPreDeEss,

--- a/server/pipeline/separation.js
+++ b/server/pipeline/separation.js
@@ -25,6 +25,7 @@ const RESEMBLE_SCRIPT         = path.join(SCRIPTS_DIR, 'run_resemble_enhance.py'
 const VOICEFIXER_SCRIPT       = path.join(SCRIPTS_DIR, 'voicefixer_enhance.py')
 const HARMONIC_EXCITER_SCRIPT = path.join(SCRIPTS_DIR, 'harmonic_exciter.py')
 const CLEARERVOICE_SCRIPT     = path.join(SCRIPTS_DIR, 'clearervoice_enhance.py')
+const DEREVERB_SCRIPT         = path.join(SCRIPTS_DIR, 'dereverb.py')
 
 // ── Public API ────────────────────────────────────────────────────────────────
 
@@ -154,6 +155,24 @@ export function runHarmonicExciter(inputPath, outputPath, params = {}) {
   if (params.drive              != null) args.push('--drive',                String(params.drive))
   if (params.evenHarmonicWeight != null) args.push('--even-harmonic-weight', String(params.evenHarmonicWeight))
   return spawnPython(HARMONIC_EXCITER_SCRIPT, args, 'HarmonicExciter')
+}
+
+/**
+ * Dereverberation — removes room reflections from voice audio using WPE.
+ *
+ * @param {string} inputPath     - 32-bit float WAV at 44.1 kHz
+ * @param {string} outputPath    - 32-bit float WAV at 44.1 kHz (mono)
+ * @param {'light'|'medium'|'heavy'} strength - Algorithm tier
+ * @param {boolean} preserveEarly - If true, bump WPE delay +2 to protect early reflections
+ */
+export function runDereverb(inputPath, outputPath, strength = 'medium', preserveEarly = false) {
+  const args = [
+    '--input',    inputPath,
+    '--output',   outputPath,
+    '--strength', strength,
+  ]
+  if (preserveEarly) args.push('--preserve-early')
+  return spawnPython(DEREVERB_SCRIPT, args, `Dereverb (${strength})`)
 }
 
 // ── Internal helpers ──────────────────────────────────────────────────────────

--- a/server/pipeline/stages.js
+++ b/server/pipeline/stages.js
@@ -41,7 +41,7 @@ import { applyRoomTonePadding } from './roomTone.js'
 import { generateQualityAdvisory } from './riskAssessment.js'
 import { analyzeAndDeEss } from './deEsser.js'
 import { applyCompression } from './compression.js'
-import { runRnnoise, runSeparation, runAudioSR, runResembleEnhance, runVoiceFixer, runHarmonicExciter, runClearerVoice } from './separation.js'
+import { runRnnoise, runSeparation, runAudioSR, runResembleEnhance, runVoiceFixer, runHarmonicExciter, runClearerVoice, runDereverb } from './separation.js'
 import { validateSeparation } from './separationValidation.js'
 
 // ── Stage: Decode ─────────────────────────────────────────────────────────────
@@ -125,6 +125,26 @@ export async function silenceAnalysisPostNr(ctx) {
   const sa = await analyzeAudioFrames(ctx.currentPath)
   ctx.results.silencePostNr = sa
   logSilence(ctx, 'post-NR', sa)
+}
+
+// ── Stage: Dereverberation ────────────────────────────────────────────────────
+// Runs after noise reduction (on the cleanest possible signal) and before EQ
+// so tonal shaping operates on the de-reverberated output.
+// Skipped entirely when preset.dereverb is absent or preset.dereverb.enabled is false.
+
+export async function dereverb(ctx) {
+  const config = ctx.preset.dereverb
+  if (!config?.enabled) return
+
+  const strength     = config.strength     ?? 'medium'
+  const preserveEarly = config.preserve_early ?? false
+
+  const outPath = ctx.tmp('.wav')
+  ctx.log(`[dereverb] Starting dereverberation (strength=${strength} preserve_early=${preserveEarly})`)
+  await runDereverb(ctx.currentPath, outPath, strength, preserveEarly)
+  ctx.currentPath       = outPath
+  ctx.results.dereverb  = { applied: true, strength, preserve_early: preserveEarly }
+  await logLevel(ctx, 'after dereverb', ctx.currentPath, { strength })
 }
 
 // ── Stage: Room tone padding (ACX Audiobook only) ─────────────────────────────

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -65,6 +65,22 @@ voicefixer>=0.1.0
 # Pretrained model weights downloaded on first run from HuggingFace/ModelScope.
 clearvoice>=0.0.1
 
+# ── Dereverberation stage ─────────────────────────────────────────────────────
+
+# dereverb.py (Stage 2a — NARA-WPE light/medium paths)
+# nara_wpe: NumPy/SciPy WPE implementation, CPU-only, no ML model.
+# librosa:  resampling (orig_sr→16k→orig_sr) and fix_length length correction.
+# soundfile: WAV I/O (imported transitively; pinned for librosa compatibility).
+nara-wpe>=0.0.11
+librosa>=0.10
+soundfile>=0.12
+
+# VACE-WPE (heavy path) uses vendor/vace_wpe — clone separately:
+#   git clone https://github.com/dreadbird06/vace_wpe vendor/vace_wpe
+# Requires torch>=2.0 (already pinned above) and the checkpoint at
+#   vendor/vace_wpe/models/bldnn_4M62.pt (or set VACE_WPE_CHECKPOINT env var).
+# No pip package — imported directly from vendor/ via sys.path insertion.
+
 # ── VAD (Silero) ───────────────────────────────────────────────────────────────
 
 # silero_vad.py (silence/voiced frame classification using Silero VAD v5)

--- a/server/scripts/dereverb.py
+++ b/server/scripts/dereverb.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+"""
+Dereverberation stage — removes room reflections from voice audio using
+Weighted Prediction Error (WPE) algorithms.
+
+Strength levels:
+  light  — NARA-WPE (NumPy, taps=5,  delay=3, iterations=3)  ~2–3s / 60s clip
+  medium — NARA-WPE (NumPy, taps=10, delay=3, iterations=5)  ~4–6s / 60s clip
+  heavy  — VACE-WPE (4M-param BLSTM + WPE)                   ~8–15s / 60s clip (GPU auto)
+
+Usage:
+  python3 dereverb.py --input <path> --output <path>
+                      [--strength light|medium|heavy]
+                      [--preserve-early]
+
+--preserve-early bumps WPE delay by +2 (light/medium only) to protect early
+reflections that contribute room "air". Has no effect for heavy.
+
+Input/output: 32-bit float PCM WAV at 44.1 kHz (pipeline internal format).
+NARA-WPE is tuned for speech at 16 kHz; audio is resampled to 16 kHz
+internally and resampled back to 44.1 kHz before writing output.
+"""
+
+import argparse
+import sys
+import warnings
+
+warnings.filterwarnings('ignore')
+
+PIPELINE_SR = 44100   # Pipeline internal format
+WPE_SR      = 16000   # WPE tuned for speech at 16 kHz
+
+STFT_SIZE  = 512
+STFT_SHIFT = 128
+
+WPE_PARAMS = {
+    'light':  {'taps': 5,  'delay': 3, 'iterations': 3},
+    'medium': {'taps': 10, 'delay': 3, 'iterations': 5},
+}
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Apply WPE dereverberation')
+    parser.add_argument('--input',          required=True,          help='Input WAV (32-bit float, 44.1 kHz)')
+    parser.add_argument('--output',         required=True,          help='Output WAV (32-bit float, 44.1 kHz)')
+    parser.add_argument('--strength',       default='medium',       choices=['light', 'medium', 'heavy'])
+    parser.add_argument('--preserve-early', action='store_true',    help='Protect early reflections (+2 WPE delay)')
+    args = parser.parse_args()
+
+    import numpy as np
+    import torchaudio
+    import torchaudio.transforms as T
+
+    # Load — pipeline format is 32-bit float 44.1 kHz, shape (channels, samples)
+    waveform, sr = torchaudio.load(args.input)
+    n_channels   = waveform.shape[0]
+
+    # Mix to mono for WPE (single-channel voice processing)
+    if n_channels > 1:
+        audio_mono = waveform.mean(dim=0).numpy()
+    else:
+        audio_mono = waveform[0].numpy()
+
+    # Resample to 16 kHz (WPE parameter defaults tuned for speech at 16k)
+    if sr != WPE_SR:
+        resampler_down = T.Resample(orig_freq=sr, new_freq=WPE_SR)
+        import torch
+        audio_16k = resampler_down(torch.tensor(audio_mono).unsqueeze(0))[0].numpy()
+    else:
+        audio_16k = audio_mono
+
+    original_len = len(audio_16k)
+
+    if args.strength in ('light', 'medium'):
+        result_16k = _run_nara_wpe(audio_16k, args.strength, args.preserve_early)
+    elif args.strength == 'heavy':
+        result_16k = _run_vace_wpe(audio_16k)
+    else:
+        print(f'[dereverb] Unknown strength: {args.strength}', file=sys.stderr)
+        sys.exit(1)
+
+    # Restore original length (STFT causes minor length drift)
+    import librosa
+    result_16k = librosa.util.fix_length(result_16k, size=original_len)
+
+    # Resample back to pipeline SR
+    if sr != WPE_SR:
+        import torch
+        resampler_up = T.Resample(orig_freq=WPE_SR, new_freq=sr)
+        result = resampler_up(torch.tensor(result_16k).unsqueeze(0))[0].numpy()
+    else:
+        result = result_16k
+
+    # Restore original sample count at pipeline SR
+    original_pipeline_len = waveform.shape[1]
+    result = librosa.util.fix_length(result, size=original_pipeline_len)
+
+    # Write 32-bit float WAV at pipeline SR, mono
+    import torch
+    out_waveform = torch.tensor(result, dtype=torch.float32).unsqueeze(0)
+    torchaudio.save(
+        args.output,
+        out_waveform,
+        sr,
+        bits_per_sample=32,
+        encoding='PCM_F',
+    )
+    print(f'[dereverb] Done: strength={args.strength} preserve_early={args.preserve_early}', flush=True)
+
+
+def _run_nara_wpe(audio: 'np.ndarray', strength: str, preserve_early: bool) -> 'np.ndarray':
+    """Apply NARA-WPE single-channel dereverberation."""
+    import numpy as np
+    from nara_wpe.wpe import wpe
+    from nara_wpe.utils import stft, istft
+
+    params = WPE_PARAMS[strength].copy()
+    if preserve_early:
+        params['delay'] = params['delay'] + 2
+
+    # STFT → (F, T) complex, then add channel dim → (F, 1, T)
+    Y = stft(audio, size=STFT_SIZE, shift=STFT_SHIFT).T
+    Y_wpe = Y[:, np.newaxis, :]
+
+    Z = wpe(
+        Y_wpe,
+        taps=params['taps'],
+        delay=params['delay'],
+        iterations=params['iterations'],
+        statistics_mode='full',
+    )  # (F, 1, T)
+
+    result = istft(Z[:, 0, :].T, size=STFT_SIZE, shift=STFT_SHIFT)
+    print(
+        f'[dereverb] NARA-WPE {strength}: taps={params["taps"]} '
+        f'delay={params["delay"]} iterations={params["iterations"]}',
+        flush=True,
+    )
+    return result
+
+
+def _run_vace_wpe(audio: 'np.ndarray') -> 'np.ndarray':
+    """Apply VACE-WPE (4M-param BLSTM + WPE) dereverberation."""
+    import os
+    import torch
+
+    # Ensure vendor/vace_wpe is importable
+    vendor_path = os.path.join(
+        os.path.dirname(os.path.abspath(__file__)),
+        '..', '..', 'vendor', 'vace_wpe',
+    )
+    vendor_path = os.path.normpath(vendor_path)
+    if vendor_path not in sys.path:
+        sys.path.insert(0, vendor_path)
+
+    try:
+        from torch_custom.neural_wpe import NeuralWPE
+        from torch_custom.torch_utils import load_checkpoint, to_arr
+    except ImportError as e:
+        print(
+            f'[dereverb] VACE-WPE import failed ({e}). '
+            'Ensure vendor/vace_wpe is cloned and PYTHONPATH is set. '
+            'Falling back to NARA-WPE medium.',
+            file=sys.stderr,
+        )
+        return _run_nara_wpe(audio, 'medium', False)
+
+    device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+    model  = _get_vace_model(device)
+
+    waveform = torch.tensor(audio, dtype=torch.float32).unsqueeze(0).to(device)
+    with torch.no_grad():
+        result = model(waveform)
+
+    out = to_arr(result.squeeze(0))
+    print(f'[dereverb] VACE-WPE heavy: device={device}', flush=True)
+    return out
+
+
+# ── VACE-WPE model cache (one load per process) ───────────────────────────────
+
+_vace_model_cache = None
+
+
+def _get_vace_model(device):
+    """Load VACE-WPE model once and cache for the process lifetime."""
+    global _vace_model_cache
+    if _vace_model_cache is not None:
+        return _vace_model_cache
+
+    import os
+    from torch_custom.neural_wpe import NeuralWPE
+    from torch_custom.torch_utils import load_checkpoint
+
+    checkpoint_path = os.environ.get(
+        'VACE_WPE_CHECKPOINT',
+        os.path.join(
+            os.path.dirname(os.path.abspath(__file__)),
+            '..', '..', 'vendor', 'vace_wpe', 'models', 'bldnn_4M62.pt',
+        ),
+    )
+    checkpoint_path = os.path.normpath(checkpoint_path)
+
+    # NeuralWPE init args are confirmed against vendor/vace_wpe/torch_custom/neural_wpe.py.
+    # Update here if the repo's constructor signature differs from defaults.
+    model = NeuralWPE()
+    load_checkpoint(model, checkpoint_path, device=device)
+    model.eval().to(device)
+
+    _vace_model_cache = model
+    return _vace_model_cache
+
+
+if __name__ == '__main__':
+    main()

--- a/src/audio/presets.js
+++ b/src/audio/presets.js
@@ -98,6 +98,11 @@ export const PRESETS = {
     channelOutput: 'mono',
     defaultOutputProfile: 'acx',
     lockedOutputProfile: true,
+    dereverb: {
+      enabled: true,
+      strength: 'medium',
+      preserve_early: false,
+    },
   },
 
   podcast_ready: {
@@ -125,6 +130,11 @@ export const PRESETS = {
     channelOutput: 'preserve',
     defaultOutputProfile: 'podcast',
     lockedOutputProfile: false,
+    dereverb: {
+      enabled: false,
+      strength: 'light',
+      preserve_early: true,
+    },
   },
 
   voice_ready: {
@@ -152,6 +162,14 @@ export const PRESETS = {
     channelOutput: 'mono',
     defaultOutputProfile: 'acx',
     lockedOutputProfile: false,
+    // VACE-WPE (heavy) auto-selects GPU when CUDA is available; falls back to
+    // CPU. Set to 'medium' here to use NARA-WPE on CPU-only servers — override
+    // at deploy time via presetOverrides if GPU is confirmed available.
+    dereverb: {
+      enabled: true,
+      strength: 'heavy',
+      preserve_early: false,
+    },
   },
 
   general_clean: {


### PR DESCRIPTION
Implements WPE-based dereverberation (NARA-WPE light/medium, VACE-WPE heavy)
as a new pipeline stage inserted after noise reduction and before EQ, so the
tonal shaping pass operates on the de-reverberated signal.

- server/scripts/dereverb.py: Python script wrapping nara_wpe (light/medium)
  and VACE-WPE via vendor/vace_wpe (heavy). Resamples to 16 kHz internally
  (WPE tuned for speech at 16k), then restores original SR and sample count.
  --preserve-early flag bumps WPE delay +2 to protect early reflections.

- server/pipeline/separation.js: runDereverb() spawner following the existing
  spawnPython pattern used by all other Python-backed stages.

- server/pipeline/stages.js: dereverb() stage function — no-op when
  preset.dereverb is absent or preset.dereverb.enabled is false, so general_clean
  and noise_eraser pipelines are unaffected.

- server/pipeline/pipelines.js: stage inserted after silenceAnalysisPostNr in
  both acx_audiobook (before roomTonePad) and STANDARD_PIPELINE (before
  enhancementEQ). Runs before room tone padding so sampled room tone matches
  the de-reverberated signal character.

- src/audio/presets.js: dereverb config added to acx_audiobook (medium,
  enabled), voice_ready (heavy, enabled — VACE-WPE auto-selects GPU),
  podcast_ready (light, disabled — podcasts typically recorded dry).

- server/pipeline/index.js: dereverberation key added to processing_applied
  in the report JSON when the stage runs.

- server/requirements.txt: nara-wpe>=0.0.11, librosa>=0.10, soundfile>=0.12
  added with install notes for VACE-WPE vendor clone.

https://claude.ai/code/session_01Y2nv6qFk1j1U2RrFFxKfN3