### PR TITLE
Add vocal saturation stage to all processing pipelines

### DIFF
--- a/server/pipeline/pipelines.js
+++ b/server/pipeline/pipelines.js
@@ -40,6 +40,7 @@ const STANDARD_PIPELINE = [
   stages.enhancementEQ,
   //stages.harmonicExciter,
   //stages.roomTonePad,             // TO DO: Make configurable option; For ACX-only preset only; Changes file length
+  stages.vocalSaturation,
   stages.normalize,
   stages.truePeakLimit,
   stages.measureAfter,
@@ -87,8 +88,9 @@ export const PIPELINES = {
     stages.parallelCompress,         // parallel compression
     stages.vocalExpander,            // Stage 4a-E — frequency-selective expander
     stages.autoLevel,                // VAD-gated gain riding; no-op when drift ≤ 3 dB σ
-    stages.enhancementEQ,           
+    stages.enhancementEQ,
     //stages.harmonicExciter,         // Adds presence/air harmonic content before normalization
+    stages.vocalSaturation,
     stages.normalize,                // Loudness normalization
     stages.truePeakLimit,            // True peak limiting
     stages.measureAfter,
@@ -128,8 +130,9 @@ export const PIPELINES = {
     stages.parallelCompress,         // parallel compression
     stages.vocalExpander,            // Stage 4a-E — frequency-selective expander
     stages.autoLevel,                // VAD-gated gain riding; no-op when drift ≤ 3 dB σ
-    stages.enhancementEQ,           
+    stages.enhancementEQ,
     //stages.harmonicExciter,         // Adds presence/air harmonic content before normalization
+    stages.vocalSaturation,
     stages.normalize,                // Loudness normalization
     stages.truePeakLimit,            // True peak limiting
     stages.measureAfter,

--- a/server/pipeline/separation.js
+++ b/server/pipeline/separation.js
@@ -23,8 +23,9 @@ const SCRIPTS_DIR = path.join(path.dirname(fileURLToPath(import.meta.url)), '..'
 const RNNOISE_SCRIPT          = path.join(SCRIPTS_DIR, 'rnnoise_denoise.py')
 const SEPARATE_SCRIPT         = path.join(SCRIPTS_DIR, 'separate_vocals.py')
 const VOICEFIXER_SCRIPT       = path.join(SCRIPTS_DIR, 'voicefixer_enhance.py')
-const HARMONIC_EXCITER_SCRIPT = path.join(SCRIPTS_DIR, 'harmonic_exciter.py')
-const CLEARERVOICE_SCRIPT     = path.join(SCRIPTS_DIR, 'clearervoice_enhance.py')
+const HARMONIC_EXCITER_SCRIPT  = path.join(SCRIPTS_DIR, 'harmonic_exciter.py')
+const VOCAL_SATURATION_SCRIPT  = path.join(SCRIPTS_DIR, 'vocal_saturation.py')
+const CLEARERVOICE_SCRIPT      = path.join(SCRIPTS_DIR, 'clearervoice_enhance.py')
 const DEREVERB_SCRIPT         = path.join(SCRIPTS_DIR, 'dereverb.py')
 const AP_BWE_SCRIPT           = path.join(SCRIPTS_DIR, 'ap_bwe_extend.py')
 
@@ -110,6 +111,22 @@ export function runHarmonicExciter(inputPath, outputPath, params = {}) {
   if (params.drive              != null) args.push('--drive',                String(params.drive))
   if (params.evenHarmonicWeight != null) args.push('--even-harmonic-weight', String(params.evenHarmonicWeight))
   return spawnPython(HARMONIC_EXCITER_SCRIPT, args, 'HarmonicExciter')
+}
+
+/**
+ * Vocal Saturation — parallel tanh soft-saturation mixed with the dry signal.
+ *
+ * @param {string} inputPath  - 32-bit float WAV at 44.1 kHz
+ * @param {string} outputPath - 32-bit float WAV at 44.1 kHz
+ * @param {object} [params]
+ * @param {number} [params.drive=2.0]   - tanh saturation factor
+ * @param {number} [params.wetDry=0.3]  - mix ratio (0=dry, 1=wet)
+ */
+export function runVocalSaturation(inputPath, outputPath, params = {}) {
+  const args = ['--input', inputPath, '--output', outputPath]
+  if (params.drive  != null) args.push('--drive',   String(params.drive))
+  if (params.wetDry != null) args.push('--wet-dry', String(params.wetDry))
+  return spawnPython(VOCAL_SATURATION_SCRIPT, args, 'VocalSaturation')
 }
 
 /**

--- a/server/pipeline/stages.js
+++ b/server/pipeline/stages.js
@@ -40,7 +40,7 @@ import { applyRoomTonePadding } from './roomTone.js'
 import { generateQualityAdvisory } from './riskAssessment.js'
 import { analyzeAndDeEss } from './deEsser.js'
 import { applyCompression } from './compression.js'
-import { runRnnoise, runSeparation, runVoiceFixer, runHarmonicExciter, runClearerVoice, runDereverb, runApBwe } from './separation.js'
+import { runRnnoise, runSeparation, runVoiceFixer, runHarmonicExciter, runVocalSaturation, runClearerVoice, runDereverb, runApBwe } from './separation.js'
 import { validateSeparation } from './separationValidation.js'
 import { applyAutoLeveler } from './autoLeveler.js'
 import { applyParallelCompression } from './parallelCompression.js'
@@ -477,6 +477,22 @@ export async function harmonicExciter(ctx) {
   ctx.currentPath = outPath
   ctx.results.harmonicExciter = { applied: true }
   await logLevel(ctx, 'after harmonic exciter', ctx.currentPath, {})
+}
+
+// ── Stage: Vocal saturation ───────────────────────────────────────────────────
+// Parallel tanh saturation mixed with the dry signal at wet_dry ratio.
+// Runs after all compression/leveling and before normalization so the
+// loudness pass absorbs any residual energy shift from the blend.
+
+export async function vocalSaturation(ctx) {
+  const outPath = ctx.tmp('.wav')
+  const sat     = ctx.preset.saturation ?? {}
+  const drive   = sat.drive  ?? 2.0
+  const wetDry  = sat.wetDry ?? 0.3
+  await runVocalSaturation(ctx.currentPath, outPath, { drive, wetDry })
+  ctx.currentPath = outPath
+  ctx.results.vocalSaturation = { applied: true, drive, wetDry }
+  await logLevel(ctx, 'after vocal saturation', ctx.currentPath, {})
 }
 
 // ── Stage: Normalize ──────────────────────────────────────────────────────────

--- a/server/scripts/vocal_saturation.py
+++ b/server/scripts/vocal_saturation.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""
+Vocal Saturation — parallel tanh soft-saturation mixed with the dry signal.
+
+Input/output: 32-bit float WAV at 44.1 kHz.
+"""
+
+import argparse
+
+import numpy as np
+from scipy.io import wavfile
+
+
+def vocal_saturation(audio, drive=2.0, wet_dry=0.3):
+    """
+    Parallel tanh saturation blended with the dry signal.
+
+    drive:   tanh saturation factor — higher adds more harmonic content
+    wet_dry: mix ratio (0.0 = fully dry, 1.0 = fully wet)
+    """
+    # 1. Generate wet (saturated) signal
+    wet = np.tanh(audio * drive)
+
+    # 2. RMS-match wet to dry so the blend is level-neutral at any mix ratio.
+    #    np.tanh compresses energy at drive > 1 — without matching the wet track
+    #    would be quieter than dry, making wet_dry=1.0 sound like a gain cut.
+    dry_rms = np.sqrt(np.mean(audio ** 2)) + 1e-8
+    wet_rms = np.sqrt(np.mean(wet ** 2)) + 1e-8
+    wet = wet * (dry_rms / wet_rms)
+
+    # 3. Parallel blend
+    output = (1.0 - wet_dry) * audio + wet_dry * wet
+
+    # 4. Safety clip — guards against rare over-ceiling values at high wet_dry + high drive
+    output = np.clip(output, -1.0, 1.0)
+
+    return output
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Parallel tanh vocal saturation')
+    parser.add_argument('--input',   required=True, help='Input WAV path (32-bit float, 44.1 kHz)')
+    parser.add_argument('--output',  required=True, help='Output WAV path (32-bit float, 44.1 kHz)')
+    parser.add_argument('--drive',   type=float, default=2.0,
+                        help='Tanh saturation drive factor (default: 2.0)')
+    parser.add_argument('--wet-dry', type=float, default=0.3,
+                        help='Wet/dry mix ratio: 0.0=dry, 1.0=wet (default: 0.3)')
+    args = parser.parse_args()
+
+    sr, audio = wavfile.read(args.input)
+    audio = audio.astype(np.float32)
+
+    # Handle multichannel: process each channel independently
+    if audio.ndim == 1:
+        processed = vocal_saturation(audio, args.drive, args.wet_dry)
+    else:
+        channels = [
+            vocal_saturation(audio[:, ch], args.drive, args.wet_dry)
+            for ch in range(audio.shape[1])
+        ]
+        processed = np.stack(channels, axis=1)
+
+    wavfile.write(args.output, sr, processed.astype(np.float32))
+    print(
+        f'Vocal saturation applied: '
+        f'drive={args.drive}  wet_dry={args.wet_dry}'
+    )
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Parallel tanh soft-saturation blended with the dry signal at a
configurable wet/dry ratio. Runs just before Stage 5 (Loudness
Normalization) in all three pipelines (STANDARD_PIPELINE, noise_eraser,
clearervoice_eraser) so the loudness pass absorbs any residual energy
shift from the blend.

- server/scripts/vocal_saturation.py: numpy.tanh saturation with
  RMS-matched wet track and safety clip; accepts --drive and --wet-dry
- server/pipeline/separation.js: runVocalSaturation() spawner
- server/pipeline/stages.js: vocalSaturation stage; reads drive/wetDry
  from ctx.preset.saturation with defaults (drive=2.0, wet_dry=0.3)
- server/pipeline/pipelines.js: stage inserted before normalize in all
  three pipeline definitions

https://claude.ai/code/session_013JujCZ2DXMy3GaESZgdzyK