### PR TITLE
Unify enhancement EQ: profile-keyed refs, 6 bands, bi-directional

### DIFF
--- a/server/pipeline/enhancementEQ.js
+++ b/server/pipeline/enhancementEQ.js
@@ -1,115 +1,107 @@
 /**
- * Stage 3 — Enhancement EQ.
+ * Stage 3 — Enhancement EQ (unified).
  *
  * Analyzes the spectral envelope of voiced speech using Meyda.js, compares
- * against the preset's EQ reference profile, and computes parametric EQ
- * parameters for FFmpeg's `equalizer` filter.
+ * against the eqProfile's reference curve, and computes parametric EQ
+ * parameters for FFmpeg's `equalizer` / `treble` filters.
  *
  * Reference: processing spec v3, Stage 3.
  *
- * Diagnostic bands:
- *   Body/warmth    100–250 Hz
- *   Mud/boxiness   200–400 Hz
- *   Clarity zone   400–700 Hz
- *   Presence       2000–5000 Hz
- *   Air/sibilance  6000–12000 Hz
+ * Diagnostic bands (six):
+ *   Body/warmth      100–250  Hz
+ *   Mud/boxiness     200–400  Hz
+ *   Clarity zone     400–700  Hz
+ *   Upper mid        700–2000 Hz
+ *   Presence         2000–5000 Hz
+ *   Air/sibilance    6000–12000 Hz
  *
- * EQ operations are applied in one chained FFmpeg pass.
- * No single band adjustment exceeds ±5 dB (spec constraint).
+ * Every band is bi-directional: sign of the delta picks cut vs boost.
+ * The only preset-specific logic remaining is the ACX noise-floor guard,
+ * which halves HF boosts when the measured noise floor is close to -60 dBFS.
  */
 
 import Meyda from 'meyda'
 import { readWavSamples } from './wavReader.js'
 
-const FFT_SIZE      = 4096
-const SAMPLE_RATE   = 44100
-const MAX_GAIN_DB   = 5    // spec: ±5 dB maximum per band (standard presets)
-const NE_MAX_GAIN_DB = 4   // spec: ±4 dB for NE-7 (separated audio more sensitive)
-const HOP_SIZE      = FFT_SIZE  // non-overlapping frames for batch analysis
+const FFT_SIZE    = 4096
+const SAMPLE_RATE = 44100
+const MAX_GAIN_DB = 5   // spec: ±5 dB maximum per band
+const HOP_SIZE    = FFT_SIZE  // non-overlapping frames for batch analysis
 
 // ── EQ Reference Profiles ────────────────────────────────────────────────────
