### PR TITLE
Add Stage 3b dynamic resonance suppressor to standard pipeline

### DIFF
--- a/server/pipeline/index.js
+++ b/server/pipeline/index.js
@@ -163,7 +163,8 @@ function buildReport(ctx) {
       ...(results.autoLeveler         && { auto_leveler:         formatAutoLevelerResult(results.autoLeveler) }),
       ...(results.compression         && { compression:           formatCompressionResult(results.compression) }),
       ...(results.parallelCompression && { parallel_compression:  formatParallelCompressionResult(results.parallelCompression) }),
-      ...(results.vocalExpander       && { vocal_expander:        formatVocalExpanderResult(results.vocalExpander) }),
+      ...(results.vocalExpander         && { vocal_expander:          formatVocalExpanderResult(results.vocalExpander) }),
+      ...(results.resonanceSuppressor   && { resonance_suppressor:    formatResonanceSuppressorResult(results.resonanceSuppressor) }),
       normalization_gain_db:
         results.afterMeasurements?.rmsDbfs == null || results.beforeMeasurements?.rmsDbfs == null
           ? null
@@ -416,6 +417,18 @@ function formatVocalExpanderResult(r) {
       pct_frames_expanded:        r.pctFramesExpanded,
       over_expansion_flag:        r.overExpansionFlag,
     },
+  }
+}
+
+function formatResonanceSuppressorResult(r) {
+  if (!r) return null
+  if (r.skipped || r.applied === false) return { applied: false }
+  return {
+    applied:           true,
+    max_reduction_db:  r.max_reduction_db  ?? null,
+    mean_reduction_db: r.mean_reduction_db ?? null,
+    spike_frames:      r.spike_frames      ?? null,
+    artifact_risk:     r.artifact_risk     ?? false,
   }
 }
 

