### PR TITLE
Add post-BWE sibilance EQ (9 kHz bell cut) configurable per preset

### DIFF
--- a/server/pipeline/stages.js
+++ b/server/pipeline/stages.js
@@ -733,7 +733,28 @@ export async function bandwidthExtension(ctx) {
   await decodeToFloat32(bwe48kPath, bwe44kPath)
   ctx.currentPath = bwe44kPath
 
-  ctx.results.separationPipeline.bandwidthExtension = { applied: true }
+  // Post-BWE sibilance EQ: narrow bell cut to tame HF harshness introduced by BWE.
+  // AP-BWE synthesises broadband HF content that can skew sibilant; applying a cut
+  // here — before enhancement EQ and the de-esser — corrects this at the source.
+  // Parameters (freq, q, gainDb) are configurable per preset via bwe.postEq.
+  const postEq = ctx.preset.bwe.postEq
+  if (postEq?.enabled) {
+    const freq   = postEq.freq   ?? 9000
+    const q      = postEq.q      ?? 2
+    const gainDb = postEq.gainDb
+    const filter = `equalizer=f=${freq}:t=q:w=${q}:g=${gainDb}`
+    const eqPath = ctx.tmp('.wav')
+    await applyParametricEQ(ctx.currentPath, eqPath, [filter])
+    ctx.currentPath = eqPath
+    ctx.log(`[NE-6] Post-BWE EQ: ${filter}`)
+  }
+
+  ctx.results.separationPipeline.bandwidthExtension = {
+    applied: true,
+    ...(postEq?.enabled && {
+      postEq: { applied: true, freq: postEq.freq ?? 9000, q: postEq.q ?? 2, gainDb: postEq.gainDb },
+    }),
+  }
   await logLevel(ctx, 'after NE-6 bandwidth extension', ctx.currentPath, {})
 }
 

--- a/src/audio/presets.js
+++ b/src/audio/presets.js
@@ -96,7 +96,7 @@ export function resolveOutputProfileId(id) {
  * @property {{ maxGainDb: number, maxRateDbPerS: number }} autoLeveler
  * @property {'demucs'|'convtasnet'} [separationModel]   - Noise Eraser only
  * @property {'mossformer2_48k'|'frcrn_16k'} [clearervoiceModel]   - ClearerVoice Eraser only
- * @property {{ enabled: boolean }} bwe - Bandwidth extension (AP-BWE); enabled for NE presets, disabled for standard presets
+ * @property {{ enabled: boolean, postEq?: { enabled: boolean, freq?: number, q?: number, gainDb: number } }} bwe - Bandwidth extension (AP-BWE); enabled for NE presets, disabled for standard presets. postEq applies a narrow bell cut after BWE to tame sibilance introduced by HF synthesis.
  */
 
 /** @type {Record<string, Preset>} */
@@ -150,7 +150,7 @@ export const PRESETS = {
       crestGuardThresholdDb:       12,
       parallelDesserMaxReductionDb: 10,
     },
-    bwe: { enabled: true },
+    bwe: { enabled: true, postEq: { enabled: true, freq: 9000, q: 2, gainDb: -3 } },
   },
 
   podcast_ready: {
@@ -202,7 +202,7 @@ export const PRESETS = {
       crestGuardThresholdDb:       12,
       parallelDesserMaxReductionDb: 10,
     },
-    bwe: { enabled: true },
+    bwe: { enabled: true, postEq: { enabled: true, freq: 9000, q: 2, gainDb: -3 } },
   },
 
   voice_ready: {
@@ -257,7 +257,7 @@ export const PRESETS = {
       crestGuardThresholdDb:       12,
       parallelDesserMaxReductionDb: 10,
     },
-    bwe: { enabled: true },
+    bwe: { enabled: true, postEq: { enabled: true, freq: 9000, q: 2, gainDb: -3 } },
   },
 
   general_clean: {
@@ -309,7 +309,7 @@ export const PRESETS = {
       crestGuardThresholdDb:       9,      // relaxed per spec
       parallelDesserMaxReductionDb: 12,
     },
-    bwe: { enabled: true },
+    bwe: { enabled: true, postEq: { enabled: true, freq: 9000, q: 2, gainDb: -3 } },
   },
 
   noise_eraser: {
@@ -368,7 +368,7 @@ export const PRESETS = {
       crestGuardThresholdDb:       12,
       parallelDesserMaxReductionDb: 8,     // fixed-band only; lower ceiling per spec
     },
-    bwe: { enabled: true },
+    bwe: { enabled: true, postEq: { enabled: true, freq: 9000, q: 2, gainDb: -4 } },
   },
 
   clearervoice_eraser: {
@@ -405,7 +405,7 @@ export const PRESETS = {
       maxGainDb:     8.0,
       maxRateDbPerS: 1.5,
     },
-    bwe: { enabled: true },
+    bwe: { enabled: true, postEq: { enabled: true, freq: 9000, q: 2, gainDb: -4 } },
   },
 
 }


### PR DESCRIPTION
AP-BWE synthesises broadband HF content that can introduce harshness or
excess sibilance. A narrow bell cut applied immediately after BWE corrects
this at the source, before enhancement EQ and the de-esser run.

- Extend bwe preset config with optional postEq sub-object
  { enabled, freq, q, gainDb } — defaults to 9000 Hz, Q=2 if omitted
- Add postEq to all BWE-enabled presets:
    acx_audiobook, podcast_ready, voice_ready, general_clean: -3 dB
    noise_eraser, clearervoice_eraser: -4 dB (separation skews more sibilant)
- Apply via applyParametricEQ (already imported) inside bandwidthExtension
  stage, gated on postEq.enabled, between BWE resample and results write
- Record postEq result in ctx.results.separationPipeline.bandwidthExtension

https://claude.ai/code/session_01D4fGgBbqG1kJi233EoYgjj