### PR TITLE
Move noise floor measurement from histogram to silence analysis

### DIFF
--- a/server/pipeline/index.js
+++ b/server/pipeline/index.js
@@ -190,7 +190,10 @@ function formatMeasurements(m) {
   return {
     rms_dbfs:         m.rmsDbfs,
     true_peak_dbfs:   m.truePeakDbfs,
-    noise_floor_dbfs: m.noiseFloorDbfs,
+    // noiseFloorDbfs is merged into beforeMeasurements / afterMeasurements
+    // by the measureBefore / measureAfter stages from silenceAnalysis. If a
+    // future pipeline forgets to populate it the report emits null.
+    noise_floor_dbfs: m.noiseFloorDbfs ?? null,
     lufs_integrated:  m.lufsIntegrated,
   }
 }

--- a/server/pipeline/logger.js
+++ b/server/pipeline/logger.js
@@ -148,12 +148,13 @@ class PipelineLogger {
         // Full audio measurement at this checkpoint.
         // measureAudio runs FFmpeg volumedetect + libebur128 LUFS/true-peak in
         // parallel, adding ~0.2–0.5 s per step — acceptable for a debug tool.
+        // Noise floor is no longer measured here; it lives on the silence
+        // analysis and is only captured at measureBefore / measureAfter.
         try {
           const m = await measureAudio(audioPath)
           lines.push(
             `   Audio:  RMS=${fmt(m.rmsDbfs)} dBFS  ` +
             `TruePeak=${fmt(m.truePeakDbfs)} dBTP  ` +
-            `NoiseFloor=${fmt(m.noiseFloorDbfs)} dBFS  ` +
             `LUFS=${fmt(m.lufsIntegrated)}`
           )
         } catch (e) {

--- a/server/pipeline/measure.js
+++ b/server/pipeline/measure.js
@@ -1,12 +1,22 @@
 /**
  * Stage 7 — Audio measurement and ACX certification.
  *
- * Measures RMS, true peak, noise floor, and LUFS of a WAV file.
+ * Measures RMS, true peak, and LUFS of a WAV file.
  *
  * LUFS (integrated loudness) and true peak are measured via the ebur128-wasm
  * WASM binding (libebur128), which is more precise than the FFmpeg loudnorm
- * filter proxy used previously. RMS and noise floor still use FFmpeg
- * volumedetect since libebur128 does not expose RMS.
+ * filter proxy used previously. RMS uses FFmpeg volumedetect since libebur128
+ * does not expose RMS.
+ *
+ * Noise floor is NOT measured here. It comes from the frame-based silence
+ * analysis (silenceAnalysis.js) and is merged into the measurements object by
+ * the measureBefore / measureAfter stages. Previous revisions of this file
+ * computed noise floor from FFmpeg volumedetect's histogram by picking the
+ * deepest non-zero bucket, but that reports the level of the single quietest
+ * sample (dominated by zero-crossings) rather than the actual steady-state
+ * silence floor, so it was effectively always below the ACX ceiling and the
+ * noise-floor check passed regardless of the real recording. The silence
+ * analysis bootstrap is the authoritative source.
  *
  * Sprint 2: Added measureVoicedRms() for silence-excluding RMS measurement
  * used in Stage 5 ACX normalization (spec §5b).
@@ -28,7 +38,11 @@ import {
 
 /**
  * Measure audio properties of a WAV file.
- * Returns { rmsDbfs, truePeakDbfs, noiseFloorDbfs, lufsIntegrated }.
+ * Returns { rmsDbfs, truePeakDbfs, lufsIntegrated }.
+ *
+ * Note: noiseFloorDbfs is intentionally not included. Callers that need a
+ * noise floor should merge one in from silenceAnalysis (see measureBefore /
+ * measureAfter stages). See file header for rationale.
  */
 export async function measureAudio(filePath) {
   const [volumeStats, loudnormStats] = await Promise.all([
@@ -37,15 +51,15 @@ export async function measureAudio(filePath) {
   ])
 
   return {
-    rmsDbfs: volumeStats.meanVolume,
-    truePeakDbfs: loudnormStats.truePeak,
-    noiseFloorDbfs: volumeStats.noiseFloor,
+    rmsDbfs:        volumeStats.meanVolume,
+    truePeakDbfs:   loudnormStats.truePeak,
     lufsIntegrated: loudnormStats.integratedLoudness,
   }
 }
 
 /**
- * Use FFmpeg's volumedetect filter for RMS and peak measurements.
+ * Use FFmpeg's volumedetect filter for mean/max volume. Noise floor is
+ * deliberately not derived from the histogram — see file header.
  */
 async function measureVolume(filePath) {
   const { stderr } = await runFfmpeg([
@@ -56,32 +70,14 @@ async function measureVolume(filePath) {
   ])
 
   const meanMatch = stderr.match(/mean_volume:\s*([-\d.]+)\s*dB/)
-  const maxMatch = stderr.match(/max_volume:\s*([-\d.]+)\s*dB/)
+  const maxMatch  = stderr.match(/max_volume:\s*([-\d.]+)\s*dB/)
 
   const meanVolume = meanMatch ? parseFloat(meanMatch[1]) : null
-  const maxVolume = maxMatch ? parseFloat(maxMatch[1]) : null
-
-  // Estimate noise floor from the histogram data if available,
-  // otherwise use a rough estimate (mean - 20 dB as placeholder).
-  // True noise floor measurement requires silence frame analysis.
-  const histMatches = [...stderr.matchAll(/histogram_(\d+)db:\s*(\d+)/g)]
-  let noiseFloor = meanVolume ? meanVolume - 20 : -60
-
-  if (histMatches.length > 0) {
-    // Filter to buckets with non-zero counts, then pick the deepest
-    const nonZero = histMatches.filter(m => parseInt(m[2]) > 0)
-    if (nonZero.length > 0) {
-      const deepest = nonZero.reduce((min, m) =>
-        parseInt(m[1]) > parseInt(min[1]) ? m : min
-      )
-      noiseFloor = -parseInt(deepest[1])
-    }
-  }
+  const maxVolume  = maxMatch  ? parseFloat(maxMatch[1])  : null
 
   return {
     meanVolume: round2(meanVolume),
-    maxVolume: round2(maxVolume),
-    noiseFloor: round2(noiseFloor),
+    maxVolume:  round2(maxVolume),
   }
 }
 
@@ -131,6 +127,8 @@ async function measureLoudness(filePath) {
  * with per-check pass/fail and measured values.
  *
  * @param {object} measurements - { rmsDbfs, truePeakDbfs, noiseFloorDbfs, lufsIntegrated }
+ *   noiseFloorDbfs must be merged in by the caller from silence analysis —
+ *   measureAudio() does not populate it (see file header).
  * @param {object} fileMetadata - { sampleRate: number, bitDepth: string, channels: number }
  * @returns {{ certificate: 'pass'|'fail', checks: object }}
  */
@@ -220,7 +218,9 @@ export async function measureVoicedRms(wavPath, silenceAnalysis) {
 
   if (numFrames === 0) return -60
 
-  // Bootstrap noise floor from lowest 20 frames
+  // Bootstrap noise floor from lowest 20 frames, combined in the power
+  // domain so the result is the RMS of the combined quietest frames rather
+  // than the mean of per-frame RMS values. Matches silenceAnalysis.js.
   const frameRms = new Float64Array(numFrames)
   for (let f = 0; f < numFrames; f++) {
     const s = f * frameSamples
@@ -230,10 +230,10 @@ export async function measureVoicedRms(wavPath, silenceAnalysis) {
   }
 
   const sorted = Float64Array.from(frameRms).sort()
-  let noiseRms = 0
   const n = Math.min(20, sorted.length)
-  for (let i = 0; i < n; i++) noiseRms += sorted[i]
-  noiseRms /= n
+  let noiseSumSq = 0
+  for (let i = 0; i < n; i++) noiseSumSq += sorted[i] * sorted[i]
+  const noiseRms = n > 0 ? Math.sqrt(noiseSumSq / n) : 0
 
   const noiseFloorDb  = noiseRms > 0 ? 20 * Math.log10(noiseRms) : -120
   const thresholdDb   = noiseFloorDb + 6

--- a/server/pipeline/silenceAnalysis.js
+++ b/server/pipeline/silenceAnalysis.js
@@ -122,12 +122,7 @@ async function analyzeAudioFramesSilero(wavPath) {
     frameRms[f] = Math.sqrt(sumSq / frameLengthSamples)
   }
 
-  const sorted = Float64Array.from(frameRms).sort()
-  let noiseRmsLinear = 0
-  const n = Math.min(BOOTSTRAP_FRAMES, sorted.length)
-  for (let i = 0; i < n; i++) noiseRmsLinear += sorted[i]
-  noiseRmsLinear /= n
-
+  const noiseRmsLinear   = bootstrapNoiseRms(frameRms)
   const noiseFloorDbfs   = rmsToDbfs(noiseRmsLinear)
   const silenceThreshold = noiseFloorDbfs + 6
 
@@ -250,13 +245,8 @@ async function analyzeAudioFramesEnergy(wavPath) {
     frameRms[f] = Math.sqrt(sumSq / frameLengthSamples)
   }
 
-  // Bootstrap noise floor: average the BOOTSTRAP_FRAMES lowest-energy frames
-  const sorted = Float64Array.from(frameRms).sort()
-  let noiseRmsLinear = 0
-  const n = Math.min(BOOTSTRAP_FRAMES, sorted.length)
-  for (let i = 0; i < n; i++) noiseRmsLinear += sorted[i]
-  noiseRmsLinear /= n
-
+  // Bootstrap noise floor: RMS over the BOOTSTRAP_FRAMES lowest-energy frames
+  const noiseRmsLinear    = bootstrapNoiseRms(frameRms)
   const noiseFloorDbfs    = rmsToDbfs(noiseRmsLinear)
   const silenceThreshold  = noiseFloorDbfs + 6 // dynamic threshold per spec
 
@@ -345,6 +335,29 @@ function findQuietestSilenceSegment(frames, frameRms, frameLengthSamples) {
 function rmsToDbfs(rms) {
   if (rms <= 0) return -120
   return 20 * Math.log10(rms)
+}
+
+/**
+ * Bootstrap a noise-floor estimate from per-frame linear RMS values.
+ *
+ * Selects the BOOTSTRAP_FRAMES lowest-energy frames and combines them in the
+ * power domain (not linear-RMS average), so the result is mathematically the
+ * RMS of the combined quietest frames — consistent with how voicedRmsDbfs is
+ * computed elsewhere in this module and with how noise floor is compared
+ * against the ACX noiseFloorCeiling downstream.
+ *
+ * A plain mean of linear RMS values underestimates the true RMS whenever the
+ * chosen frames have non-uniform energy, which biases the silenceThreshold
+ * (= noise_floor + 6) low and can cause voiced-frame misclassification in the
+ * energy-fallback branch.
+ */
+function bootstrapNoiseRms(frameRms) {
+  if (frameRms.length === 0) return 0
+  const sorted = Float64Array.from(frameRms).sort()
+  const n = Math.min(BOOTSTRAP_FRAMES, sorted.length)
+  let sumSq = 0
+  for (let i = 0; i < n; i++) sumSq += sorted[i] * sorted[i]
+  return Math.sqrt(sumSq / n)
 }
 
 function round2(n) {

--- a/server/pipeline/stages.js
+++ b/server/pipeline/stages.js
@@ -77,9 +77,22 @@ export async function monoMixdown(ctx) {
 }
 
 // ── Stage: Measure before ─────────────────────────────────────────────────────
+//
+// Runs before peakNormalize and silenceAnalysisRaw, so there is no pre-existing
+// silence analysis to borrow a noise floor from. We run one inline — it's the
+// same work silenceAnalysisRaw would do later, but on the pre-peak-normalize
+// audio, which is what beforeMeasurements is meant to capture. The cost is a
+// single extra analyzeAudioFrames pass per job.
 
 export async function measureBefore(ctx) {
-  ctx.results.beforeMeasurements = await measureAudio(ctx.currentPath)
+  const [audio, silenceAnalysis] = await Promise.all([
+    measureAudio(ctx.currentPath),
+    analyzeAudioFrames(ctx.currentPath),
+  ])
+  ctx.results.beforeMeasurements = {
+    ...audio,
+    noiseFloorDbfs: silenceAnalysis.noiseFloorDbfs,
+  }
 }
 
 // ── Stage: Peak normalize (pre-processing) ───────────────────────────────────
@@ -318,9 +331,23 @@ export async function truePeakLimit(ctx) {
 }
 
 // ── Stage: Measure after ──────────────────────────────────────────────────────
+//
+// Populates afterMeasurements including the noise floor from a fresh silence
+// analysis on the fully processed audio. The ACX noise-floor check runs off
+// this value, so it must reflect the actual silence floor (frame-based) and
+// not a histogram-derived proxy. The silence analysis is stashed on ctx for
+// qualityAdvisory to reuse — avoids a second analyzeAudioFrames pass.
 
 export async function measureAfter(ctx) {
-  ctx.results.afterMeasurements = await measureAudio(ctx.currentPath)
+  const [audio, silenceAnalysis] = await Promise.all([
+    measureAudio(ctx.currentPath),
+    analyzeAudioFrames(ctx.currentPath),
+  ])
+  ctx.results.afterMeasurements = {
+    ...audio,
+    noiseFloorDbfs: silenceAnalysis.noiseFloorDbfs,
+  }
+  ctx.results.afterSilenceAnalysis = silenceAnalysis
 }
 
 // ── Stage: ACX Certification ──────────────────────────────────────────────────
@@ -343,7 +370,10 @@ export async function acxCertification(ctx) {
 // ── Stage: Quality advisory ───────────────────────────────────────────────────
 
 export async function qualityAdvisory(ctx) {
-  const postProcessSilenceAnalysis = await analyzeAudioFrames(ctx.currentPath)
+  // Reuse the silence analysis produced by measureAfter when available —
+  // it was computed on the same audio and is otherwise identical work.
+  const postProcessSilenceAnalysis =
+    ctx.results.afterSilenceAnalysis ?? await analyzeAudioFrames(ctx.currentPath)
   const pipelineContext = {
     preNrNoiseFloor: ctx.results.rawNoiseFloor ?? null,
     noiseFloorDbfs:  ctx.results.noiseReduction?.post_noise_floor_dbfs ?? null,

--- a/server/pipeline/stages.js
+++ b/server/pipeline/stages.js
@@ -339,10 +339,8 @@ export async function truePeakLimit(ctx) {
 // qualityAdvisory to reuse — avoids a second analyzeAudioFrames pass.
 
 export async function measureAfter(ctx) {
-  const [audio, silenceAnalysis] = await Promise.all([
-    measureAudio(ctx.currentPath),
-    analyzeAudioFrames(ctx.currentPath),
-  ])
+  const audio = await measureAudio(ctx.currentPath)
+  const silenceAnalysis = await analyzeAudioFrames(ctx.currentPath)
   ctx.results.afterMeasurements = {
     ...audio,
     noiseFloorDbfs: silenceAnalysis.noiseFloorDbfs,

--- a/server/pipeline/stages.js
+++ b/server/pipeline/stages.js
@@ -85,10 +85,8 @@ export async function monoMixdown(ctx) {
 // single extra analyzeAudioFrames pass per job.
 
 export async function measureBefore(ctx) {
-  const [audio, silenceAnalysis] = await Promise.all([
-    measureAudio(ctx.currentPath),
-    analyzeAudioFrames(ctx.currentPath),
-  ])
+  const audio = await measureAudio(ctx.currentPath)
+  const silenceAnalysis = await analyzeAudioFrames(ctx.currentPath)
   ctx.results.beforeMeasurements = {
     ...audio,
     noiseFloorDbfs: silenceAnalysis.noiseFloorDbfs,


### PR DESCRIPTION
## Summary
Refactors noise floor measurement to use frame-based silence analysis instead of FFmpeg histogram data. This improves accuracy by measuring the actual steady-state silence floor rather than the level of the single quietest sample.

## Key Changes

- **measure.js**: Removed noise floor calculation from FFmpeg volumedetect histogram parsing. The `measureAudio()` function now returns only `{rmsDbfs, truePeakDbfs, lufsIntegrated}` without `noiseFloorDbfs`.

- **silenceAnalysis.js**: Extracted noise floor bootstrapping logic into a new `bootstrapNoiseRms()` helper function that combines the lowest-energy frames in the power domain (RMS of combined frames) rather than averaging linear RMS values. This ensures consistent noise floor calculation across the codebase.

- **stages.js**: Updated `measureBefore()` and `measureAfter()` stages to merge noise floor from silence analysis into their measurement results. The `measureAfter()` stage now caches the silence analysis result on the context for reuse by `qualityAdvisory()`, avoiding redundant computation.

- **index.js**: Updated `formatMeasurements()` to handle `noiseFloorDbfs` as an optional field that may be undefined if not populated by the measurement stages.

- **logger.js**: Removed noise floor from debug output since it's no longer produced by `measureAudio()`.

## Implementation Details

The noise floor is now sourced exclusively from frame-based silence analysis, which provides a more reliable estimate by:
- Selecting the lowest-energy frames
- Combining them in the power domain (mathematically the RMS of combined frames)
- Avoiding histogram artifacts where zero-crossings dominate the quietest bucket

This matches how `voicedRmsDbfs` is computed elsewhere and aligns with how noise floor is compared against ACX ceilings downstream. The previous histogram-based approach was ineffective because it reported the single quietest sample level rather than the actual steady-state silence floor, causing the noise-floor check to pass regardless of real recording quality.

https://claude.ai/code/session_01Wt5tyQVV7BSfap6g3gE4PR