--- a/server/pipeline/index.js
+++ b/server/pipeline/index.js
@@ -422,7 +422,7 @@ function formatVocalExpanderResult(r) {
 
 function formatResonanceSuppressorResult(r) {
   if (!r) return null
-  if (r.skipped || r.applied === false) return { applied: false }
+  if (r.applied === false) return { applied: false }
   return {
     applied:           true,
     max_reduction_db:  r.max_reduction_db  ?? null,

--- a/server/pipeline/pipelines.js
+++ b/server/pipeline/pipelines.js
@@ -43,6 +43,7 @@ const STANDARD_PIPELINE = [
   stages.airBoost,               // Stage 3b — Maag EQ4-style air/HF shelf lift; no-op when air_boost_db ≤ 0
   stages.deEss,
   stages.enhancementEQ,
+  stages.resonanceSuppressor,   // Dynamic resonance suppressor — voiced frames only; excluded from NE/CE pipelines
   //stages.roomTonePad,           // TO DO: Make configurable option; For ACX-only preset only; Changes file length
   stages.normalize,
   stages.truePeakLimit,

--- a/server/pipeline/resonanceSuppressor.js
+++ b/server/pipeline/resonanceSuppressor.js
@@ -1,0 +1,125 @@
+/**
+ * Stage 3b — Dynamic Resonance Suppressor.
+ *
+ * Runs instant_polish_resonance_suppressor.py as a Python subprocess.
+ * Applies STFT-based spectral spike detection and dynamic gain reduction
+ * to voiced frames only (VAD mask), leaving silence frames unmodified.
+ *
+ * Input/output: 32-bit float WAV at 44.1 kHz (pipeline internal format).
+ */
+
+import { spawn }         from 'child_process'
+import { fileURLToPath } from 'url'
+import { writeFile, rm } from 'fs/promises'
+import os                from 'os'
+import path              from 'path'
+import { tempPath }      from '../lib/ffmpeg.js'
+
+const PYTHON = process.env.RESONANCE_PYTHON
+            ?? process.env.SEPARATION_PYTHON
+            ?? process.env.DEEPFILTER_PYTHON
+            ?? 'python3'
+const NUM_THREADS = process.env.TORCH_NUM_THREADS ?? String(os.cpus().length)
+const SCRIPT = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '..', 'scripts', 'instant_polish_resonance_suppressor.py',
+)
+
+/**
+ * @param {string}      inputPath   32-bit float WAV at 44.1 kHz
+ * @param {string}      outputPath  Pre-allocated output path (ctx.tmp('.wav'))
+ * @param {string}      presetId    e.g. 'acx_audiobook'
+ * @param {object[]|null} frames    ctx.results.metrics.frames — written to a temp
+ *   JSON file for VAD gating. Pass null to suppress VAD gating (full-file mode).
+ * @returns {Promise<object>}  Result dict from resonance_suppressor_report_entry()
+ */
+export async function applyResonanceSuppression(inputPath, outputPath, presetId, frames) {
+  console.log(`[ResonanceSuppressor] Starting: preset=${presetId}`)
+
+  const args = [
+    SCRIPT,
+    '--input',  inputPath,
+    '--output', outputPath,
+    '--preset', presetId,
+  ]
+
+  let vadMaskPath = null
+  if (frames && frames.length > 0) {
+    vadMaskPath = tempPath('.json')
+    await writeFile(vadMaskPath, JSON.stringify(frames))
+    args.push('--vad-mask-json', vadMaskPath)
+  }
+
+  let result
+  try {
+    result = await runScript(args)
+  } finally {
+    if (vadMaskPath) await rm(vadMaskPath, { force: true })
+  }
+
+  console.log(
+    `[ResonanceSuppressor] Done: skipped=${result.applied === false} ` +
+    `max_reduction=${result.max_reduction_db ?? 'n/a'}dB ` +
+    `artifact_risk=${result.artifact_risk ?? false}`,
+  )
+  return result
+}
+
+function runScript(args) {
+  return new Promise((resolve, reject) => {
+    const proc = spawn(PYTHON, args, {
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env: {
+        ...process.env,
+        OMP_NUM_THREADS:   NUM_THREADS,
+        MKL_NUM_THREADS:   NUM_THREADS,
+        TORCH_NUM_THREADS: NUM_THREADS,
+      },
+    })
+
+    let stdout = ''
+    let stderr = ''
+
+    proc.stdout.on('data', chunk => {
+      const text = chunk.toString()
+      stdout += text
+      for (const line of text.split('\n')) {
+        if (line.trim() && !line.startsWith('JSON_RESULT:')) {
+          console.log(`[ResonanceSuppressor] ${line}`)
+        }
+      }
+    })
+
+    proc.stderr.on('data', chunk => {
+      stderr += chunk.toString()
+      if (stderr.length > 4000) stderr = stderr.slice(-4000)
+    })
+
+    proc.on('close', (code, signal) => {
+      if (stderr.trim() && code === 0) console.log(`[ResonanceSuppressor] ${stderr.trim()}`)
+      if (code === 0 && signal === null) {
+        const jsonLine = stdout.split('\n').find(l => l.startsWith('JSON_RESULT:'))
+        if (!jsonLine) {
+          reject(new Error('ResonanceSuppressor: script exited 0 but emitted no JSON_RESULT line'))
+          return
+        }
+        try {
+          resolve(JSON.parse(jsonLine.slice('JSON_RESULT:'.length)))
+        } catch (e) {
+          reject(new Error(`ResonanceSuppressor: failed to parse JSON result: ${e.message}`))
+        }
+      } else {
+        const parts = []
+        if (code   !== null) parts.push(`code ${code}`)
+        if (signal !== null) parts.push(`signal ${signal}`)
+        reject(new Error(
+          `ResonanceSuppressor exited with ${parts.join(', ')}.\n${stderr.slice(-2000)}`,
+        ))
+      }
+    })
+
+    proc.on('error', err => {
+      reject(new Error(`Failed to spawn ResonanceSuppressor: ${err.message}`))
+    })
+  })
+}

--- a/server/pipeline/riskAssessment.js
+++ b/server/pipeline/riskAssessment.js
@@ -183,8 +183,9 @@ export async function generateQualityAdvisory(
   }
 
   // --- Resonance Suppressor advisory flag ---
-  // Emitted when the suppressor ran (not skipped) and artifact_risk is true,
-  // indicating mean reduction depth exceeded 3 dB across active frames.
+  // Emitted when the suppressor ran and artifact_risk is true.
+  // artifact_risk is set when mean gain reduction across bins with > 0.01 dB
+  // reduction exceeds 3 dB, indicating the file had sustained resonant spikes.
   const rsResult = pipelineContext.resonanceSuppressor
   if (rsResult && rsResult.applied && rsResult.artifact_risk) {
     flags.push({

--- a/server/pipeline/riskAssessment.js
+++ b/server/pipeline/riskAssessment.js
@@ -69,7 +69,7 @@ const CREST_FACTOR_THRESHOLD_DB = 8
  * @param {string} outputProfileId
  * @param {import('./frameAnalysis.js').FrameAnalysis} frameAnalysis
  * @param {number} voicedRmsDbfs - Average voiced RMS (for breath comparison)
- * @param {object} pipelineContext - { preNrNoiseFloor: number|null, noiseFloorDbfs: number|null }
+ * @param {object} pipelineContext - { preNrNoiseFloor: number|null, noiseFloorDbfs: number|null, resonanceSuppressor: object|null }
  * @returns {QualityAdvisory}
  */
 export async function generateQualityAdvisory(
@@ -180,6 +180,18 @@ export async function generateQualityAdvisory(
         message: 'The expander may have affected quiet speech. Listen for unnatural silences between words or clipped consonants.',
       })
     }
+  }
+
+  // --- Resonance Suppressor advisory flag ---
+  // Emitted when the suppressor ran (not skipped) and artifact_risk is true,
+  // indicating mean reduction depth exceeded 3 dB across active frames.
+  const rsResult = pipelineContext.resonanceSuppressor
+  if (rsResult && rsResult.applied && rsResult.artifact_risk) {
+    flags.push({
+      id:       'resonance_suppressor_high_reduction',
+      severity: 'info',
+      message:  'The resonance suppressor applied heavy reduction in some frequency bands. Listen for spectral smearing or unnatural tonal balance.',
+    })
   }
 
   const review_recommended = flags.some(f => f.severity === 'review')

--- a/server/pipeline/stages.js
+++ b/server/pipeline/stages.js
@@ -47,6 +47,7 @@ import { applyParallelCompression } from './parallelCompression.js'
 import { applyVocalExpander } from './vocalExpander.js'
 import { analyzeHum } from './humEQ.js'
 import { applyAirBoost } from './airBoost.js'
+import { applyResonanceSuppression } from './resonanceSuppressor.js'
 
 // ── Stage: Decode ─────────────────────────────────────────────────────────────
 
@@ -349,6 +350,25 @@ export async function enhancementEQ(ctx) {
   await logLevel(ctx, 'after EQ', ctx.currentPath, {
     applied: eqResult.applied,
     filters: eqResult.ffmpegFilters.length,
+  })
+}
+
+// ── Stage: Resonance Suppressor ───────────────────────────────────────────────
+// Soothe2-inspired dynamic spectral resonance suppressor. Runs after
+// enhancementEQ (static tonal corrections already applied) and before normalize.
+// Only included in STANDARD_PIPELINE — excluded from noise_eraser and
+// clearervoice_eraser by pipeline omission.
+
+export async function resonanceSuppressor(ctx) {
+  const outPath = ctx.tmp('.wav')
+  const frames  = ctx.results.metrics?.frames ?? null
+  const result  = await applyResonanceSuppression(ctx.currentPath, outPath, ctx.presetId, frames)
+  if (!result.skipped) ctx.currentPath = outPath
+  ctx.results.resonanceSuppressor = result
+  await logLevel(ctx, 'after resonance suppressor', ctx.currentPath, {
+    skipped:       result.skipped,
+    max_red:       result.max_reduction_db != null ? `${result.max_reduction_db}dB` : 'n/a',
+    artifact_risk: result.artifact_risk ?? false,
   })
 }
 
@@ -678,10 +698,11 @@ export async function qualityAdvisory(ctx) {
     ? ctx.results.metrics
     : await analyzeFrames(ctx.currentPath)
   const pipelineContext = {
-    preNrNoiseFloor: ctx.results.beforeMeasurements?.noiseFloorDbfs ?? null,
-    noiseFloorDbfs:  ctx.results.noiseReduction?.post_noise_floor_dbfs ?? null,
-    autoLeveler:     ctx.results.autoLeveler ?? null,
-    vocalExpander:   ctx.results.vocalExpander ?? null,
+    preNrNoiseFloor:     ctx.results.beforeMeasurements?.noiseFloorDbfs ?? null,
+    noiseFloorDbfs:      ctx.results.noiseReduction?.post_noise_floor_dbfs ?? null,
+    autoLeveler:         ctx.results.autoLeveler ?? null,
+    vocalExpander:       ctx.results.vocalExpander ?? null,
+    resonanceSuppressor: ctx.results.resonanceSuppressor ?? null,
   }
   ctx.results.qualityAdvisory = await generateQualityAdvisory(
     ctx.currentPath,

--- a/server/pipeline/stages.js
+++ b/server/pipeline/stages.js
@@ -363,10 +363,10 @@ export async function resonanceSuppressor(ctx) {
   const outPath = ctx.tmp('.wav')
   const frames  = ctx.results.metrics?.frames ?? null
   const result  = await applyResonanceSuppression(ctx.currentPath, outPath, ctx.presetId, frames)
-  if (!result.skipped) ctx.currentPath = outPath
+  if (result.applied) ctx.currentPath = outPath
   ctx.results.resonanceSuppressor = result
   await logLevel(ctx, 'after resonance suppressor', ctx.currentPath, {
-    skipped:       result.skipped,
+    skipped:       result.applied === false,
     max_red:       result.max_reduction_db != null ? `${result.max_reduction_db}dB` : 'n/a',
     artifact_risk: result.artifact_risk ?? false,
   })

--- a/server/scripts/instant_polish_resonance_suppressor.py
+++ b/server/scripts/instant_polish_resonance_suppressor.py
@@ -5,7 +5,7 @@ Stage 3b — Dynamic Resonance Suppressor
 Soothe2-inspired spectral spike detection and dynamic attenuation.
 Operates on 32-bit float PCM at 44.1 kHz (Instant Polish internal format).
 
-Dependencies: numpy, scipy, soundfile (for standalone testing)
+Dependencies: numpy, scipy
 All processing is frame-based via STFT/ISTFT with overlap-add reconstruction.
 """
 
@@ -215,20 +215,32 @@ class ResonanceSuppressor:
         reduction_db = np.clip(raw_reduction, 0.0, max_reduction)
         return reduction_db
 
-    def process(self, audio: np.ndarray) -> dict:
+    def process(self, audio: np.ndarray, voiced_frame_indices=None) -> dict:
         """
         Apply dynamic resonance suppression to a mono audio array.
 
+        Processes one STFT frame at a time (streaming) to keep memory proportional
+        to the audio length plus one FFT window — not to n_frames × n_bins. This
+        avoids multi-GB intermediate matrix allocations for long files.
+
+        VAD gating is applied at the STFT frame level: frames whose index is not in
+        voiced_frame_indices receive target_gr=0, letting the attack/release IIR
+        decay smoothed_gr naturally. This prevents hard per-sample splicing, which
+        causes discontinuities at overlap-add boundaries.
+
         Args:
             audio: 1D float32 numpy array at self.sr sample rate.
+            voiced_frame_indices: set of int STFT frame indices where voice is
+                present. Frames outside this set are gated (target_gr=0).
+                None means all frames are processed (no VAD gating).
 
         Returns:
             dict with keys:
-              'audio'           : processed audio (float32 ndarray, same length as input)
-              'max_reduction_db': peak reduction applied at any single bin/frame
-              'mean_reduction_db': mean reduction across all active bins and frames
-              'spike_frames'    : number of frames where any reduction was applied
-              'artifact_risk'   : bool — True if mean_reduction_db > 3 dB (advisory flag trigger)
+              'audio'            : processed audio (float32 ndarray, same length as input)
+              'max_reduction_db' : peak gain reduction at any bin across all frames (dB)
+              'mean_reduction_db': mean reduction over bins with > 0.01 dB reduction
+              'spike_frames'     : frames where any bin exceeded 0.01 dB reduction
+              'artifact_risk'    : True when mean_reduction_db > 3 dB
         """
         if audio.ndim != 1:
             raise ValueError("ResonanceSuppressor expects mono input (1D array).")
@@ -236,20 +248,15 @@ class ResonanceSuppressor:
         n_fft = self.n_fft
         hop = self.hop_length
         window = get_window("hann", n_fft, fftbins=True)
+        window_squared = window ** 2
 
-        # --- STFT ---
-        # Pad signal so all samples are covered
         pad = n_fft // 2
         audio_padded = np.pad(audio, pad, mode="reflect")
+        n_padded = len(audio_padded)
 
-        frames = []
-        pos = 0
-        while pos + n_fft <= len(audio_padded):
-            frame = audio_padded[pos : pos + n_fft] * window
-            frames.append(frame)
-            pos += hop
+        n_frames = max(0, (n_padded - n_fft) // hop + 1)
 
-        if not frames:
+        if n_frames == 0:
             logger.warning("ResonanceSuppressor: audio too short, returning unmodified.")
             return {
                 "audio": audio,
@@ -259,77 +266,76 @@ class ResonanceSuppressor:
                 "artifact_risk": False,
             }
 
-        # FFT of all frames → complex spectra
-        spectra = np.array([np.fft.rfft(f) for f in frames])  # shape: (n_frames, n_bins)
-        magnitudes = np.abs(spectra)                           # linear magnitude
-        phases = np.angle(spectra)                              # phase (preserved throughout)
+        # Output buffers scale with audio length, not n_frames × n_bins
+        output_buffer      = np.zeros(n_padded, dtype=np.float64)
+        window_accumulator = np.zeros(n_padded, dtype=np.float64)
 
-        # Convert to dB (small epsilon to avoid log(0))
-        eps = 1e-10
-        magnitudes_db = 20.0 * np.log10(magnitudes + eps)
-
-        # --- Per-frame resonance detection and gain reduction ---
-        n_frames = len(frames)
-        gain_reduction_db = np.zeros_like(magnitudes_db)  # shape: (n_frames, n_bins)
-
-        # Smoothed gain reduction state for attack/release (per bin)
+        # Per-bin attack/release state (the only O(n_bins) persistent allocation)
         smoothed_gr = np.zeros(self.n_bins)
 
+        # Telemetry accumulators
+        max_reduction       = 0.0
+        sum_reduction       = 0.0
+        n_active_bins_total = 0
+        spike_frames        = 0
+        active_threshold    = 0.01  # dB — consistent floor for mean and spike counting
+
+        eps = 1e-10
+
         for i in range(n_frames):
-            mag_db_frame = magnitudes_db[i]
-            smoothed_env = self._compute_smoothed_envelope(mag_db_frame)
-            target_gr = self._compute_gain_reduction(mag_db_frame, smoothed_env)
-
-            # Attack/release time smoothing (per-bin IIR)
-            # When target_gr > smoothed_gr → attack (gain reducing faster)
-            # When target_gr < smoothed_gr → release (gain recovering)
-            increasing = target_gr >= smoothed_gr
-            coeff = np.where(increasing, self.attack_coeff, self.release_coeff)
-            smoothed_gr = coeff * smoothed_gr + (1.0 - coeff) * target_gr
-            gain_reduction_db[i] = smoothed_gr.copy()
-
-        # --- Apply gain reduction to linear magnitudes ---
-        gain_linear = 10.0 ** (-gain_reduction_db / 20.0)
-        modified_magnitudes = magnitudes * gain_linear
-
-        # --- Reconstruct complex spectra (original phase, modified magnitude) ---
-        modified_spectra = modified_magnitudes * np.exp(1j * phases)
-
-        # --- ISTFT with overlap-add reconstruction ---
-        output_length = len(audio_padded)
-        output_buffer = np.zeros(output_length, dtype=np.float64)
-        window_accumulator = np.zeros(output_length, dtype=np.float64)
-
-        window_squared = window ** 2  # for normalization in OLA
-
-        for i, spectrum in enumerate(modified_spectra):
-            time_frame = np.fft.irfft(spectrum, n=n_fft) * window
             start = i * hop
-            end = start + n_fft
-            if end > output_length:
-                trim = output_length - start
-                output_buffer[start:output_length] += time_frame[:trim]
-                window_accumulator[start:output_length] += window_squared[:trim]
-            else:
-                output_buffer[start:end] += time_frame
-                window_accumulator[start:end] += window_squared
+            end   = start + n_fft
 
-        # Normalize by window accumulator to correct OLA gain
+            # --- FFT ---
+            frame       = audio_padded[start:end] * window
+            spectrum    = np.fft.rfft(frame)
+            magnitude   = np.abs(spectrum)
+            phase       = np.angle(spectrum)
+            magnitude_db = 20.0 * np.log10(magnitude + eps)
+
+            # --- Resonance detection ---
+            smoothed_env = self._compute_smoothed_envelope(magnitude_db)
+            target_gr    = self._compute_gain_reduction(magnitude_db, smoothed_env)
+
+            # VAD gating at STFT-frame level: silence frames receive no gain
+            # reduction target. The IIR below decays smoothed_gr toward 0,
+            # providing smooth gain recovery without hard per-sample splicing.
+            if voiced_frame_indices is not None and i not in voiced_frame_indices:
+                target_gr = np.zeros(self.n_bins)
+
+            # --- Attack/release IIR ---
+            increasing  = target_gr >= smoothed_gr
+            coeff       = np.where(increasing, self.attack_coeff, self.release_coeff)
+            smoothed_gr = coeff * smoothed_gr + (1.0 - coeff) * target_gr
+
+            # --- Per-frame telemetry ---
+            frame_max = float(np.max(smoothed_gr))
+            if frame_max > max_reduction:
+                max_reduction = frame_max
+            active_mask = smoothed_gr > active_threshold
+            if active_mask.any():
+                sum_reduction       += float(np.sum(smoothed_gr[active_mask]))
+                n_active_bins_total += int(active_mask.sum())
+                spike_frames        += 1
+
+            # --- Apply gain reduction and ISTFT ---
+            gain_linear      = 10.0 ** (-smoothed_gr / 20.0)
+            modified_spectrum = magnitude * gain_linear * np.exp(1j * phase)
+            time_frame        = np.fft.irfft(modified_spectrum, n=n_fft) * window
+
+            frame_end = min(end, n_padded)
+            trim      = frame_end - start
+            output_buffer[start:frame_end]      += time_frame[:trim]
+            window_accumulator[start:frame_end] += window_squared[:trim]
+
+        # OLA normalization
         safe_acc = np.where(window_accumulator > 1e-8, window_accumulator, 1.0)
         output_buffer /= safe_acc
 
-        # Remove padding and cast back to float32
         output_audio = output_buffer[pad : pad + len(audio)].astype(np.float32)
 
-        # --- Telemetry for processing report ---
-        max_reduction = float(np.max(gain_reduction_db))
-        mean_reduction = float(np.mean(gain_reduction_db[gain_reduction_db > 0.01]))
-        if np.isnan(mean_reduction):
-            mean_reduction = 0.0
-        spike_frames = int(np.sum(np.any(gain_reduction_db > 0.5, axis=1)))
-
-        # Artifact risk: if mean reduction is high, flag for advisory system
-        artifact_risk = mean_reduction > 3.0
+        mean_reduction = (sum_reduction / n_active_bins_total) if n_active_bins_total > 0 else 0.0
+        artifact_risk  = mean_reduction > 3.0
 
         logger.info(
             f"ResonanceSuppressor: max_reduction={max_reduction:.2f} dB | "
@@ -382,18 +388,25 @@ def apply_resonance_suppression(
 
     suppressor = ResonanceSuppressor(sample_rate=sample_rate, preset=preset)
 
+    voiced_frame_indices = None
     if vad_voiced_mask is not None and len(vad_voiced_mask) == len(audio):
-        # Process only voiced segments; splice results back in
-        # Simple approach: process full audio, then blend with original on silence frames
-        result = suppressor.process(audio)
-        processed = result["audio"]
-        # On silence frames (not voiced), restore original
-        silence_mask = ~vad_voiced_mask
-        processed[silence_mask] = audio[silence_mask]
-        result["audio"] = processed
-    else:
-        result = suppressor.process(audio)
+        # Convert per-sample VAD mask to a set of STFT frame indices.
+        # Frame i is "voiced" when any sample in its analysis window overlaps
+        # with voiced audio. Gating at the STFT frame level (not per-sample)
+        # avoids discontinuities at voiced/silence boundaries — the attack/release
+        # IIR in process() decays gain reduction smoothly toward zero on silence
+        # frames instead of hard-splicing original samples post-OLA.
+        pad           = suppressor.n_fft // 2
+        n_padded      = len(audio) + 2 * pad
+        n_stft_frames = max(0, (n_padded - suppressor.n_fft) // suppressor.hop_length + 1)
+        voiced_frame_indices = set()
+        for fi in range(n_stft_frames):
+            orig_start = max(0, fi * suppressor.hop_length - pad)
+            orig_end   = min(len(audio), fi * suppressor.hop_length - pad + suppressor.n_fft)
+            if orig_start < orig_end and vad_voiced_mask[orig_start:orig_end].any():
+                voiced_frame_indices.add(fi)
 
+    result = suppressor.process(audio, voiced_frame_indices=voiced_frame_indices)
     result["skipped"] = False
     return result
 

--- a/server/scripts/instant_polish_resonance_suppressor.py
+++ b/server/scripts/instant_polish_resonance_suppressor.py
@@ -1,0 +1,466 @@
+"""
+instant_polish_resonance_suppressor.py
+Stage 3b — Dynamic Resonance Suppressor
+
+Soothe2-inspired spectral spike detection and dynamic attenuation.
+Operates on 32-bit float PCM at 44.1 kHz (Instant Polish internal format).
+
+Dependencies: numpy, scipy, soundfile (for standalone testing)
+All processing is frame-based via STFT/ISTFT with overlap-add reconstruction.
+"""
+
+import numpy as np
+from scipy.signal import get_window
+from scipy.ndimage import uniform_filter1d
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Preset-calibrated default parameters
+# ---------------------------------------------------------------------------
+
+PRESET_DEFAULTS = {
+    "acx_audiobook": {
+        "depth": 0.5,          # Global reduction scale (0.0–1.0). Conservative for ACX.
+        "sharpness": 0.4,      # Smoothing window relative width (0.0–1.0). Lower = broader context.
+        "selectivity": 4.0,    # Spike threshold in dB above smoothed floor. Higher = fewer cuts.
+        "attack_ms": 15.0,     # Gain reduction onset speed.
+        "release_ms": 80.0,    # Gain reduction recovery speed.
+        "max_reduction_db": 6.0,  # Hard ceiling on any single notch. Conservative for ACX.
+        "freq_floor_hz": 80.0,    # Don't process below this (HPF already handled sub-vocals).
+        "freq_ceil_hz": 16000.0,  # Don't process above this.
+        "mode": "soft",           # "soft" = gradual knee; "hard" = more aggressive curve.
+    },
+    "podcast_ready": {
+        "depth": 0.65,
+        "sharpness": 0.5,
+        "selectivity": 3.0,
+        "attack_ms": 8.0,
+        "release_ms": 60.0,
+        "max_reduction_db": 9.0,
+        "freq_floor_hz": 80.0,
+        "freq_ceil_hz": 16000.0,
+        "mode": "soft",
+    },
+    "voice_ready": {
+        "depth": 0.55,
+        "sharpness": 0.45,
+        "selectivity": 3.5,
+        "attack_ms": 12.0,
+        "release_ms": 70.0,
+        "max_reduction_db": 7.0,
+        "freq_floor_hz": 80.0,
+        "freq_ceil_hz": 16000.0,
+        "mode": "soft",
+    },
+    "general_clean": {
+        "depth": 0.7,
+        "sharpness": 0.55,
+        "selectivity": 2.5,
+        "attack_ms": 8.0,
+        "release_ms": 50.0,
+        "max_reduction_db": 12.0,
+        "freq_floor_hz": 60.0,
+        "freq_ceil_hz": 18000.0,
+        "mode": "soft",
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# Core algorithm
+# ---------------------------------------------------------------------------
+
+class ResonanceSuppressor:
+    """
+    Dynamic resonance suppressor using STFT-based spectral spike detection.
+
+    For each frame:
+      1. Compute magnitude spectrum via STFT.
+      2. Compute a spectrally-smoothed version of the magnitude (the "expected" envelope).
+      3. Find bins where actual magnitude exceeds smoothed by more than `selectivity` dB.
+      4. Compute per-bin gain reduction proportional to spike depth * `depth` scale.
+      5. Smooth gain reduction in time (attack/release envelope).
+      6. Apply reduction to complex STFT bins (magnitude only; phase preserved).
+      7. Reconstruct via ISTFT with overlap-add.
+    """
+
+    def __init__(
+        self,
+        sample_rate: int = 44100,
+        n_fft: int = 2048,
+        hop_length: int = 512,
+        preset: str = "acx_audiobook",
+        **override_params,
+    ):
+        self.sr = sample_rate
+        self.n_fft = n_fft
+        self.hop_length = hop_length
+
+        # Load preset defaults, then apply any overrides
+        params = PRESET_DEFAULTS.get(preset, PRESET_DEFAULTS["acx_audiobook"]).copy()
+        params.update(override_params)
+        self.params = params
+
+        # Frequency bin mask — only process bins within [freq_floor, freq_ceil]
+        freqs = np.fft.rfftfreq(n_fft, d=1.0 / sample_rate)
+        self.active_bins = (freqs >= params["freq_floor_hz"]) & (freqs <= params["freq_ceil_hz"])
+        self.n_bins = len(freqs)
+
+        # Smoothing window width in bins (derived from sharpness)
+        # sharpness=0.0 → very wide context window (catches only very broad peaks)
+        # sharpness=1.0 → very narrow context window (catches tight resonant spikes)
+        # Soothe behavior: higher sharpness → narrower smoothing → sharper notches
+        min_window = 5    # bins — minimum meaningful context
+        max_window = 120  # bins — very broad spectral context
+        sharpness = params["sharpness"]
+        # Invert: high sharpness = small smoothing window
+        self.smooth_window_bins = max(
+            min_window,
+            int(max_window * (1.0 - sharpness)),
+        )
+
+        # Attack/release time constants as frame-domain coefficients
+        # Convert ms → per-frame coefficient using hop_length/sample_rate as frame period
+        frame_period_ms = (hop_length / sample_rate) * 1000.0
+        self.attack_coeff = self._time_to_coeff(params["attack_ms"], frame_period_ms)
+        self.release_coeff = self._time_to_coeff(params["release_ms"], frame_period_ms)
+
+        logger.info(
+            f"ResonanceSuppressor init | preset={preset} | "
+            f"n_fft={n_fft} | hop={hop_length} | "
+            f"smooth_window={self.smooth_window_bins} bins | "
+            f"selectivity={params['selectivity']} dB | "
+            f"depth={params['depth']} | max_cut={params['max_reduction_db']} dB"
+        )
+
+    @staticmethod
+    def _time_to_coeff(time_ms: float, frame_period_ms: float) -> float:
+        """Convert a time constant in ms to a per-frame IIR smoothing coefficient."""
+        if time_ms <= 0 or frame_period_ms <= 0:
+            return 1.0
+        return np.exp(-frame_period_ms / time_ms)
+
+    def _compute_smoothed_envelope(self, magnitude_db: np.ndarray) -> np.ndarray:
+        """
+        Compute the spectrally-smoothed reference envelope for one frame.
+        Uses a uniform moving average across frequency bins.
+        The smoothed envelope represents the 'expected' spectral shape
+        without sharp resonant peaks.
+
+        Args:
+            magnitude_db: 1D array of magnitude in dB for all freq bins, shape (n_bins,)
+
+        Returns:
+            smoothed: 1D array of smoothed magnitude in dB, shape (n_bins,)
+        """
+        # uniform_filter1d applies a causal average across the frequency axis.
+        # mode='reflect' handles edges cleanly without zero-padding artifacts.
+        smoothed = uniform_filter1d(
+            magnitude_db,
+            size=self.smooth_window_bins,
+            mode="reflect",
+        )
+        return smoothed
+
+    def _compute_gain_reduction(
+        self,
+        magnitude_db: np.ndarray,
+        smoothed_db: np.ndarray,
+    ) -> np.ndarray:
+        """
+        Compute per-bin gain reduction in dB for one frame.
+
+        Bins where actual > smoothed + selectivity_threshold are identified as spikes.
+        Reduction = (spike_amount - threshold) * depth_scale, clipped to max_reduction.
+
+        Args:
+            magnitude_db: actual magnitude (dB), shape (n_bins,)
+            smoothed_db:  smoothed envelope (dB), shape (n_bins,)
+
+        Returns:
+            reduction_db: gain reduction to apply (positive = cut), shape (n_bins,)
+        """
+        p = self.params
+        selectivity_db = p["selectivity"]
+        depth = p["depth"]
+        max_reduction = p["max_reduction_db"]
+        mode = p["mode"]
+
+        spike_db = magnitude_db - smoothed_db  # positive where peaks stick out
+
+        # Only process active frequency range
+        spike_db_masked = np.where(self.active_bins, spike_db, 0.0)
+
+        # Amount above the selectivity threshold
+        above_threshold = np.maximum(0.0, spike_db_masked - selectivity_db)
+
+        if mode == "soft":
+            # Soft knee: smooth onset using a quadratic curve below 2x threshold
+            knee_width = selectivity_db * 0.5
+            in_knee = above_threshold < knee_width
+            soft_curve = np.where(
+                in_knee,
+                above_threshold ** 2 / (2.0 * max(knee_width, 1e-6)),
+                above_threshold,
+            )
+            raw_reduction = soft_curve * depth
+        else:
+            # Hard mode: linear reduction above threshold
+            raw_reduction = above_threshold * depth
+
+        # Clip to hard ceiling
+        reduction_db = np.clip(raw_reduction, 0.0, max_reduction)
+        return reduction_db
+
+    def process(self, audio: np.ndarray) -> dict:
+        """
+        Apply dynamic resonance suppression to a mono audio array.
+
+        Args:
+            audio: 1D float32 numpy array at self.sr sample rate.
+
+        Returns:
+            dict with keys:
+              'audio'           : processed audio (float32 ndarray, same length as input)
+              'max_reduction_db': peak reduction applied at any single bin/frame
+              'mean_reduction_db': mean reduction across all active bins and frames
+              'spike_frames'    : number of frames where any reduction was applied
+              'artifact_risk'   : bool — True if mean_reduction_db > 3 dB (advisory flag trigger)
+        """
+        if audio.ndim != 1:
+            raise ValueError("ResonanceSuppressor expects mono input (1D array).")
+
+        n_fft = self.n_fft
+        hop = self.hop_length
+        window = get_window("hann", n_fft, fftbins=True)
+
+        # --- STFT ---
+        # Pad signal so all samples are covered
+        pad = n_fft // 2
+        audio_padded = np.pad(audio, pad, mode="reflect")
+
+        frames = []
+        pos = 0
+        while pos + n_fft <= len(audio_padded):
+            frame = audio_padded[pos : pos + n_fft] * window
+            frames.append(frame)
+            pos += hop
+
+        if not frames:
+            logger.warning("ResonanceSuppressor: audio too short, returning unmodified.")
+            return {
+                "audio": audio,
+                "max_reduction_db": 0.0,
+                "mean_reduction_db": 0.0,
+                "spike_frames": 0,
+                "artifact_risk": False,
+            }
+
+        # FFT of all frames → complex spectra
+        spectra = np.array([np.fft.rfft(f) for f in frames])  # shape: (n_frames, n_bins)
+        magnitudes = np.abs(spectra)                           # linear magnitude
+        phases = np.angle(spectra)                              # phase (preserved throughout)
+
+        # Convert to dB (small epsilon to avoid log(0))
+        eps = 1e-10
+        magnitudes_db = 20.0 * np.log10(magnitudes + eps)
+
+        # --- Per-frame resonance detection and gain reduction ---
+        n_frames = len(frames)
+        gain_reduction_db = np.zeros_like(magnitudes_db)  # shape: (n_frames, n_bins)
+
+        # Smoothed gain reduction state for attack/release (per bin)
+        smoothed_gr = np.zeros(self.n_bins)
+
+        for i in range(n_frames):
+            mag_db_frame = magnitudes_db[i]
+            smoothed_env = self._compute_smoothed_envelope(mag_db_frame)
+            target_gr = self._compute_gain_reduction(mag_db_frame, smoothed_env)
+
+            # Attack/release time smoothing (per-bin IIR)
+            # When target_gr > smoothed_gr → attack (gain reducing faster)
+            # When target_gr < smoothed_gr → release (gain recovering)
+            increasing = target_gr >= smoothed_gr
+            coeff = np.where(increasing, self.attack_coeff, self.release_coeff)
+            smoothed_gr = coeff * smoothed_gr + (1.0 - coeff) * target_gr
+            gain_reduction_db[i] = smoothed_gr.copy()
+
+        # --- Apply gain reduction to linear magnitudes ---
+        gain_linear = 10.0 ** (-gain_reduction_db / 20.0)
+        modified_magnitudes = magnitudes * gain_linear
+
+        # --- Reconstruct complex spectra (original phase, modified magnitude) ---
+        modified_spectra = modified_magnitudes * np.exp(1j * phases)
+
+        # --- ISTFT with overlap-add reconstruction ---
+        output_length = len(audio_padded)
+        output_buffer = np.zeros(output_length, dtype=np.float64)
+        window_accumulator = np.zeros(output_length, dtype=np.float64)
+
+        window_squared = window ** 2  # for normalization in OLA
+
+        for i, spectrum in enumerate(modified_spectra):
+            time_frame = np.fft.irfft(spectrum, n=n_fft) * window
+            start = i * hop
+            end = start + n_fft
+            if end > output_length:
+                trim = output_length - start
+                output_buffer[start:output_length] += time_frame[:trim]
+                window_accumulator[start:output_length] += window_squared[:trim]
+            else:
+                output_buffer[start:end] += time_frame
+                window_accumulator[start:end] += window_squared
+
+        # Normalize by window accumulator to correct OLA gain
+        safe_acc = np.where(window_accumulator > 1e-8, window_accumulator, 1.0)
+        output_buffer /= safe_acc
+
+        # Remove padding and cast back to float32
+        output_audio = output_buffer[pad : pad + len(audio)].astype(np.float32)
+
+        # --- Telemetry for processing report ---
+        max_reduction = float(np.max(gain_reduction_db))
+        mean_reduction = float(np.mean(gain_reduction_db[gain_reduction_db > 0.01]))
+        if np.isnan(mean_reduction):
+            mean_reduction = 0.0
+        spike_frames = int(np.sum(np.any(gain_reduction_db > 0.5, axis=1)))
+
+        # Artifact risk: if mean reduction is high, flag for advisory system
+        artifact_risk = mean_reduction > 3.0
+
+        logger.info(
+            f"ResonanceSuppressor: max_reduction={max_reduction:.2f} dB | "
+            f"mean_reduction={mean_reduction:.2f} dB | "
+            f"spike_frames={spike_frames}/{n_frames} | "
+            f"artifact_risk={artifact_risk}"
+        )
+
+        return {
+            "audio": output_audio,
+            "max_reduction_db": max_reduction,
+            "mean_reduction_db": mean_reduction,
+            "spike_frames": spike_frames,
+            "artifact_risk": artifact_risk,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Pipeline integration helper
+# ---------------------------------------------------------------------------
+
+def apply_resonance_suppression(
+    audio: np.ndarray,
+    sample_rate: int,
+    preset: str,
+    vad_voiced_mask: np.ndarray = None,
+) -> dict:
+    """
+    Pipeline integration entry point for Stage 3b.
+
+    If a VAD voiced_mask is provided (same shape as audio, boolean), processing
+    is applied only to voiced frames. Silence frames pass through unmodified.
+    This prevents the suppressor from processing noise-floor-only segments,
+    which would introduce artifacts.
+
+    Args:
+        audio:           Mono float32 audio at sample_rate.
+        sample_rate:     Sample rate (should be 44100 in the Instant Polish pipeline).
+        preset:          One of: acx_audiobook, podcast_ready, voice_ready, general_clean.
+        vad_voiced_mask: Optional boolean array, True where voice is present.
+
+    Returns:
+        dict: same structure as ResonanceSuppressor.process(), plus 'skipped' bool.
+    """
+    # Skip for noise_eraser — caller should enforce this, but guard here too
+    if preset == "noise_eraser":
+        logger.info("ResonanceSuppressor: skipping for noise_eraser preset.")
+        return {"audio": audio, "skipped": True, "max_reduction_db": 0.0,
+                "mean_reduction_db": 0.0, "spike_frames": 0, "artifact_risk": False}
+
+    suppressor = ResonanceSuppressor(sample_rate=sample_rate, preset=preset)
+
+    if vad_voiced_mask is not None and len(vad_voiced_mask) == len(audio):
+        # Process only voiced segments; splice results back in
+        # Simple approach: process full audio, then blend with original on silence frames
+        result = suppressor.process(audio)
+        processed = result["audio"]
+        # On silence frames (not voiced), restore original
+        silence_mask = ~vad_voiced_mask
+        processed[silence_mask] = audio[silence_mask]
+        result["audio"] = processed
+    else:
+        result = suppressor.process(audio)
+
+    result["skipped"] = False
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Processing report integration
+# ---------------------------------------------------------------------------
+
+def resonance_suppressor_report_entry(result: dict) -> dict:
+    """
+    Format the suppressor result for inclusion in the Stage 7 processing report JSON.
+
+    Usage:
+        report["processing_applied"]["resonance_suppressor"] = \
+            resonance_suppressor_report_entry(result)
+    """
+    if result.get("skipped"):
+        return {"applied": False}
+
+    return {
+        "applied": True,
+        "max_reduction_db": round(result["max_reduction_db"], 1),
+        "mean_reduction_db": round(result["mean_reduction_db"], 1),
+        "spike_frames": result["spike_frames"],
+        "artifact_risk": result["artifact_risk"],
+    }
+
+
+# ---------------------------------------------------------------------------
+# CLI entry point
+# ---------------------------------------------------------------------------
+
+if __name__ == '__main__':
+    import argparse
+    import json
+    from scipy.io import wavfile
+
+    parser = argparse.ArgumentParser(
+        description='Dynamic resonance suppressor for voice audio (Stage 3b)'
+    )
+    parser.add_argument('--input',         required=True,
+                        help='Input WAV path (32-bit float, 44.1 kHz)')
+    parser.add_argument('--output',        required=True,
+                        help='Output WAV path (32-bit float, 44.1 kHz)')
+    parser.add_argument('--preset',        default='acx_audiobook',
+                        help='Preset ID: acx_audiobook | podcast_ready | voice_ready | general_clean')
+    parser.add_argument('--vad-mask-json', default=None,
+                        help='Path to JSON file with VAD frame metadata '
+                             '(array of {isSilence, offsetSamples, lengthSamples, rmsDbfs})')
+    args = parser.parse_args()
+
+    sr, audio = wavfile.read(args.input)
+    audio = audio.astype(np.float32)
+
+    vad_voiced_mask = None
+    if args.vad_mask_json:
+        with open(args.vad_mask_json, 'r') as fh:
+            frame_list = json.load(fh)
+        total = len(audio)
+        vad_voiced_mask = np.zeros(total, dtype=bool)
+        for frame in frame_list:
+            if not frame['isSilence']:
+                s = frame['offsetSamples']
+                e = s + frame['lengthSamples']
+                vad_voiced_mask[s:min(e, total)] = True
+
+    result = apply_resonance_suppression(audio, sr, args.preset, vad_voiced_mask)
+    wavfile.write(args.output, sr, result['audio'].astype(np.float32))
+    report = resonance_suppressor_report_entry(result)
+    print('JSON_RESULT:' + json.dumps(report), flush=True)


### PR DESCRIPTION
Integrates a Soothe2-inspired spectral resonance suppressor that detects
time-varying frequency spikes via STFT and applies targeted gain reduction
only to voiced frames, leaving silence regions unmodified.

- server/scripts/instant_polish_resonance_suppressor.py: Python implementation
  (STFT analysis, per-bin gain reduction, OLA reconstruction, preset-calibrated
  defaults for all 4 standard presets, CLI entry point with VAD mask support)
- server/pipeline/resonanceSuppressor.js: Node.js subprocess spawner (matches
  noiseReduce.js pattern; passes VAD frame metadata via temp JSON file)
- stages.js: resonanceSuppressor stage function + pipelineContext entry
- pipelines.js: inserted after enhancementEQ in STANDARD_PIPELINE only
  (noise_eraser and clearervoice_eraser excluded by omission)
- index.js: formatResonanceSuppressorResult formatter + processing_applied entry
- riskAssessment.js: resonance_suppressor_high_reduction advisory flag
  (severity: info, triggered when artifact_risk=true / mean reduction > 3 dB)

https://claude.ai/code/session_014MDHqAtG8H6AsrNhNEdwpk