-// Each entry is the expected normalized energy (in dB relative to spectral mean)
-// for recordings that "sound right" for the target use case.
-// Deviations from these targets drive the trigger logic.
-//
-// Values are relative to spectral mean across all diagnostic bands.
+// Each entry is the expected normalized energy (in dB relative to spectral
+// mean) for recordings that "sound right" for the target use case.
+// Values are relative to spectral mean across all six diagnostic bands.
 const EQ_REFERENCES = {
-  acx_audiobook: {
-    warmth:   -1,    // 100–250 Hz: natural, slight cut OK
-    mud:      -3,    // 200–400 Hz: slightly suppressed
-    clarity:  -2,    // 400–700 Hz: slightly suppressed
-    presence: +3,    // 2–5 kHz:    forward-leaning
-    air:       0,    // 6–12 kHz:   neutral
+  audiobook: {
+    warmth:    -1,   // natural, slight cut OK
+    mud:       -3,   // slightly suppressed
+    clarity:   -2,   // slightly suppressed
+    upper_mid:  0,   // articulation untouched
+    presence:  +3,   // forward-leaning
+    air:        0,   // neutral
   },
-  podcast_ready: {
-    warmth:   -2,    // 100–250 Hz: thinner for phone speakers
-    mud:      -5,    // 200–400 Hz: assertive mud cut
-    clarity:  -3,    // 400–700 Hz: clarity cut for earbuds
-    presence: +4,    // 2–5 kHz:    punchy presence
-    air:      +1,    // 6–12 kHz:   slight air lift
+  podcast: {
+    warmth:    -2,   // thinner for phone speakers
+    mud:       -5,   // assertive mud cut
+    clarity:   -3,   // clarity cut for earbuds
+    upper_mid: -1,   // shave 1 kHz to reduce honk on small speakers
+    presence:  +4,   // punchy presence
+    air:       +1,   // slight air lift
   },
-  voice_ready: {
-    warmth:   -1,    // 100–250 Hz: neutral-warm
-    mud:      -3,    // 200–400 Hz: moderate mud cut
-    clarity:  -2,    // 400–700 Hz: slight clarity cut
-    presence: +3,    // 2–5 kHz:    broadcast presence
-    air:      +0.5,  // 6–12 kHz:   conservative air
+  music: {
+    warmth:     0,   // neutral
+    mud:       -1,   // light mud control only
+    clarity:    0,   // neutral
+    upper_mid:  0,   // neutral
+    presence:   0,   // neutral — voice shaping disabled
+    air:       +1,   // small sparkle
   },
-  general_clean: {
-    warmth:    0,    // 100–250 Hz: neutral
-    mud:      -3,    // 200–400 Hz: moderate mud cut
-    clarity:  -2,    // 400–700 Hz: moderate clarity cut
-    presence: +3,    // 2–5 kHz:    clear presence
-    air:       0,    // 6–12 kHz:   neutral
-  },
-
-  // Noise Eraser post-separation EQ reference (NE-7).
-  // Separated audio is typically:
-  //   - Thin in the 200–400 Hz body range (Demucs attenuates lower-mids with noise)
-  //   - Reduced in 100–200 Hz warmth range
-  //   - Potentially harsh in 3–6 kHz if bandwidth extension over-synthesised
-  //   - Variable in the air band depending on BWE contribution
-  // Max gain constraint: ±4 dB (tighter than standard ±5 dB — NE-7 spec).
-  noise_eraser: {
-    warmth:   -3,    // 100–250 Hz: expect below reference (body stripped with noise)
-    mud:      -2,    // 200–400 Hz: slightly suppressed reference — boost if deficient
-    clarity:  -2,    // 400–700 Hz: neutral-slightly suppressed
-    presence: +2,    // 2–5 kHz:    moderate — may be boosted by BWE
-    air:      +1,    // 6–12 kHz:   slight uplift reference — cut if BWE over-synthesised
+  general: {
+    warmth:     0,   // neutral
+    mud:       -3,   // moderate mud cut
+    clarity:   -2,   // moderate clarity cut
+    upper_mid:  0,   // neutral
+    presence:  +3,   // clear presence
+    air:        0,   // neutral
   },
 }
 
-// ── Trigger thresholds (dB deviation from reference to apply EQ) ──────────────
-// Per spec: mud cut triggers at > 3 dB above ref (ACX/General), 2 dB (Podcast)
-//           presence boost triggers at > 2 dB below ref
-const TRIGGERS = {
-  acx_audiobook: { mud: 3, presence: 2, warmth: 4, air: 4, clarity: 2 },
-  podcast_ready: { mud: 2, presence: 2, warmth: 3, air: 3, clarity: 2 },
-  voice_ready:   { mud: 3, presence: 2, warmth: 4, air: 4, clarity: 2 },
-  general_clean: { mud: 3, presence: 2, warmth: 3, air: 4, clarity: 2 },
-  // NE-7: tighter triggers — separated audio is more sensitive to overcorrection
-  noise_eraser:  { mud: 4, presence: 3, warmth: 3, air: 4, clarity: 3 },
-}
-
-// ── EQ center frequencies ────────────────────────────────────────────────────
-// Chosen to represent the diagnostic band character. Q factor targets the
-// specified bandwidth from the spec.
+// ── EQ center frequencies / Q factors ────────────────────────────────────────
 const EQ_CENTERS = {
-  warmth:   { freq: 180, q: 1.5 },  // 100–250 Hz warmth
-  mud:      { freq: 285, q: 2.5 },  // 200–400 Hz mud (spec: Q 2–3)
-  clarity:  { freq: 520, q: 2.0 },  // 400–700 Hz clarity
-  presence: { freq: 4000, q: 1.5 }, // 2–5 kHz presence (spec: 4 kHz, Q 1.5)
-  air:      { freq: 10000, q: 0.7, shelf: true }, // 10 kHz shelf per spec
+  warmth:    { freq: 180,   q: 1.5 },
+  mud:       { freq: 285,   q: 2.5 },
+  clarity:   { freq: 520,   q: 2.0 },
+  upper_mid: { freq: 1200,  q: 1.0 },
+  presence:  { freq: 4000,  q: 1.5 },
+  air:       { freq: 10000, q: 0.7, shelf: true },
 }
 
 // ── Diagnostic band frequency limits ─────────────────────────────────────────
 const BANDS = {
-  warmth:   [100, 250],
-  mud:      [200, 400],
-  clarity:  [400, 700],
-  presence: [2000, 5000],
-  air:      [6000, 12000],
+  warmth:    [100,  250],
+  mud:       [200,  400],
+  clarity:   [400,  700],
+  upper_mid: [700,  2000],
+  presence:  [2000, 5000],
+  air:       [6000, 12000],
 }
+
+// ── Per-band treatment config (uniform across all profiles) ──────────────────
+// gainScale keeps corrections partial so voices are pulled toward the
+// reference, never snapped to it. maxGainDb reflects each band's perceptual
+// sensitivity.
+const BAND_CONFIG = {
+  warmth:    { gainScale: 0.5, maxGainDb: 3 },
+  mud:       { gainScale: 0.8, maxGainDb: MAX_GAIN_DB },
+  clarity:   { gainScale: 0.5, maxGainDb: 2 },
+  upper_mid: { gainScale: 0.5, maxGainDb: 3 },
+  presence:  { gainScale: 0.7, maxGainDb: MAX_GAIN_DB },
+  air:       { gainScale: 0.4, maxGainDb: 2 },
+}
+
+// Band order matters for filter chaining: low → high.
+const BAND_ORDER = ['warmth', 'mud', 'clarity', 'upper_mid', 'presence', 'air']
 
 // ── Main API ─────────────────────────────────────────────────────────────────
 
@@ -118,21 +110,22 @@ const BANDS = {
  * Does NOT apply the EQ — caller passes these to applyParametricEQ().
  *
  * @param {string} wavPath
- * @param {string} presetId
+ * @param {string} eqProfile  - One of 'audiobook' | 'podcast' | 'music' | 'general'
  * @param {import('./frameAnalysis.js').FrameAnalysis} frameAnalysis
- * @param {number} noiseFloorDbfs  - For Stage 3c ACX noise floor constraint check
+ * @param {number} noiseFloorDbfs  - For ACX noise-floor guard
+ * @param {{ presetId?: string }} [opts]
  * @returns {EQResult}
  *
  * @typedef {Object} EQResult
- * @property {string[]} ffmpegFilters  - FFmpeg equalizer filter strings (may be empty)
+ * @property {string[]} ffmpegFilters  - FFmpeg equalizer/treble filter strings (may be empty)
  * @property {Object}   bands          - Per-band EQ details for the report
- * @property {string}   profile        - Preset profile name used
+ * @property {string}   profile        - eqProfile name used
  * @property {boolean}  applied        - True if any EQ was applied
  */
-export async function analyzeSpectrum(wavPath, presetId, frameAnalysis, noiseFloorDbfs) {
-  const ref     = EQ_REFERENCES[presetId] ?? EQ_REFERENCES.general_clean
-  const trigger = TRIGGERS[presetId]      ?? TRIGGERS.general_clean
-  const maxGain = presetId === 'noise_eraser' ? NE_MAX_GAIN_DB : MAX_GAIN_DB
+export async function analyzeSpectrum(wavPath, eqProfile, frameAnalysis, noiseFloorDbfs, opts = {}) {
+  const profile = EQ_REFERENCES[eqProfile] ? eqProfile : 'general'
+  const ref     = EQ_REFERENCES[profile]
+  const presetId = opts.presetId
 
   const { samples } = await readWavSamples(wavPath)
 
@@ -140,7 +133,7 @@ export async function analyzeSpectrum(wavPath, presetId, frameAnalysis, noiseFlo
   const voicedFrameBuffers = collectVoicedFrames(samples, frameAnalysis, FFT_SIZE)
 
   if (voicedFrameBuffers.length === 0) {
-    return noEQResult(presetId)
+    return noEQResult(profile)
   }
 
   // Compute average power spectrum across voiced frames
@@ -152,101 +145,56 @@ export async function analyzeSpectrum(wavPath, presetId, frameAnalysis, noiseFlo
   // Compute spectral mean (average across all diagnostic bands, in dB)
   const specMeanDb = Object.values(measured).reduce((s, v) => s + v, 0) / Object.keys(measured).length
 
-  // Convert to deviation from spectral mean (so we compare shape, not absolute level)
+  // Convert to deviation from spectral mean (compare shape, not absolute level)
   const deviation = {}
   for (const band of Object.keys(measured)) {
     deviation[band] = measured[band] - specMeanDb
   }
 
-  // Compute how far each band deviates from its reference target
+  // How far each band deviates from its reference target
   const delta = {}
   for (const band of Object.keys(ref)) {
-    delta[band] = deviation[band] - ref[band]  // positive = band is elevated
+    delta[band] = deviation[band] - ref[band]  // positive = band is elevated vs ref
   }
 
-  // Build EQ decisions per band
+  // Build EQ decisions per band — fully bi-directional, uniform across profiles
   const bandResults = {}
   const filters = []
 
-  // --- Mud cut ---
-  bandResults.mud_cut = decideBand({
-    name: 'mud_cut',
-    delta: delta.mud,
-    trigger: trigger.mud,
-    direction: 'cut',     // positive delta → cut
-    maxGain,
-    center: EQ_CENTERS.mud,
-    gainScale: 0.8,       // don't cut the full delta, be conservative
-  })
-  if (bandResults.mud_cut.applied) filters.push(bandResults.mud_cut.filter)
-
-  // --- Clarity cut (follows mud cut, per spec) ---
-  bandResults.clarity_cut = decideBand({
-    name: 'clarity_cut',
-    delta: delta.clarity,
-    trigger: trigger.clarity,
-    direction: 'cut',
-    maxGain: Math.min(2, maxGain),  // spec: -1 to -2 dB clarity cut
-    center: EQ_CENTERS.clarity,
-    gainScale: 0.5,
-  })
-  if (bandResults.clarity_cut.applied) filters.push(bandResults.clarity_cut.filter)
-
-  // --- Presence boost ---
-  bandResults.presence_boost = decideBand({
-    name: 'presence_boost',
-    delta: delta.presence,
-    trigger: trigger.presence,
-    direction: 'boost',   // negative delta → boost
-    maxGain,
-    center: EQ_CENTERS.presence,
-    gainScale: 0.7,
-  })
-  if (bandResults.presence_boost.applied) filters.push(bandResults.presence_boost.filter)
-
-  // --- Warmth boost (ACX: only if mud cut NOT applied, per spec) ---
-  // noise_eraser: warmth boost always eligible (body is typically thin post-separation)
-  const warmthCutApplicable   = presetId === 'podcast_ready'
-  const warmthBoostApplicable = presetId !== 'podcast_ready' && !bandResults.mud_cut.applied
-  bandResults.warmth_boost = { applied: false }
-
-  if (warmthCutApplicable && delta.warmth > trigger.warmth) {
-    // Podcast warmth cut
-    const gainDb = Math.min(delta.warmth * 0.5, 2)
-    bandResults.warmth_boost = buildCut('warmth_cut', gainDb, EQ_CENTERS.warmth)
-    if (bandResults.warmth_boost.applied) filters.push(bandResults.warmth_boost.filter)
-  } else if (warmthBoostApplicable && delta.warmth < -trigger.warmth) {
-    // Warmth boost (only if no mud cut applied)
-    const gainDb = Math.min(Math.abs(delta.warmth) * 0.5, Math.min(maxGain, 3))
-    bandResults.warmth_boost = buildBoost('warmth_boost', gainDb, EQ_CENTERS.warmth)
-    if (bandResults.warmth_boost.applied) filters.push(bandResults.warmth_boost.filter)
-  }
-
-  // --- Air: boost if deficient, cut if BWE over-synthesised (NE-7 bidirectional) ---
-  if (delta.air < -trigger.air) {
-    const gainDb = Math.min(Math.abs(delta.air) * 0.4, presetId === 'podcast_ready' ? 2 : 1.5)
-    bandResults.air_boost = buildBoost('air_boost', gainDb, EQ_CENTERS.air)
-    if (bandResults.air_boost.applied) filters.push(bandResults.air_boost.filter)
-  } else if (presetId === 'noise_eraser' && delta.air > trigger.air) {
-    // NE-7: cut air if BWE has over-synthesised HF content
-    const gainDb = Math.min(delta.air * 0.5, maxGain)
-    bandResults.air_boost = buildCut('air_cut', gainDb, EQ_CENTERS.air)
-    if (bandResults.air_boost.applied) filters.push(bandResults.air_boost.filter)
-  } else {
-    bandResults.air_boost = { applied: false }
-  }
-
-  // --- Stage 3c: ACX noise floor constraint ---
-  // If we boosted presence/air and the noise floor is already close to -60 dBFS,
-  // reduce or skip high-frequency boosts to avoid pushing hiss above threshold.
-  if ((presetId === 'acx_audiobook' || presetId === 'voice_ready') && noiseFloorDbfs > -66) {
-    const toMute = filters.filter(f => f.includes('f=10000') || f.includes('f=4000'))
-    toMute.forEach(f => {
-      const idx = filters.indexOf(f)
-      // Halve the gain to reduce noise floor risk
-      const halved = f.replace(/g=([\d.]+)/, (_, g) => `g=${round2(parseFloat(g) / 2)}`)
-      filters[idx] = halved
+  for (const band of BAND_ORDER) {
+    const result = decideBand({
+      name:      band,
+      delta:     delta[band],
+      center:    EQ_CENTERS[band],
+      gainScale: BAND_CONFIG[band].gainScale,
+      maxGainDb: BAND_CONFIG[band].maxGainDb,
     })
+    bandResults[band] = result
+    if (result.applied) filters.push(result.filter)
+  }
+
+  // --- ACX noise floor guard (Stage 3c) ---
+  // If HF boosts are applied and the noise floor is close to -60 dBFS,
+  // halve their gain to avoid pushing hiss above the ACX threshold.
+  // Scoped to acx_audiobook only — voice_ready and others are unaffected.
+  if (presetId === 'acx_audiobook' && noiseFloorDbfs > -66) {
+    for (let i = 0; i < filters.length; i++) {
+      const f = filters[i]
+      if (f.includes('f=10000') || f.includes('f=4000')) {
+        // Halve the gain (works for both equalizer=...:g=X and treble=g=X:...)
+        filters[i] = f.replace(/g=(-?)([\d.]+)/, (_, sign, g) =>
+          `g=${sign}${round2(parseFloat(g) / 2)}`)
+      }
+    }
+    // Sync the halved gain into the band results for the report.
+    for (const band of ['presence', 'air']) {
+      const br = bandResults[band]
+      if (br.applied) {
+        br.gain_db = round2(br.gain_db / 2)
+        br.filter  = br.filter.replace(/g=(-?)([\d.]+)/, (_, sign, g) =>
+          `g=${sign}${round2(parseFloat(g) / 2)}`)
+      }
+    }
   }
 
   const applied = filters.length > 0
@@ -254,7 +202,7 @@ export async function analyzeSpectrum(wavPath, presetId, frameAnalysis, noiseFlo
   return {
     ffmpegFilters: filters,
     bands: bandResults,
-    profile: presetId,
+    profile,
     applied,
   }
 }
@@ -288,7 +236,6 @@ function averagePowerSpectrum(frames) {
   const sum = new Float64Array(size)
 
   for (const frame of frames) {
-    // Meyda.extract expects a standard array or Float32Array of length bufferSize
     const ps = Meyda.extract('powerSpectrum', frame)
     if (!ps) continue
     for (let i = 0; i < size && i < ps.length; i++) {
@@ -310,9 +257,9 @@ function measureBandEnergies(powerSpectrum, sampleRate, fftSize) {
 }
 
 function bandEnergyDb(ps, sampleRate, fftSize, freqLo, freqHi) {
-  const binHz  = sampleRate / fftSize
-  const loIdx  = Math.max(0, Math.floor(freqLo / binHz))
-  const hiIdx  = Math.min(ps.length - 1, Math.ceil(freqHi / binHz))
+  const binHz = sampleRate / fftSize
+  const loIdx = Math.max(0, Math.floor(freqLo / binHz))
+  const hiIdx = Math.min(ps.length - 1, Math.ceil(freqHi / binHz))
   let sum = 0
   let count = 0
   for (let i = loIdx; i <= hiIdx; i++) {
@@ -323,21 +270,28 @@ function bandEnergyDb(ps, sampleRate, fftSize, freqLo, freqHi) {
   return 10 * Math.log10(sum / count)
 }
 
-function decideBand({ name, delta, trigger, direction, maxGain, center, gainScale }) {
-  const triggered = direction === 'cut'
-    ? delta > trigger         // elevated → cut
-    : delta < -trigger        // deficient → boost
+/**
+ * Bi-directional band decision. Positive delta → cut; negative delta → boost.
+ * No separate trigger threshold: the 0.5 dB perception floor on the final
+ * gain is the only gate, combined with partial correction via gainScale.
+ */
+function decideBand({ name, delta, center, gainScale, maxGainDb }) {
+  if (!Number.isFinite(delta)) return unapplied(center)
 
-  if (!triggered) return { applied: false }
-
-  let gainDb = Math.abs(delta) * gainScale
-  gainDb = Math.min(gainDb, maxGain)
+  const magnitude = Math.abs(delta)
+  let gainDb = magnitude * gainScale
+  gainDb = Math.min(gainDb, maxGainDb)
   gainDb = round2(gainDb)
 
-  if (gainDb < 0.5) return { applied: false }  // below perception threshold
+  if (gainDb < 0.5) return unapplied(center)  // below perception threshold
 
-  if (direction === 'cut') return buildCut(name, gainDb, center)
-  return buildBoost(name, gainDb, center)
+  return delta > 0
+    ? buildCut(name, gainDb, center)
+    : buildBoost(name, gainDb, center)
+}
+
+function unapplied(center) {
+  return { applied: false, freq_hz: center.freq, gain_db: 0 }
 }
 
 function buildCut(name, gainDb, center) {
@@ -354,17 +308,15 @@ function buildBoost(name, gainDb, center) {
   return { applied: true, freq_hz: center.freq, gain_db: gainDb, filter }
 }
 
-function noEQResult(presetId) {
+function noEQResult(profile) {
+  const bands = {}
+  for (const band of BAND_ORDER) {
+    bands[band] = unapplied(EQ_CENTERS[band])
+  }
   return {
     ffmpegFilters: [],
-    bands: {
-      mud_cut: { applied: false },
-      clarity_cut: { applied: false },
-      presence_boost: { applied: false },
-      warmth_boost: { applied: false },
-      air_boost: { applied: false },
-    },
-    profile: presetId,
+    bands,
+    profile,
     applied: false,
   }
 }

--- a/server/pipeline/index.js
+++ b/server/pipeline/index.js
@@ -157,7 +157,6 @@ function buildReport(ctx) {
       ...(results.noiseReduction && { noise_reduction:   formatNrResult(results.noiseReduction) }),
       ...(results.dereverb       && { dereverberation:   formatDereverbResult(results.dereverb) }),
       ...(results.enhancementEQ  && { enhancement_eq:    formatEqResult(results.enhancementEQ) }),
-      ...(results.separationEQ   && { separation_eq:     formatEqResult(results.separationEQ) }),
       ...(results.roomTonePad    && { room_tone_padding:  formatRoomToneResult(results.roomTonePad) }),
       ...(results.deEss          && { de_esser:           formatDeEssResult(results.deEss) }),
       ...(results.autoLeveler         && { auto_leveler:         formatAutoLevelerResult(results.autoLeveler) }),
@@ -181,7 +180,6 @@ function buildReport(ctx) {
     ...(results.enhancementPipeline && {
       enhancement_pipeline: formatEnhancementPipelineResult(results.enhancementPipeline),
     }),
-    // separationEQ appears in processing_applied for noise_eraser (replaces enhancementEQ)
     quality_advisory: results.qualityAdvisory ?? null,
     warnings:         buildWarnings(ctx),
   }
@@ -240,12 +238,13 @@ function formatDereverbResult(r) {
 function formatEqResult(r) {
   if (!r?.applied) return null
   return {
-    profile:        r.profile,
-    mud_cut:        bandReport(r.bands.mud_cut),
-    warmth_boost:   bandReport(r.bands.warmth_boost),
-    clarity_cut:    bandReport(r.bands.clarity_cut),
-    presence_boost: bandReport(r.bands.presence_boost),
-    air_boost:      bandReport(r.bands.air_boost),
+    profile:   r.profile,
+    warmth:    bandReport(r.bands.warmth),
+    mud:       bandReport(r.bands.mud),
+    clarity:   bandReport(r.bands.clarity),
+    upper_mid: bandReport(r.bands.upper_mid),
+    presence:  bandReport(r.bands.presence),
+    air:       bandReport(r.bands.air),
   }
 }
 

--- a/server/pipeline/pipelines.js
+++ b/server/pipeline/pipelines.js
@@ -90,8 +90,9 @@ export const PIPELINES = {
   // Key differences from STANDARD_PIPELINE:
   //   - monoMixdown is omitted — separateVocals handles channel conversion
   //     AFTER separation to preserve separation quality on stereo inputs.
-  //   - hpf / noiseReduce / enhancementEQ / deEss / compress are all replaced
-  //     by the NE-1 through NE-7 separation stages.
+  //   - hpf / noiseReduce / deEss / compress are augmented by the NE-1 through
+  //     NE-6 separation stages; enhancementEQ is retained and serves as NE-7
+  //     (post-separation tonal correction) via the preset's eqProfile.
   //   - analyzeFramesRaw is kept: populates ctx.results.metrics with the
   //     initial noise floor needed by NE-2 tonal analysis and NE-4 validation,
   //     and back-fills beforeMeasurements.noiseFloorDbfs.
@@ -115,7 +116,6 @@ export const PIPELINES = {
     stages.deEss,
     //stages.dereverb,
     stages.remeasureFramesPostNr,    // Updates ctx.results.metrics with post-BWE energy values for enhancementEQ
-    //stages.separationEQ,
     stages.enhancementEQ,
     stages.compress,              // Stage 4a — serial compression
     stages.parallelCompress,      // Stage NE-PC — parallel compression (NEW)
@@ -151,8 +151,7 @@ export const PIPELINES = {
     stages.separationValidation,    // NE-4: Artifact/sibilance/breath assessment
     stages.residualCleanup,         // NE-5: DF3 Tier 2 residual cleanup (conditional)
     stages.bandwidthExtension,      // NE-6: AP-BWE HF restoration (conditional)
-    //stages.separationEQ,            // NE-7: Post-separation enhancement EQ
-    stages.enhancementEQ,
+    stages.enhancementEQ,           // NE-7: Post-separation enhancement EQ (unified stage)
     stages.autoLevel,             // Stage 4b — no-op for clearervoice_eraser (preset not in LEVELER_CONFIG)
     stages.harmonicExciter,         // Adds presence/air harmonic content before normalization
     stages.normalize,               // Stage 5: Loudness normalization

--- a/server/pipeline/stages.js
+++ b/server/pipeline/stages.js
@@ -310,9 +310,10 @@ export async function roomTonePad(ctx) {
 export async function enhancementEQ(ctx) {
   const eqResult = await analyzeSpectrum(
     ctx.currentPath,
-    ctx.presetId,
+    ctx.preset?.eqProfile ?? 'general',
     ctx.results.metrics,
     ctx.results.metrics.noiseFloorDbfs,
+    { presetId: ctx.presetId },
   )
   const eqPath = ctx.tmp('.wav')
   await applyParametricEQ(ctx.currentPath, eqPath, eqResult.ffmpegFilters)
@@ -700,7 +701,7 @@ export async function separationValidation(ctx) {
   ctx.results.separationValidation = assessment
 
   // Merge the post-separation frame analysis into the canonical metrics object
-  // so downstream processing stages (residualCleanup, separationEQ) always
+  // so downstream processing stages (residualCleanup, enhancementEQ) always
   // read from ctx.results.metrics rather than from assessment directly.
   if (assessment.postSeparationFrameAnalysis) {
     Object.assign(ctx.results.metrics, assessment.postSeparationFrameAnalysis)
@@ -809,28 +810,6 @@ export async function bandwidthExtension(ctx) {
   }
   await logLevel(ctx, 'after NE-6 bandwidth extension', ctx.currentPath, {})
 }
-
-// ── NE Stage: Post-separation enhancement EQ (NE-7) ──────────────────────────
-// Corrects tonal imbalances from separation + BWE using a separation-specific
-// reference profile. Max gain ±4 dB (tighter than standard ±5 dB).
-
-export async function separationEQ(ctx) {
-  // Use the canonical metrics object, which was updated by separationValidation
-  // with the post-separation frame analysis. This ensures voiced frame detection
-  // reflects the separated signal character, not the pre-processing signal.
-  const eqResult = await analyzeSpectrum(
-    ctx.currentPath, 'noise_eraser', ctx.results.metrics, ctx.results.metrics.noiseFloorDbfs ?? -60
-  )
-  const eqPath   = ctx.tmp('.wav')
-  await applyParametricEQ(ctx.currentPath, eqPath, eqResult.ffmpegFilters)
-  ctx.currentPath      = eqPath
-  ctx.results.separationEQ = eqResult
-  await logLevel(ctx, 'after NE-7 separation EQ', ctx.currentPath, {
-    applied: eqResult.applied,
-    filters: eqResult.ffmpegFilters.length,
-  })
-}
-
 
 // ── CE Stage: ClearerVoice speech enhancement (CE-3) ─────────────────────────
 // Single-model replacement for Demucs/ConvTasNet vocal separation (NE-3).

--- a/src/audio/presets.js
+++ b/src/audio/presets.js
@@ -121,7 +121,7 @@ export const PRESETS = {
       attack: 10,
       release: 100,
     },
-    eqProfile: 'acx_narration',
+    eqProfile: 'audiobook',
     deEsser: {
       sensitivity: 'standard',
       trigger: 8,
@@ -225,7 +225,7 @@ export const PRESETS = {
       attack: 8,
       release: 90,
     },
-    eqProfile: 'voice_over',
+    eqProfile: 'general',
     deEsser: {
       sensitivity: 'standard',
       trigger: 8,
@@ -332,13 +332,12 @@ export const PRESETS = {
       attack: 8,
       release: 100,
     },
-    eqProfile: 'general',
+    eqProfile: 'podcast',
     deEsser: {
       sensitivity: 'high',
       trigger: 6,
       maxReduction: 8,
     },
-    eqProfile: 'separation_recovery',
     channelOutput: 'mono',
     defaultOutputProfile: 'podcast',
     lockedOutputProfile: false,
@@ -385,7 +384,7 @@ export const PRESETS = {
       attack: 0,
       release: 0,
     },
-    eqProfile: 'separation_recovery',
+    eqProfile: 'podcast',
     deEsser: {
       sensitivity: 'none',
       trigger: 0,


### PR DESCRIPTION
Collapse enhancementEQ and separationEQ into a single stage driven by the
preset's eqProfile field. Four reference profiles (audiobook, podcast,
music, general) replace the five preset-keyed reference tables.

- Add upper_mid diagnostic + EQ band (700-2000 Hz, 1200 Hz @ Q 1.0)
- Make every band bi-directional (sign of delta picks cut vs boost)
- Drop preset-specific gainScale, maxGain, and trigger tables; use a single
  shared BAND_CONFIG with sensible per-band caps
- Remove the TRIGGERS table entirely; the 0.5 dB perception floor combined
  with partial gainScale already preserves voice character without
  homogenising toward the reference curve
- Scope the ACX noise-floor guard on HF boosts to acx_audiobook only
- Delete the dead separationEQ stage function and its report wiring
- Update preset eqProfile values: acx_audiobook=audiobook, voice_ready=
  general, noise_eraser/clearervoice_eraser=podcast; fix duplicate
  eqProfile key on noise_eraser

https://claude.ai/code/session_018NoavwRyHnVsFay3EF2XZW