### PR TITLE
Configure PyTorch thread pools for all AI model subprocesses on 8-core CPU

### DIFF
--- a/server/pipeline/frameAnalysis.js
+++ b/server/pipeline/frameAnalysis.js
@@ -39,6 +39,7 @@
 import { spawn }          from 'child_process'
 import { readFile, rm }   from 'fs/promises'
 import { fileURLToPath }  from 'url'
+import os                 from 'os'
 import path               from 'path'
 
 import { readWavSamples } from './wavReader.js'
@@ -46,6 +47,7 @@ import { readWavSamples } from './wavReader.js'
 const FRAME_DURATION_S = 0.1   // 100 ms frames — must match FRAME_DURATION_S in silero_vad.py
 const BOOTSTRAP_FRAMES = 20    // use this many lowest-energy frames to bootstrap noise floor
 
+const NUM_THREADS   = process.env.TORCH_NUM_THREADS ?? String(os.cpus().length)
 const VAD_BACKEND   = process.env.VAD_BACKEND   ?? 'silero'
 // Fall back through the other pipeline Python env vars so all scripts share
 // the same interpreter without requiring a separate SILERO_PYTHON entry.
@@ -204,7 +206,10 @@ function spawnSilero(inputPath, outputJsonPath) {
       SILERO_SCRIPT,
       '--input',  inputPath,
       '--output', outputJsonPath,
-    ], { stdio: ['ignore', 'pipe', 'pipe'] })
+    ], {
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env: { ...process.env, OMP_NUM_THREADS: NUM_THREADS, MKL_NUM_THREADS: NUM_THREADS, TORCH_NUM_THREADS: NUM_THREADS },
+    })
 
     let stdout = ''
     let stderr = ''

--- a/server/pipeline/noiseReduce.js
+++ b/server/pipeline/noiseReduce.js
@@ -15,6 +15,7 @@
 
 import { spawn } from 'child_process'
 import { fileURLToPath } from 'url'
+import os from 'os'
 import path from 'path'
 import fs from 'fs'
 import { decodeToFloat32, tempPath, removeTmp } from '../lib/ffmpeg.js'
@@ -28,6 +29,7 @@ import { decodeToFloat32, tempPath, removeTmp } from '../lib/ffmpeg.js'
 //   Defaults to 'python3'. Set to a venv python path if needed.
 const DEEPFILTER_BINARY = process.env.DEEPFILTER_BINARY ?? null
 const PYTHON = process.env.DEEPFILTER_PYTHON ?? 'python3'
