### PR TITLE
Add VAD Gate stage for silence-floor attenuation

### DIFF
--- a/server/pipeline/index.js
+++ b/server/pipeline/index.js
@@ -164,6 +164,7 @@ function buildReport(ctx) {
       ...(results.compression         && { compression:           formatCompressionResult(results.compression) }),
       ...(results.parallelCompression && { parallel_compression:  formatParallelCompressionResult(results.parallelCompression) }),
       ...(results.vocalExpander         && { vocal_expander:          formatVocalExpanderResult(results.vocalExpander) }),
+      ...(results.vadGate               && { vad_gate:                formatVadGateResult(results.vadGate) }),
       ...(results.resonanceSuppressor   && { resonance_suppressor:    formatResonanceSuppressorResult(results.resonanceSuppressor) }),
       normalization_gain_db:
         results.afterMeasurements?.rmsDbfs == null || results.beforeMeasurements?.rmsDbfs == null
@@ -415,6 +416,33 @@ function formatVocalExpanderResult(r) {
       max_attenuation_db:         r.maxAttenuationAppliedDb,
       pct_frames_expanded:        r.pctFramesExpanded,
       over_expansion_flag:        r.overExpansionFlag,
+    },
+  }
+}
+
+function formatVadGateResult(r) {
+  if (!r) return null
+  if (!r.applied) {
+    return {
+      applied:        false,
+      skipped_reason: r.reason ?? null,
+    }
+  }
+  return {
+    applied:        true,
+    skipped_reason: null,
+    parameters: {
+      lookahead_ms: r.lookaheadMs,
+      hold_ms:      r.holdMs,
+      attack_ms:    r.attackMs,
+      release_ms:   r.releaseMs,
+      floor_db:     r.floorDb,
+    },
+    result: {
+      voiced_frames:        r.voicedFrames,
+      silence_frames:       r.silenceFrames,
+      open_segments:        r.openSegments,
+      pct_samples_at_floor: r.pctSamplesAtFloor,
     },
   }
 }

