### PR TITLE
Add LavaSR bandwidth extension as alternative to AP-BWE

### DIFF
--- a/server/pipeline/separation.js
+++ b/server/pipeline/separation.js
@@ -29,6 +29,7 @@ const VOCAL_SATURATION_SCRIPT  = path.join(SCRIPTS_DIR, 'vocal_saturation.py')
 const CLEARERVOICE_SCRIPT      = path.join(SCRIPTS_DIR, 'clearervoice_enhance.py')
 const DEREVERB_SCRIPT         = path.join(SCRIPTS_DIR, 'dereverb.py')
 const AP_BWE_SCRIPT           = path.join(SCRIPTS_DIR, 'ap_bwe_extend.py')
+const LAVASR_SCRIPT           = path.join(SCRIPTS_DIR, 'lavasr_extend.py')
 
 // ── Public API ────────────────────────────────────────────────────────────────
 
@@ -192,6 +193,25 @@ export function runApBwe(inputPath, outputPath) {
     ['--input', inputPath, '--output', outputPath, '--device', DEVICE],
     'AP-BWE',
     { AP_BWE_CHECKPOINT: process.env.AP_BWE_CHECKPOINT, AP_BWE_REPO: process.env.AP_BWE_REPO }
+  )
+}
+
+/**
+ * Stage NE-6 (LavaSR path): Lightweight Vocos-based bandwidth extension.
+ * Outputs 48 kHz WAV; caller resamples back to 44.1 kHz via decodeToFloat32.
+ *
+ * Requires:
+ *   LAVASR_MODEL_PATH  - HuggingFace Hub ID or local path (default: YatharthS/LavaSR)
+ *
+ * @param {string} inputPath  - 32-bit float WAV at 44.1 kHz
+ * @param {string} outputPath - 32-bit float WAV at 48 kHz
+ */
+export function runLavaSR(inputPath, outputPath) {
+  return spawnPython(
+    LAVASR_SCRIPT,
+    ['--input', inputPath, '--output', outputPath, '--device', DEVICE],
+    'LavaSR',
+    { LAVASR_MODEL_PATH: process.env.LAVASR_MODEL_PATH }
   )
 }
 

--- a/server/pipeline/stages.js
+++ b/server/pipeline/stages.js
@@ -40,7 +40,7 @@ import { applyRoomTonePadding } from './roomTone.js'
 import { generateQualityAdvisory } from './riskAssessment.js'
 import { analyzeAndDeEss } from './deEsser.js'
 import { applyCompression } from './compression.js'
-import { runRnnoise, runDtln, runSeparation, runVoiceFixer, runHarmonicExciter, runVocalSaturation, runClearerVoice, runDereverb, runApBwe } from './separation.js'
+import { runRnnoise, runDtln, runSeparation, runVoiceFixer, runHarmonicExciter, runVocalSaturation, runClearerVoice, runDereverb, runApBwe, runLavaSR } from './separation.js'
 import { validateSeparation } from './separationValidation.js'
 import { applyAutoLeveler } from './autoLeveler.js'
 import { applyParallelCompression } from './parallelCompression.js'