+const NUM_THREADS = process.env.TORCH_NUM_THREADS ?? String(os.cpus().length)
 const SCRIPT  = path.join(path.dirname(fileURLToPath(import.meta.url)), '..', 'scripts', 'deepfilter_enhance.py')
 
 /**
@@ -124,7 +126,10 @@ function runDeepFilterPython(inputPath, outputPath, attenLimDb) {
  */
 function spawnProcess(executable, args, label) {
   return new Promise((resolve, reject) => {
-    const proc = spawn(executable, args, { stdio: ['ignore', 'pipe', 'pipe'] })
+    const proc = spawn(executable, args, {
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env: { ...process.env, OMP_NUM_THREADS: NUM_THREADS, MKL_NUM_THREADS: NUM_THREADS, TORCH_NUM_THREADS: NUM_THREADS },
+    })
 
     let stdout = ''
     let stderr = ''

--- a/server/pipeline/separation.js
+++ b/server/pipeline/separation.js
@@ -12,10 +12,12 @@
 
 import { spawn } from 'child_process'
 import { fileURLToPath } from 'url'
+import os from 'os'
 import path from 'path'
 
 const PYTHON = process.env.SEPARATION_PYTHON ?? 'python3'
 const DEVICE = process.env.SEPARATION_DEVICE ?? 'auto'
+const NUM_THREADS = process.env.TORCH_NUM_THREADS ?? String(os.cpus().length)
 
 const SCRIPTS_DIR = path.join(path.dirname(fileURLToPath(import.meta.url)), '..', 'scripts')
 const RNNOISE_SCRIPT          = path.join(SCRIPTS_DIR, 'rnnoise_denoise.py')
@@ -153,7 +155,10 @@ export function runApBwe(inputPath, outputPath) {
 
 function spawnPython(script, args, label) {
   return new Promise((resolve, reject) => {
-    const proc = spawn(PYTHON, [script, ...args], { stdio: ['ignore', 'pipe', 'pipe'] })
+    const proc = spawn(PYTHON, [script, ...args], {
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env: { ...process.env, OMP_NUM_THREADS: NUM_THREADS, MKL_NUM_THREADS: NUM_THREADS, TORCH_NUM_THREADS: NUM_THREADS },
+    })
 
     let stderr = ''
 

--- a/server/scripts/ap_bwe_extend.py
+++ b/server/scripts/ap_bwe_extend.py
@@ -107,6 +107,10 @@ def main():
 
     print(f'AP-BWE using device: {device}')
 
+    num_threads = int(os.environ.get('TORCH_NUM_THREADS', os.cpu_count() or 4))
+    torch.set_num_threads(num_threads)
+    print(f'AP-BWE using {num_threads} CPU threads')
+
     # ── Load config and model ─────────────────────────────────────────────────
     with open(config_path) as f:
         h = AttrDict(json.load(f))

--- a/server/scripts/deepfilter_enhance.py
+++ b/server/scripts/deepfilter_enhance.py
@@ -10,6 +10,7 @@ reduction, then writes the result as 32-bit float PCM WAV at 48 kHz.
 The caller (noiseReduce.js) resamples back to 44.1 kHz via FFmpeg.
 """
 import argparse
+import os
 import warnings
 
 warnings.filterwarnings('ignore')
@@ -27,6 +28,9 @@ def main():
 
     import torch
     from df.enhance import enhance, init_df, load_audio, save_audio
+
+    num_threads = int(os.environ.get('TORCH_NUM_THREADS', os.cpu_count() or 4))
+    torch.set_num_threads(num_threads)
 
     # Load model — weights cached at ~/.cache/DeepFilterNet/DeepFilterNet3
     model, df_state, _ = init_df()

--- a/server/scripts/separate_vocals.py
+++ b/server/scripts/separate_vocals.py
@@ -29,6 +29,7 @@ Output: 32-bit float PCM WAV at 44.1 kHz, mono or stereo per input channels.
         Channel output is controlled by the caller (stages.separateVocals).
 """
 import argparse
+import os
 import warnings
 
 warnings.filterwarnings('ignore')
@@ -153,6 +154,8 @@ def main():
     from scipy.io import wavfile
 
     device = resolve_device(args.device)
+    num_threads = int(os.environ.get('TORCH_NUM_THREADS', os.cpu_count() or 4))
+    torch.set_num_threads(num_threads)
 
     # Load — scipy returns (samples,) mono or (samples, channels) stereo
     sr, audio_np = wavfile.read(args.input)

--- a/server/scripts/silero_vad.py
+++ b/server/scripts/silero_vad.py
@@ -29,6 +29,7 @@ latency on CPU. Set SILERO_DEVICE=cuda to reduce this significantly.
 import argparse
 import json
 import math
+import os
 import sys
 import warnings
 
@@ -65,6 +66,9 @@ def main():
     from math import gcd
 
     device = resolve_device(args.device)
+
+    num_threads = int(os.environ.get('TORCH_NUM_THREADS', os.cpu_count() or 4))
+    torch.set_num_threads(num_threads)
 
     # Load Silero VAD model.
     #


### PR DESCRIPTION
All five model scripts (DeepFilterNet3, Silero VAD, Demucs, ConvTasNet, AP-BWE)
now call torch.set_num_threads() from the TORCH_NUM_THREADS env var, defaulting
to os.cpu_count(). The three Node.js spawners (noiseReduce.js, frameAnalysis.js,
separation.js) explicitly pass OMP_NUM_THREADS, MKL_NUM_THREADS, and
TORCH_NUM_THREADS into each child process env so the C-level ATen thread pools
are configured at library load time, before any model code runs.

https://claude.ai/code/session_01RGrwyvGu2PzKJByGmMTxa9