--- a/server/pipeline/pipelines.js
+++ b/server/pipeline/pipelines.js
@@ -41,6 +41,7 @@ const STANDARD_PIPELINE = [
   stages.noiseReduce,             // Conditional secondary NR pass
   stages.parallelCompress,        // Parallel compression
   stages.vocalExpander,           // Frequency-selective expander (silence-floor residual attenuator)
+  stages.vadGate,                 // Smooth VAD-driven silence-floor gate (no-op when preset.vadGate.enabled is false)
   stages.vocalSaturation,
   stages.airBoost,                // Maag EQ4-style air/HF shelf lift; no-op when air_boost_db ≤ 0
   stages.resonanceSuppressor,     // Dynamic resonance suppressor — voiced frames only
@@ -95,6 +96,7 @@ export const PIPELINES = {
     stages.compress,                 // standard serial compression
     //stages.parallelCompress,         // parallel compression
     stages.vocalExpander,            // Stage 4a-E — frequency-selective expander
+    stages.vadGate,                  // Smooth VAD-driven silence-floor gate (no-op when preset.vadGate.enabled is false)
     stages.autoLevel,                // VAD-gated gain riding; no-op when drift ≤ 3 dB σ
     stages.enhancementEQ,
     stages.airBoost,               // Stage 3b — no-op for noise_eraser (air_boost_db = 0)
@@ -138,6 +140,7 @@ export const PIPELINES = {
     stages.compress,                 // standard serial compression
     stages.parallelCompress,         // parallel compression
     stages.vocalExpander,            // Stage 4a-E — frequency-selective expander
+    stages.vadGate,                  // Smooth VAD-driven silence-floor gate (no-op when preset.vadGate.enabled is false)
     stages.autoLevel,                // VAD-gated gain riding; no-op when drift ≤ 3 dB σ
     stages.enhancementEQ,
     stages.airBoost,               // Stage 3b — no-op for clearervoice_eraser (air_boost_db = 0)

--- a/server/pipeline/stages.js
+++ b/server/pipeline/stages.js
@@ -47,6 +47,7 @@ import { validateSeparation } from './separationValidation.js'
 import { applyAutoLeveler } from './autoLeveler.js'
 import { applyParallelCompression } from './parallelCompression.js'
 import { applyVocalExpander } from './vocalExpander.js'
+import { applyVadGate }       from './vadGate.js'
 import { analyzeHum } from './humEQ.js'
 import { applyAirBoost } from './airBoost.js'
 
@@ -739,6 +740,42 @@ export async function vocalExpander(ctx) {
     )
   } else {
     ctx.log(`[vocal-expander] Skipped — ${result.reason}`)
+  }
+}
+
+// ── Stage: VAD Gate ───────────────────────────────────────────────────────────
+// Smoothly attenuates non-voiced frames using Silero VAD labels. Converts the
+// binary VAD mask into a per-sample gain envelope shaped by lookahead (catches
+// word onsets that begin mid-frame), hold (catches word tails that decay past
+// the voiced label), and asymmetric attack/release smoothing (prevents clicks
+// at transitions). Floors at preset.vadGate.floorDb so silence retains a
+// faint room tone rather than collapsing to digital silence.
+//
+// Skips silently when preset.vadGate is absent or vadGate.enabled is false.
+// Runs after vocalExpander (the soft silence-floor attenuator) and before
+// normalize so the final loudness pass sees the gated silence floor.
+
+export async function vadGate(ctx) {
+  const config = ctx.preset?.vadGate
+  if (!config?.enabled) {
+    ctx.results.vadGate = { applied: false, reason: 'preset_not_configured' }
+    return
+  }
+
+  const outPath = ctx.tmp('.wav')
+  const result  = await applyVadGate(ctx.currentPath, outPath, ctx.presetId, ctx.results.metrics)
+  if (result.applied) ctx.currentPath = outPath
+  ctx.results.vadGate = result
+
+  if (result.applied) {
+    ctx.log(
+      `[vad-gate] Applied — segments=${result.openSegments} ` +
+      `floor=${result.floorDb}dB lookahead=${result.lookaheadMs}ms ` +
+      `hold=${result.holdMs}ms attack=${result.attackMs}ms release=${result.releaseMs}ms ` +
+      `atFloor=${result.pctSamplesAtFloor}%`
+    )
+  } else {
+    ctx.log(`[vad-gate] Skipped — ${result.reason}`)
   }
 }
 

--- a/server/pipeline/stages.js
+++ b/server/pipeline/stages.js
@@ -763,7 +763,7 @@ export async function vadGate(ctx) {
   }
 
   const outPath = ctx.tmp('.wav')
-  const result  = await applyVadGate(ctx.currentPath, outPath, ctx.presetId, ctx.results.metrics)
+  const result  = await applyVadGate(ctx.currentPath, outPath, config, ctx.results.metrics)
   if (result.applied) ctx.currentPath = outPath
   ctx.results.vadGate = result
 

--- a/server/pipeline/vadGate.js
+++ b/server/pipeline/vadGate.js
@@ -1,0 +1,210 @@
+/**
+ * VAD Gate — silence-floor attenuator driven by VAD frame labels.
+ *
+ * Converts the binary voiced/silence frame labels from Silero VAD into a smooth
+ * per-sample gain envelope and applies it to every channel. The envelope is
+ * shaped by four parameters that work together to avoid the click/word-chop
+ * pathology of a naive binary gate:
+ *
+ *   lookaheadMs — open the gate this many ms BEFORE the voiced frame starts,
+ *                 catching word onsets that begin partway through a frame.
+ *   holdMs      — keep the gate open this many ms AFTER the last voiced frame,
+ *                 catching word tails (consonant releases, breathy decays) that
+ *                 extend past the VAD's voiced classification.
+ *   attackMs    — one-pole rise time when the target transitions silence→open.
+ *   releaseMs   — one-pole fall time when the target transitions open→silence.
+ *
+ * The gate never closes fully — `floorDb` sets the residual gain so silence
+ * regions retain a faint room tone rather than collapsing to digital silence.
+ *
+ * Performance notes:
+ *   - The prototype build_vad_gate_envelope() in the design doc allocates four
+ *     full-length sample buffers (np.repeat, np.roll, maximum_filter1d, and the
+ *     IIR output). This implementation collapses all four passes into a single
+ *     O(N) walk: voiced frame ranges → segment list with lookahead/hold applied
+ *     as integer offsets (no max-filter pass needed) → asymmetric IIR smoothing
+ *     and floor mapping inlined while applying the gain to each channel.
+ *   - Memory: O(numFrames) for the segment list (≪ numSamples) plus the output
+ *     channel buffers. No intermediate envelope buffer is materialised.
+ *
+ * Chain position: after vocalExpander and before normalize. The expander
+ * already attenuates silence-floor residual via a soft ratio — the VAD gate is
+ * a complementary, harder cut for files where deeper silence is desired.
+ */
+
+import { readWavAllChannels } from './wavReader.js'
+import { writeWavChannels }   from './wavWriter.js'
+import { PRESETS }            from '../presets.js'
+
+// Default parameters; each preset's vadGate config can override any subset.
+const DEFAULTS = {
+  lookaheadMs: 20,
+  holdMs:      80,
+  attackMs:    8,
+  releaseMs:   40,
+  floorDb:     -60,
+}
+
+/**
+ * Apply the VAD gate to an audio file.
+ *
+ * @param {string} inputPath
+ * @param {string} outputPath
+ * @param {string} presetId
+ * @param {import('./stages.js').AudioMetrics} frameAnalysis
+ * @returns {Promise<VadGateResult>}
+ *
+ * @typedef {Object} VadGateResult
+ * @property {boolean} applied
+ * @property {string|null} [reason]
+ * @property {number} [lookaheadMs]
+ * @property {number} [holdMs]
+ * @property {number} [attackMs]
+ * @property {number} [releaseMs]
+ * @property {number} [floorDb]
+ * @property {number} [voicedFrames]
+ * @property {number} [silenceFrames]
+ * @property {number} [openSegments]
+ * @property {number} [pctSamplesAtFloor]   - % of samples at or near the floor
+ */
+export async function applyVadGate(inputPath, outputPath, presetId, frameAnalysis) {
+  const config = PRESETS[presetId]?.vadGate
+  if (!config?.enabled) {
+    await copyThrough(inputPath, outputPath)
+    return { applied: false, reason: 'preset_not_configured' }
+  }
+
+  const frames = frameAnalysis?.frames
+  if (!frames || frames.length === 0) {
+    await copyThrough(inputPath, outputPath)
+    return { applied: false, reason: 'no_vad_frames' }
+  }
+
+  const params = { ...DEFAULTS, ...config }
+  const { channels, sampleRate, numSamples } = await readWavAllChannels(inputPath)
+
+  // Skip when there are no voiced frames — the gate would just attenuate the
+  // entire file to the floor, which is almost never what the user wants.
+  let voicedCount = 0
+  for (const f of frames) if (!f.isSilence) voicedCount++
+  if (voicedCount === 0) {
+    await copyThrough(inputPath, outputPath)
+    return { applied: false, reason: 'no_voiced_frames' }
+  }
+
+  const lookaheadSamples = Math.max(0, Math.round(params.lookaheadMs * sampleRate / 1000))
+  const holdSamples      = Math.max(0, Math.round(params.holdMs      * sampleRate / 1000))
+  // Use sample-count time constants so the IIR coefficients match perceived ms.
+  const attackTau  = Math.max(1, params.attackMs  * sampleRate / 1000)
+  const releaseTau = Math.max(1, params.releaseMs * sampleRate / 1000)
+  const attackCoeff  = 1 - Math.exp(-1 / attackTau)
+  const releaseCoeff = 1 - Math.exp(-1 / releaseTau)
+  const floorLinear  = Math.pow(10, params.floorDb / 20)
+  const span         = 1 - floorLinear
+
+  // ── 1. Build voiced segments at sample resolution ────────────────────────
+  // Frames are emitted in index order with uniform lengthSamples, but we read
+  // offsetSamples directly so we tolerate any irregularities. Each segment is
+  // [openStart, closeEnd] after applying lookahead (-) and hold (+). Segments
+  // that overlap after expansion are merged on the fly.
+
+  const segments = []  // packed pairs: [s0, e0, s1, e1, ...]
+  let curStart = -1
+  let curEnd   = -1
+
+  for (const frame of frames) {
+    if (frame.isSilence) continue
+    const fStart = frame.offsetSamples
+    const fEnd   = frame.offsetSamples + frame.lengthSamples
+
+    // Coalesce consecutive voiced frames into a single segment before applying
+    // expansion offsets so that hold/lookahead are not applied within a span.
+    if (curEnd === fStart) {
+      curEnd = fEnd
+    } else {
+      if (curStart >= 0) pushExpanded(segments, curStart, curEnd, lookaheadSamples, holdSamples, numSamples)
+      curStart = fStart
+      curEnd   = fEnd
+    }
+  }
+  if (curStart >= 0) pushExpanded(segments, curStart, curEnd, lookaheadSamples, holdSamples, numSamples)
+
+  const numSegments = segments.length / 2
+
+  // ── 2. Single-pass envelope smoothing + gain application ─────────────────
+  // Walk samples once. `segIdx` advances monotonically through the segment
+  // list. The target is 1.0 inside an open segment, 0.0 elsewhere. The IIR
+  // produces a smooth envelope; we map [0, 1] → [floor, 1] inline and multiply
+  // every channel sample as we go. No intermediate envelope array allocated.
+
+  let envelope = 0
+  let segIdx = 0
+  let segStart = numSegments > 0 ? segments[0]     : Infinity
+  let segEnd   = numSegments > 0 ? segments[1]     : Infinity
+  let nearFloorCount = 0
+  // Threshold for "at or near the floor" reporting: within 0.5 dB of floor.
+  const nearFloorLinear = Math.pow(10, (params.floorDb + 0.5) / 20)
+
+  const numChannels = channels.length
+  const output = channels.map(() => new Float32Array(numSamples))
+
+  for (let i = 0; i < numSamples; i++) {
+    // Advance segment cursor past any segments whose close has been crossed.
+    while (i >= segEnd && segIdx < numSegments - 1) {
+      segIdx++
+      segStart = segments[2 * segIdx]
+      segEnd   = segments[2 * segIdx + 1]
+    }
+    const target = (i >= segStart && i < segEnd) ? 1 : 0
+
+    const coeff = target > envelope ? attackCoeff : releaseCoeff
+    envelope += coeff * (target - envelope)
+
+    const gain = floorLinear + envelope * span
+    if (gain <= nearFloorLinear) nearFloorCount++
+
+    for (let ch = 0; ch < numChannels; ch++) {
+      output[ch][i] = channels[ch][i] * gain
+    }
+  }
+
+  await writeWavChannels(output, sampleRate, outputPath)
+
+  return {
+    applied:           true,
+    lookaheadMs:       params.lookaheadMs,
+    holdMs:            params.holdMs,
+    attackMs:          params.attackMs,
+    releaseMs:         params.releaseMs,
+    floorDb:           params.floorDb,
+    voicedFrames:      voicedCount,
+    silenceFrames:     frames.length - voicedCount,
+    openSegments:      numSegments,
+    pctSamplesAtFloor: numSamples > 0 ? round2(100 * nearFloorCount / numSamples) : 0,
+  }
+}
+
+/**
+ * Append a voiced segment to the packed [start,end,...] list, applying
+ * lookahead/hold expansion and merging with the previous segment when the
+ * expanded range overlaps. Clamps to [0, numSamples].
+ */
+function pushExpanded(segments, fStart, fEnd, lookaheadSamples, holdSamples, numSamples) {
+  const s = Math.max(0, fStart - lookaheadSamples)
+  const e = Math.min(numSamples, fEnd + holdSamples)
+  if (segments.length > 0 && s <= segments[segments.length - 1]) {
+    // Overlap with the previous segment's close — extend it.
+    if (e > segments[segments.length - 1]) segments[segments.length - 1] = e
+    return
+  }
+  segments.push(s, e)
+}
+
+async function copyThrough(inputPath, outputPath) {
+  const { readFile, writeFile } = await import('fs/promises')
+  await writeFile(outputPath, await readFile(inputPath))
+}
+
+function round2(n) {
+  return Math.round(n * 100) / 100
+}

--- a/server/pipeline/vadGate.js
+++ b/server/pipeline/vadGate.js
@@ -34,7 +34,6 @@
 
 import { readWavAllChannels } from './wavReader.js'
 import { writeWavChannels }   from './wavWriter.js'
-import { PRESETS }            from '../presets.js'
 
 // Default parameters; each preset's vadGate config can override any subset.
 const DEFAULTS = {
@@ -50,7 +49,10 @@ const DEFAULTS = {
  *
  * @param {string} inputPath
  * @param {string} outputPath
- * @param {string} presetId
+ * @param {Object|null|undefined} config - The vadGate config to use, taken from
+ *   the merged ctx.preset (NOT looked up from the global PRESETS table) so any
+ *   per-request override flows through. When falsy or `enabled !== true` the
+ *   stage copies the input through and returns `applied: false`.
  * @param {import('./stages.js').AudioMetrics} frameAnalysis
  * @returns {Promise<VadGateResult>}
  *
@@ -67,8 +69,7 @@ const DEFAULTS = {
  * @property {number} [openSegments]
  * @property {number} [pctSamplesAtFloor]   - % of samples at or near the floor
  */
-export async function applyVadGate(inputPath, outputPath, presetId, frameAnalysis) {
-  const config = PRESETS[presetId]?.vadGate
+export async function applyVadGate(inputPath, outputPath, config, frameAnalysis) {
   if (!config?.enabled) {
     await copyThrough(inputPath, outputPath)
     return { applied: false, reason: 'preset_not_configured' }
@@ -107,6 +108,17 @@ export async function applyVadGate(inputPath, outputPath, presetId, frameAnalysi
   // offsetSamples directly so we tolerate any irregularities. Each segment is
   // [openStart, closeEnd] after applying lookahead (-) and hold (+). Segments
   // that overlap after expansion are merged on the fly.
+  //
+  // Trailing partial frame: frameAnalysis emits floor(samples / frameLength)
+  // frames, so the last (samples % frameLength) samples are not classified.
+  // When the final classified frame is voiced we extend its sample-range end
+  // to numSamples so the partial-tail inherits the voiced state — otherwise
+  // those samples fall outside every segment and the IIR ramps them down to
+  // the floor, shaving final consonants from outros that end mid-frame.
+
+  const lastFrame      = frames[frames.length - 1]
+  const lastFrameEnd   = lastFrame.offsetSamples + lastFrame.lengthSamples
+  const trailingVoiced = !lastFrame.isSilence && numSamples > lastFrameEnd
 
   const segments = []  // packed pairs: [s0, e0, s1, e1, ...]
   let curStart = -1
@@ -115,11 +127,13 @@ export async function applyVadGate(inputPath, outputPath, presetId, frameAnalysi
   for (const frame of frames) {
     if (frame.isSilence) continue
     const fStart = frame.offsetSamples
-    const fEnd   = frame.offsetSamples + frame.lengthSamples
+    const fEnd   = (frame === lastFrame && trailingVoiced)
+      ? numSamples
+      : frame.offsetSamples + frame.lengthSamples
 
     // Coalesce consecutive voiced frames into a single segment before applying
     // expansion offsets so that hold/lookahead are not applied within a span.
-    if (curEnd === fStart) {
+    if (curEnd === frame.offsetSamples) {
       curEnd = fEnd
     } else {
       if (curStart >= 0) pushExpanded(segments, curStart, curEnd, lookaheadSamples, holdSamples, numSamples)

--- a/src/audio/presets.js
+++ b/src/audio/presets.js
@@ -193,6 +193,17 @@ export const PRESETS = {
       maxAttenuationDb: 40,
       detectionBand:    { lowHz: 80, highHz: 800 },
     },
+    // VAD Gate — conservative for ACX. Shallower floor preserves audible room
+    // tone (ACX human reviewers prefer natural silence); generous hold prevents
+    // chopping the long decay of narrated word endings.
+    vadGate: {
+      enabled:     false,
+      lookaheadMs: 30,
+      holdMs:      120,
+      attackMs:    10,
+      releaseMs:   80,
+      floorDb:     -50,
+    },
     // Conservative: enough to clean audible breaths that flag ACX human review,
     // but not so deep that the narrator's breathing presence disappears entirely.
     breathReducer: { max_reduction_db: 12 },
@@ -289,6 +300,17 @@ export const PRESETS = {
       maxAttenuationDb: 18,
       detectionBand:    { lowHz: 80, highHz: 800 },
     },
+    // VAD Gate — assertive for podcast. Deeper floor matches the tighter,
+    // more processed character; faster release keeps the gate from feeling
+    // sluggish on rapid-fire dialogue.
+    vadGate: {
+      enabled:     false,
+      lookaheadMs: 20,
+      holdMs:      80,
+      attackMs:    8,
+      releaseMs:   40,
+      floorDb:     -60,
+    },
     airBoost: { gainDb: 2.5 },
     bweModel: 'ap_bwe',
     bwe: { enabled: true, postEq: { enabled: true, freq: 9000, q: 2, gainDb: -3 } },
@@ -372,6 +394,17 @@ export const PRESETS = {
       lookaheadMs:      10,
       maxAttenuationDb: 12,
       detectionBand:    { lowHz: 80, highHz: 800 },
+    },
+    // VAD Gate — broadcast-neutral. Shallower floor than podcast since
+    // voice-over often sits under music; a hard cut would be audible against
+    // the bed.
+    vadGate: {
+      enabled:     false,
+      lookaheadMs: 25,
+      holdMs:      100,
+      attackMs:    10,
+      releaseMs:   60,
+      floorDb:     -55,
     },
     airBoost: { gainDb: 2.0 },
     bweModel: 'ap_bwe',
@@ -460,6 +493,16 @@ export const PRESETS = {
       lookaheadMs:      10,
       maxAttenuationDb: 18,
       detectionBand:    { lowHz: 80, highHz: 800 },
+    },
+    // VAD Gate — assertive for general_clean. Unknown source material; a
+    // cleaner silence floor is generally preferable.
+    vadGate: {
+      enabled:     false,
+      lookaheadMs: 20,
+      holdMs:      80,
+      attackMs:    8,
+      releaseMs:   40,
+      floorDb:     -60,
     },
     airBoost: { gainDb: 16 },
     bweModel: 'ap_bwe',
@@ -580,6 +623,17 @@ export const PRESETS = {
       maxAttenuationDb: 40,
       detectionBand:    { lowHz: 80, highHz: 800 },
     },
+    // VAD Gate — assertive for noise_eraser. Source separation already produces
+    // a "dry booth" silence character; a hard gate completes the removal of
+    // residual bleed between words.
+    vadGate: {
+      enabled:     false,
+      lookaheadMs: 20,
+      holdMs:      80,
+      attackMs:    5,
+      releaseMs:   30,
+      floorDb:     -70,
+    },
     airBoost: { gainDb: 0 },
     bweModel: 'ap_bwe',
     bwe: { enabled: false, postEq: { enabled: true, freq: 9000, q: 2, gainDb: -3 } },
@@ -651,6 +705,16 @@ export const PRESETS = {
       lookaheadMs:      10,
       maxAttenuationDb: 18,
       detectionBand:    { lowHz: 80, highHz: 800 },
+    },
+    // VAD Gate — assertive for clearervoice_eraser. ClearerVoice output already
+    // has a dry, processed character; deeper floor reinforces it.
+    vadGate: {
+      enabled:     false,
+      lookaheadMs: 20,
+      holdMs:      80,
+      attackMs:    5,
+      releaseMs:   30,
+      floorDb:     -70,
     },
     airBoost: { gainDb: 0 },
     bweModel: 'ap_bwe',


### PR DESCRIPTION
## Summary
Introduces a new VAD Gate processing stage that uses Silero VAD frame labels to smoothly attenuate silence regions while preserving natural room tone. The gate applies a per-sample gain envelope shaped by lookahead, hold, and asymmetric attack/release parameters to avoid clicks and word chopping artifacts.

## Key Changes

- **New module `server/pipeline/vadGate.js`**: Implements the VAD gate with:
  - Efficient single-pass O(N) envelope generation (no intermediate buffers)
  - Lookahead parameter to catch word onsets that begin mid-frame
  - Hold parameter to preserve word tails and consonant releases
  - Asymmetric IIR smoothing (separate attack/release time constants)
  - Configurable floor level (in dB) to retain faint room tone instead of digital silence
  - Detailed result reporting (voiced/silence frame counts, segment count, % samples at floor)

- **Updated `server/pipeline/stages.js`**: Added `vadGate()` stage function that:
  - Runs after vocalExpander and before normalize in the processing chain
  - Skips silently when preset configuration is absent or disabled
  - Logs detailed parameters and results when applied

- **Updated `server/pipeline/pipelines.js`**: Inserted vadGate stage into STANDARD_PIPELINE after vocalExpander

- **Updated `server/pipeline/index.js`**: Added result formatting for VAD gate output in the processing report

- **Updated `src/audio/presets.js`**: Added preset-specific VAD gate configurations for all six presets:
  - **acx**: Conservative settings (floor -50dB, generous hold) for natural silence preferred by human reviewers
  - **podcast**: Assertive settings (floor -60dB, faster release) for tight, processed character
  - **broadcast**: Neutral settings (floor -55dB, shallower floor) to avoid hard cuts under music beds
  - **general_clean**: Assertive settings (floor -60dB) for cleaner silence on unknown material
  - **noise_eraser**: Very assertive (floor -70dB, fast attack/release) to complete source separation
  - **clearervoice_eraser**: Very assertive (floor -70dB) to reinforce dry, processed character

## Implementation Details

- Segments are built by coalescing consecutive voiced frames before applying lookahead/hold expansion, preventing unnecessary gate openings within continuous speech
- Overlapping expanded segments are merged on-the-fly to avoid redundant processing
- The envelope smoothing and gain application happen in a single O(N) pass with no intermediate buffer allocation
- Gain mapping uses `floor_linear + envelope * (1 - floor_linear)` to smoothly transition between floor and unity gain
- All presets ship with `enabled: false` by default, allowing opt-in adoption

https://claude.ai/code/session_01GuppqSAqbZmJuo2gVhSNZv