@@ -848,16 +848,24 @@ export async function bandwidthExtension(ctx) {
   //   return
   // }
 
-  // AP-BWE outputs 48 kHz — decodeToFloat32 resamples to 32-bit float 44.1 kHz
+  const bweModel = ctx.preset.bweModel ?? 'ap_bwe'
+
+  // Both AP-BWE and LavaSR output 48 kHz — decodeToFloat32 resamples to 32-bit float 44.1 kHz
   const bwe48kPath = ctx.tmp('.wav')
   const bwe44kPath = ctx.tmp('.wav')
-  await runApBwe(ctx.currentPath, bwe48kPath)
+
+  if (bweModel === 'lavasr') {
+    await runLavaSR(ctx.currentPath, bwe48kPath)
+  } else {
+    await runApBwe(ctx.currentPath, bwe48kPath)
+  }
+
   await decodeToFloat32(bwe48kPath, bwe44kPath)
   ctx.currentPath = bwe44kPath
 
   // Post-BWE sibilance EQ: narrow bell cut to tame HF harshness introduced by BWE.
-  // AP-BWE synthesises broadband HF content that can skew sibilant; applying a cut
-  // here — before enhancement EQ and the de-esser — corrects this at the source.
+  // Both models synthesise broadband HF content that can skew sibilant; applying a
+  // cut here — before enhancement EQ and the de-esser — corrects this at the source.
   // Parameters (freq, q, gainDb) are configurable per preset via bwe.postEq.
   const postEq = ctx.preset.bwe.postEq
   if (postEq?.enabled) {
@@ -873,11 +881,12 @@ export async function bandwidthExtension(ctx) {
 
   ctx.results.bandwidthExtension = {
     applied: true,
+    model: bweModel === 'lavasr' ? 'LavaSR' : 'AP-BWE',
     ...(postEq?.enabled && {
       postEq: { applied: true, freq: postEq.freq ?? 9000, q: postEq.q ?? 2, gainDb: postEq.gainDb },
     }),
   }
-  await logLevel(ctx, 'after NE-6 bandwidth extension', ctx.currentPath, {})
+  await logLevel(ctx, `after NE-6 bandwidth extension (${bweModel})`, ctx.currentPath, {})
 }
 
 // ── CE Stage: ClearerVoice speech enhancement (CE-3) ─────────────────────────

--- a/server/scripts/lavasr_extend.py
+++ b/server/scripts/lavasr_extend.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""
+LavaSR bandwidth extension script for Instant Polish pipeline (Stage NE-6).
+
+Usage:
+  python3 lavasr_extend.py --input <path> --output <path> [--device <auto|cuda|cpu>]
+                           [--denoise] [--cutoff <hz>]
+
+Environment variables:
+  LAVASR_MODEL_PATH  HuggingFace Hub model ID or local path to cached model weights.
+                     Defaults to 'YatharthS/LavaSR' (auto-downloaded on first run).
+
+Reads a 32-bit float WAV at 44.1 kHz, runs LavaSR bandwidth extension, and writes
+the result as a 32-bit float PCM WAV at 48 kHz.
+The caller (stages.js) resamples back to 44.1 kHz via decodeToFloat32/FFmpeg.
+
+LavaSR is a lightweight Vocos-based super-resolution model (~50 MB, ~500 MB VRAM).
+Runs at ~5000x realtime on GPU and ~50x realtime on CPU.
+Repo: https://github.com/ysharma3501/LavaSR
+"""
+import argparse
+import os
+import sys
+import warnings
+
+warnings.filterwarnings('ignore')
+
+
+def main():
+    parser = argparse.ArgumentParser(description='LavaSR bandwidth extension')
+    parser.add_argument('--input',   required=True,        help='Input WAV file (32-bit float, 44.1 kHz)')
+    parser.add_argument('--output',  required=True,        help='Output WAV file (32-bit float, 48 kHz)')
+    parser.add_argument('--device',  default='auto',       help='Compute device: auto, cuda, or cpu')
+    parser.add_argument('--denoise', action='store_true',  help='Enable LavaSR internal denoising pass (default: off — noise reduction runs upstream in stage 2)')
+    parser.add_argument('--cutoff',  type=int, default=None, help='Linkwitz-Riley filter cutoff Hz (default: half input SR). Lower values reduce metallic artefacts.')
+    args = parser.parse_args()
+
+    # ── Imports (deferred so arg errors print before heavy imports) ───────────
+    import numpy as np
+    import soundfile as sf
+    import torch
+    import torchaudio.functional as F
+
+    # ── Device selection ──────────────────────────────────────────────────────
+    if args.device == 'auto':
+        device = 'cuda' if torch.cuda.is_available() else 'cpu'
+    else:
+        device = args.device
+
+    print(f'LavaSR using device: {device}')
+
+    num_threads = int(os.environ.get('TORCH_NUM_THREADS', os.cpu_count() or 4))
+    torch.set_num_threads(num_threads)
+    print(f'LavaSR using {num_threads} CPU threads')
+
+    # ── Load model ────────────────────────────────────────────────────────────
+    model_path = os.environ.get('LAVASR_MODEL_PATH', 'YatharthS/LavaSR')
+    print(f'LavaSR loading model from: {model_path}')
+
+    try:
+        from LavaSR.model import LavaEnhance2
+    except ImportError:
+        print(
+            'LavaSR package not found.\n'
+            'Install it with:\n'
+            '  pip install git+https://github.com/ysharma3501/LavaSR.git\n'
+            'Or set LAVASR_MODEL_PATH to a local cached model directory.',
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    model = LavaEnhance2(model_path, device=device)
+
+    # ── Load input audio ──────────────────────────────────────────────────────
+    # Read the 32-bit float WAV produced by the upstream pipeline stage.
+    audio_np, sr = sf.read(args.input, dtype='float32', always_2d=True)  # [samples, channels]
+    audio_np = audio_np.T  # → [channels, samples]
+
+    # Mix to mono — LavaSR operates on single-channel audio
+    if audio_np.shape[0] > 1:
+        audio_np = audio_np.mean(axis=0, keepdims=True)
+
+    # Convert to torch tensor [1, samples] and resample to the 16 kHz rate that
+    # the LavaSR denoiser expects. LavaEnhance2.enhance() accepts a [1, samples]
+    # tensor at 16 kHz.
+    audio_t = torch.from_numpy(audio_np)  # [1, samples] at input sr
+    if sr != 16000:
+        audio_t = F.resample(audio_t, sr, 16000)
+
+    # ── Run LavaSR inference ──────────────────────────────────────────────────
+    # denoise=False by default: noise reduction runs upstream in stage 2 (DF3).
+    # Setting batch=True handles long files safely by processing in 1.28 s chunks.
+    kwargs = dict(
+        enhance=True,
+        denoise=args.denoise,
+        batch=True,
+    )
+    if args.cutoff is not None:
+        # load_audio exposes cutoff; here we reach into the model to set it.
+        # FastLRMerge (the Linkwitz-Riley refiner) uses this cutoff frequency.
+        kwargs['cutoff'] = args.cutoff
+
+    print(f'LavaSR running inference (denoise={args.denoise}, cutoff={args.cutoff})')
+    with torch.no_grad():
+        output_t = model.enhance(audio_t, **kwargs)
+
+    # Output is a tensor at 48 kHz; shape may be [1, samples] or [samples].
+    output_t = output_t.cpu()
+    if output_t.dim() == 1:
+        output_t = output_t.unsqueeze(0)
+
+    # ── Save wideband output at 48 kHz ────────────────────────────────────────
+    # The Node.js stage (decodeToFloat32) resamples back to 44.1 kHz.
+    output_np = output_t.numpy().T  # [samples, 1] for soundfile
+    sf.write(args.output, output_np, 48000, subtype='FLOAT')
+
+    print(f'LavaSR complete: {args.input} -> {args.output} (48000 Hz)')
+
+
+if __name__ == '__main__':
+    main()

--- a/src/audio/presets.js
+++ b/src/audio/presets.js
@@ -187,6 +187,7 @@ export const PRESETS = {
       maxAttenuationDb: 40,
       detectionBand:    { lowHz: 80, highHz: 800 },
     },
+    bweModel: 'ap_bwe',
     bwe: { enabled: true, postEq: { enabled: true, freq: 9000, q: 2, gainDb: -3 } },
   },
 
@@ -269,6 +270,7 @@ export const PRESETS = {
       maxAttenuationDb: 18,
       detectionBand:    { lowHz: 80, highHz: 800 },
     },
+    bweModel: 'ap_bwe',
     bwe: { enabled: true, postEq: { enabled: true, freq: 9000, q: 2, gainDb: -3 } },
   },
 
@@ -342,6 +344,7 @@ export const PRESETS = {
       maxAttenuationDb: 12,
       detectionBand:    { lowHz: 80, highHz: 800 },
     },
+    bweModel: 'ap_bwe',
     bwe: { enabled: true, postEq: { enabled: true, freq: 9000, q: 2, gainDb: -3 } },
   },
 
@@ -410,6 +413,7 @@ export const PRESETS = {
       maxAttenuationDb: 18,
       detectionBand:    { lowHz: 80, highHz: 800 },
     },
+    bweModel: 'ap_bwe',
     bwe: { enabled: true, postEq: { enabled: true, freq: 9000, q: 2, gainDb: -3 } },
   },
 
@@ -495,6 +499,7 @@ export const PRESETS = {
       maxAttenuationDb: 40,
       detectionBand:    { lowHz: 80, highHz: 800 },
     },
+    bweModel: 'ap_bwe',
     bwe: { enabled: false, postEq: { enabled: true, freq: 9000, q: 2, gainDb: -3 } },
   },
 
@@ -564,6 +569,7 @@ export const PRESETS = {
       maxAttenuationDb: 18,
       detectionBand:    { lowHz: 80, highHz: 800 },
     },
+    bweModel: 'ap_bwe',
     bwe: { enabled: true, postEq: { enabled: true, freq: 9000, q: 2, gainDb: -4 } },
   },
 


### PR DESCRIPTION
## Summary
This PR introduces LavaSR as an optional lightweight bandwidth extension model for the Instant Polish pipeline's Stage NE-6, alongside the existing AP-BWE implementation. Users can now select between AP-BWE and LavaSR via a preset configuration option.

## Key Changes

- **New LavaSR script** (`server/scripts/lavasr_extend.py`): Implements bandwidth extension using the lightweight Vocos-based LavaSR model (~50 MB, ~500 MB VRAM). Accepts 32-bit float WAV at 44.1 kHz and outputs 48 kHz audio. Supports optional denoising and Linkwitz-Riley filter cutoff configuration.

- **Pipeline integration** (`server/pipeline/stages.js`):
  - Added `runLavaSR` import from separation module
  - Modified `bandwidthExtension()` to select between AP-BWE and LavaSR based on `ctx.preset.bweModel`
  - Updated logging and results tracking to include the selected model name
  - Both models output 48 kHz; downstream `decodeToFloat32` resamples to 44.1 kHz

- **Separation module** (`server/pipeline/separation.js`):
  - Added `runLavaSR()` export function that spawns the LavaSR Python script with device selection
  - Supports `LAVASR_MODEL_PATH` environment variable for model configuration (defaults to HuggingFace Hub ID `YatharthS/LavaSR`)

- **Preset configuration** (`src/audio/presets.js`):
  - Added `bweModel: 'ap_bwe'` field to all six presets, establishing AP-BWE as the default
  - Allows per-preset override to `'lavasr'` for alternative model selection

## Implementation Details

- LavaSR operates on 16 kHz mono audio internally; the script handles resampling from input sample rate
- Both bandwidth extension models produce 48 kHz output, maintaining consistency with existing post-processing pipeline
- Post-BWE sibilance EQ (narrow bell cut at ~9 kHz) applies to both models to mitigate HF harshness
- LavaSR denoising is disabled by default (noise reduction runs upstream in stage 2 via DF3)
- Performance: ~5000x realtime on GPU, ~50x realtime on CPU

https://claude.ai/code/session_01B6an3tgUQ7nxCXsqz3qcGF