### PR TITLE
Add MMSE spectral subtraction pre-pass before ML noise reduction

### DIFF
--- a/server/pipeline/enhancement.js
+++ b/server/pipeline/enhancement.js
@@ -26,16 +26,17 @@ import { PRESETS }       from '../presets.js'
 const RESONANCE_PYTHON = process.env.RESONANCE_PYTHON ?? SHARED_PYTHON
 const NUM_THREADS      = process.env.TORCH_NUM_THREADS ?? String(os.cpus().length)
 
-const SCRIPTS_DIR             = path.join(path.dirname(fileURLToPath(import.meta.url)), '..', 'scripts')
-const HARMONIC_EXCITER_SCRIPT = path.join(SCRIPTS_DIR, 'harmonic_exciter.py')
-const VOCAL_SATURATION_SCRIPT = path.join(SCRIPTS_DIR, 'vocal_saturation.py')
-const DEREVERB_SCRIPT         = path.join(SCRIPTS_DIR, 'dereverb.py')
-const AP_BWE_SCRIPT           = path.join(SCRIPTS_DIR, 'ap_bwe_extend.py')
-const LAVASR_SCRIPT           = path.join(SCRIPTS_DIR, 'lavasr_extend.py')
-const CLICK_REMOVER_SCRIPT    = path.join(SCRIPTS_DIR, 'click_remover.py')
-const RESONANCE_SCRIPT        = path.join(SCRIPTS_DIR, 'resonance_suppressor.py')
-const SIBILANCE_SCRIPT        = path.join(SCRIPTS_DIR, 'sibilance_suppressor.py')
-const BREATH_REDUCER_SCRIPT   = path.join(SCRIPTS_DIR, 'breath_reducer.py')
+const SCRIPTS_DIR                  = path.join(path.dirname(fileURLToPath(import.meta.url)), '..', 'scripts')
+const HARMONIC_EXCITER_SCRIPT      = path.join(SCRIPTS_DIR, 'harmonic_exciter.py')
+const VOCAL_SATURATION_SCRIPT      = path.join(SCRIPTS_DIR, 'vocal_saturation.py')
+const DEREVERB_SCRIPT              = path.join(SCRIPTS_DIR, 'dereverb.py')
+const AP_BWE_SCRIPT                = path.join(SCRIPTS_DIR, 'ap_bwe_extend.py')
+const LAVASR_SCRIPT                = path.join(SCRIPTS_DIR, 'lavasr_extend.py')
+const CLICK_REMOVER_SCRIPT         = path.join(SCRIPTS_DIR, 'click_remover.py')
+const RESONANCE_SCRIPT             = path.join(SCRIPTS_DIR, 'resonance_suppressor.py')
+const SIBILANCE_SCRIPT             = path.join(SCRIPTS_DIR, 'sibilance_suppressor.py')
+const BREATH_REDUCER_SCRIPT        = path.join(SCRIPTS_DIR, 'breath_reducer.py')
+const SPECTRAL_SUBTRACTION_SCRIPT  = path.join(SCRIPTS_DIR, 'spectral_subtraction.py')
 
 // ── Enhancement stages ────────────────────────────────────────────────────────
 
@@ -92,6 +93,33 @@ export function runDereverb(inputPath, outputPath, strength = 'medium', preserve
   const args = ['--input', inputPath, '--output', outputPath, '--strength', strength]
   if (preserveEarly) args.push('--preserve-early')
   return spawnPython(DEREVERB_SCRIPT, args, `Dereverb (${strength})`)
+}
+
+/**
+ * DSP pre-pass: MMSE decision-directed spectral subtraction + optional transient shaper.
+ *
+ * Runs before the main ML noise reduction (DF3, RNNoise, DTLN) to reduce diffuse
+ * noise and reverb energy, lowering the complexity of the signal the ML model
+ * receives. Musical noise is prevented by the decision-directed SNR estimator,
+ * spectral floor, and 3-bin median filter mop-up.
+ *
+ * @param {string} inputPath     - 32-bit float WAV at 44.1 kHz
+ * @param {string} outputPath    - 32-bit float WAV at 44.1 kHz
+ * @param {object} [params]
+ * @param {number} [params.alphaDd=0.98]              - Decision-directed smoothing (0–1; higher = more temporal smoothing)
+ * @param {number} [params.beta=0.05]                 - Spectral floor / minimum Wiener gain (0–1)
+ * @param {number} [params.strength=1.0]              - Suppression strength (0 = bypass, 1 = full)
+ * @param {boolean} [params.transientShaper=false]    - Enable transient shaper for reverb tail suppression
+ * @param {number} [params.transientMaxReductionDb=6] - Transient shaper max gain reduction in dB
+ */
+export function runSpectralSubtraction(inputPath, outputPath, params = {}) {
+  const args = ['--input', inputPath, '--output', outputPath]
+  if (params.alphaDd              != null) args.push('--alpha-dd',                   String(params.alphaDd))
+  if (params.beta                 != null) args.push('--beta',                        String(params.beta))
+  if (params.strength             != null) args.push('--strength',                    String(params.strength))
+  if (params.transientShaper)              args.push('--transient-shaper')
+  if (params.transientMaxReductionDb != null) args.push('--transient-max-reduction-db', String(params.transientMaxReductionDb))
+  return spawnPython(SPECTRAL_SUBTRACTION_SCRIPT, args, 'SpectralSubtraction')
 }
 
 /**

--- a/server/pipeline/pipelines.js
+++ b/server/pipeline/pipelines.js
@@ -29,6 +29,7 @@ const STANDARD_PIPELINE = [
   stages.clickRemove,             // Pre-HPF: Hampel + Burg AR click/lip-smack repair
   stages.humDetect,               // Pre-HPF: spectral hum detection + conditional notch EQ
   stages.hpf,                     // 80hz hi pass filter
+  stages.spectralSubtraction,     // MMSE Wiener pre-pass + optional transient shaper (before ML NR)
   stages.noiseReduce,             // Main Noise Reduction (DF3, RNNoise, DTLN)
   stages.dereverb,
   stages.breathReduce,            // Breath event detection and gain reduction
@@ -82,6 +83,7 @@ export const PIPELINES = {
     stages.analyzeFramesRaw,        // Pre-processing noise floor for NE-2/NE-4
     stages.humDetect,               // Pre-HPF: spectral hum detection + conditional notch EQ
     stages.hpf,
+    stages.spectralSubtraction,     // MMSE Wiener pre-pass + optional transient shaper (before ML NR)
     stages.noiseReduce,
     stages.tonalPretreatment,       // Hum/tonal notch filtering (conditional)
     stages.separateVocals,          // Demucs or ConvTasNet vocal extraction
@@ -128,6 +130,7 @@ export const PIPELINES = {
     stages.analyzeFramesRaw,        // Pre-processing noise floor for NE-2/NE-4
     stages.humDetect,               // Pre-HPF: spectral hum detection + conditional notch EQ
     stages.hpf,
+    stages.spectralSubtraction,     // MMSE Wiener pre-pass + optional transient shaper (before ML NR)
     stages.noiseReduce,
     stages.tonalPretreatment,       // Hum/tonal notch filtering (conditional)
     stages.clearerVoiceEnhance,     // Clearer Voice

--- a/server/pipeline/stages.js
+++ b/server/pipeline/stages.js
@@ -42,7 +42,7 @@ import { analyzeAndDeEss } from './deEsser.js'
 import { applyCompression } from './compression.js'
 import { runSeparation, runClearerVoice } from './separation.js'
 import { readFile } from 'fs/promises'
-import { runHarmonicExciter, runVocalSaturation, runDereverb, runApBwe, runLavaSR, runClickRemover, applyResonanceSuppression, applySibilanceSuppression, applyBreathReduction } from './enhancement.js'
+import { runHarmonicExciter, runVocalSaturation, runDereverb, runApBwe, runLavaSR, runClickRemover, applyResonanceSuppression, applySibilanceSuppression, applyBreathReduction, runSpectralSubtraction } from './enhancement.js'
 import { validateSeparation } from './separationValidation.js'
 import { applyAutoLeveler } from './autoLeveler.js'
 import { applyParallelCompression } from './parallelCompression.js'
@@ -299,6 +299,38 @@ export async function hpf(ctx) {
   ctx.currentPath       = hpfPath
   ctx.results.notch60Hz = notch60Hz
   await logLevel(ctx, 'after HPF', ctx.currentPath, { notch60Hz })
+}
+
+// ── Stage: Spectral Subtraction Pre-Pass ─────────────────────────────────────
+// MMSE decision-directed Wiener gain + optional transient shaper. Runs after
+// HPF and before the main ML noise reduction (DF3, RNNoise, DTLN) to reduce
+// diffuse noise and reverb energy, lowering the problem complexity the ML
+// model receives. Skipped when preset.spectralSubtraction is absent or
+// preset.spectralSubtraction.enabled is false.
+
+export async function spectralSubtraction(ctx) {
+  const config = ctx.preset.spectralSubtraction
+  if (!config?.enabled) return
+
+  const params = {
+    alphaDd:              config.alphaDd              ?? 0.98,
+    beta:                 config.beta                 ?? 0.05,
+    strength:             config.strength             ?? 1.0,
+    transientShaper:      config.transientShaper      ?? false,
+    transientMaxReductionDb: config.transientMaxReductionDb ?? 6.0,
+  }
+
+  const outPath = ctx.tmp('.wav')
+  ctx.log(
+    `[spectral-sub] Starting: alpha_dd=${params.alphaDd} beta=${params.beta} ` +
+    `strength=${params.strength} transient_shaper=${params.transientShaper}`
+  )
+  await runSpectralSubtraction(ctx.currentPath, outPath, params)
+  ctx.currentPath = outPath
+  ctx.results.spectralSubtraction = { applied: true, ...params }
+  await logLevel(ctx, 'after spectral subtraction', ctx.currentPath, {
+    strength: params.strength,
+  })
 }
 
 // ── Stage: Noise reduction ────────────────────────────────────────────────────

--- a/server/scripts/spectral_subtraction.py
+++ b/server/scripts/spectral_subtraction.py
@@ -219,8 +219,7 @@ def _process_channel(audio, args, sr):
         boundary='reflect', padded=True,
     )
     # Zxx: (n_bins, n_frames) complex64
-    mag   = np.abs(Zxx).astype(np.float32)    # (n_bins, n_frames)
-    phase = np.angle(Zxx).astype(np.float32)  # (n_bins, n_frames)
+    mag   = np.abs(Zxx).astype(np.float32)    # (n_bins, n_frames) — used for MMSE gain computation
 
     # Transpose to (n_frames, n_bins) for the sequential frame loop
     mag_T = np.ascontiguousarray(mag.T)
@@ -255,18 +254,31 @@ def _process_channel(audio, args, sr):
         gains *= t_gain[:, np.newaxis]   # broadcast to (n_frames, n_bins)
 
     # ── Reconstruct via ISTFT ─────────────────────────────────────────────────
-    # Apply combined gain to the magnitude; retain original phase.
+    # Apply the real-valued gain directly to the complex STFT rather than
+    # reconstructing via mag*exp(1j*phase). This avoids a redundant angle/exp
+    # round-trip and eliminates numerical edge cases around near-zero magnitudes
+    # where phase is poorly defined.
     gains_T = np.ascontiguousarray(gains.T)    # (n_bins, n_frames)
-    Zxx_out = gains_T * mag * np.exp(1j * phase.astype(np.complex64))
+    Zxx_out = gains_T * Zxx                    # real × complex → complex (broadcast)
 
     _, out = istft(
         Zxx_out, fs=sr, window='hann',
         nperseg=N_FFT, noverlap=n_overlap,
         boundary=True,
     )
-    # Trim to original length (STFT padding may extend the output slightly)
-    out = out[:len(audio)].astype(np.float32)
-    return out
+    # Fix output length to exactly match input. scipy.signal.istft may return
+    # slightly more or slightly fewer samples than len(audio) depending on
+    # boundary padding and hop alignment. Both cases must be handled: truncation
+    # is not enough — if the output is shorter, downstream frame/VAD label
+    # alignment breaks because the pipeline assumes sample count is stable after
+    # analyzeFramesRaw.
+    n_in  = len(audio)
+    n_out = len(out)
+    if n_out < n_in:
+        out = np.pad(out, (0, n_in - n_out))
+    elif n_out > n_in:
+        out = out[:n_in]
+    return out.astype(np.float32)
 
 
 # ── DSP helpers ───────────────────────────────────────────────────────────────

--- a/server/scripts/spectral_subtraction.py
+++ b/server/scripts/spectral_subtraction.py
@@ -1,0 +1,332 @@
+#!/usr/bin/env python3
+"""
+MMSE Decision-Directed Spectral Subtraction Pre-Pass
+
+Lightweight DSP pre-pass applied before the main ML noise reduction
+(DeepFilterNet3, RNNoise, DTLN). Reduces diffuse noise and reverb energy,
+lowering the problem complexity for the ML model and improving its output.
+
+Algorithm: MMSE decision-directed Wiener gain + optional transient shaper,
+computed in a single STFT pass. Musical noise prevention via:
+  1. Decision-directed SNR estimation (alpha_dd) — temporally coherent gains
+  2. Spectral floor (beta) — no bin ever reaches zero gain
+  3. 3-bin frequency-axis median filter — kills isolated spectral spikes
+
+Usage:
+  python3 spectral_subtraction.py --input <path> --output <path>
+    [--alpha-dd 0.98] [--beta 0.05] [--strength 1.0]
+    [--transient-shaper] [--transient-max-reduction-db 6.0]
+
+Input/output: 32-bit float PCM WAV at 44.1 kHz (pipeline internal format).
+"""
+
+import argparse
+import sys
+import warnings
+warnings.filterwarnings('ignore')
+
+import numpy as np
+
+# STFT parameters — 2048-point FFT at 44.1 kHz gives ~46 ms resolution,
+# adequate for voiced speech without over-smoothing transients.
+N_FFT      = 2048
+HOP_LENGTH = 512
+PIPELINE_SR = 44100
+
+# Noise estimator time constants (as recursive-average alpha).
+# Speech frames: very slow adaptation so voiced energy is not mistaken for noise.
+# Silence frames: faster adaptation to track room condition changes between phrases.
+ALPHA_NOISE_SPEECH  = np.float32(0.99)
+ALPHA_NOISE_SILENCE = np.float32(0.85)
+
+# Energy-based VAD threshold: mean a posteriori SNR (gamma_mean) above this
+# value classifies the frame as speech. 1.5 ≈ +1.8 dB above noise.
+VAD_SNR_THRESHOLD = np.float32(1.5)
+
+# ── Numba JIT (optional) ─────────────────────────────────────────────────────
+# The MMSE frame loop is sequential (each frame depends on the previous noise
+# estimate) and dominates runtime on long files. Numba JIT compiles it to
+# native code (~10-20x speedup). Falls back to vectorised NumPy when unavailable.
+
+try:
+    from numba import njit as _njit
+    _HAS_NUMBA = True
+except ImportError:
+    _HAS_NUMBA = False
+
+
+if _HAS_NUMBA:
+    from numba import njit
+
+    @njit(cache=True)
+    def _mmse_loop(mag, n_frames, n_bins, alpha_dd, beta,
+                   alpha_noise_speech, alpha_noise_silence, vad_snr_threshold):
+        """
+        MMSE decision-directed Wiener gain — Numba JIT implementation.
+
+        Decision-directed estimator (Ephraim & Malah 1984):
+          xi[t] = alpha_dd * |G[t-1]·Y[t-1]|² / λ[t]  +  (1−alpha_dd) * max(γ[t]−1, 0)
+          G[t]  = xi[t] / (xi[t] + 1)   ← Wiener gain, floored at beta
+
+        mag   : (n_frames, n_bins) float32 — STFT magnitude
+        returns gains (n_frames, n_bins) float32 in [beta, 1.0]
+        """
+        _ad   = np.float32(alpha_dd)
+        _mad  = np.float32(1.0 - alpha_dd)
+        _b    = np.float32(beta)
+        _aSp  = np.float32(alpha_noise_speech)
+        _aSi  = np.float32(alpha_noise_silence)
+        _mSp  = np.float32(1.0 - alpha_noise_speech)
+        _mSi  = np.float32(1.0 - alpha_noise_silence)
+        _vth  = np.float32(vad_snr_threshold)
+        _eps  = np.float32(1e-10)
+        _one  = np.float32(1.0)
+        _zero = np.float32(0.0)
+
+        noise_est  = mag[0].copy()
+        prev_clean = mag[0].copy()
+        gains      = np.empty((n_frames, n_bins), dtype=np.float32)
+
+        for t in range(n_frames):
+            mag_t     = mag[t]
+            gamma_sum = _zero
+
+            for b in range(n_bins):
+                lam   = noise_est[b] * noise_est[b] + _eps
+                gamma_b = mag_t[b] * mag_t[b] / lam
+
+                xi_dd = prev_clean[b] * prev_clean[b] / lam
+                xi_sp = gamma_b - _one
+                xi_sp = xi_sp if xi_sp > _zero else _zero
+                xi    = _ad * xi_dd + _mad * xi_sp
+
+                g = xi / (xi + _one)
+                if g < _b:
+                    g = _b
+
+                gains[t, b]    = g
+                prev_clean[b]  = g * mag_t[b]
+                gamma_sum     += gamma_b
+
+            # Energy-based VAD: mean a posteriori SNR
+            is_speech = (gamma_sum / np.float32(n_bins)) > _vth
+
+            if is_speech:
+                for b in range(n_bins):
+                    noise_est[b] = _aSp * noise_est[b] + _mSp * mag_t[b]
+            else:
+                for b in range(n_bins):
+                    noise_est[b] = _aSi * noise_est[b] + _mSi * mag_t[b]
+
+        return gains
+
+else:
+    def _mmse_loop(mag, n_frames, n_bins, alpha_dd, beta,
+                   alpha_noise_speech, alpha_noise_silence, vad_snr_threshold):
+        """
+        MMSE decision-directed Wiener gain — vectorised NumPy fallback.
+        Same algorithm as the Numba version; slower due to the Python for loop,
+        but each iteration is fully vectorised over the frequency bins.
+        """
+        _ad  = np.float32(alpha_dd)
+        _mad = np.float32(1.0 - alpha_dd)
+        _b   = np.float32(beta)
+        _aSp = np.float32(alpha_noise_speech)
+        _aSi = np.float32(alpha_noise_silence)
+        _mSp = np.float32(1.0 - alpha_noise_speech)
+        _mSi = np.float32(1.0 - alpha_noise_silence)
+
+        noise_est  = mag[0].copy()
+        prev_clean = mag[0].copy()
+        gains      = np.empty((n_frames, n_bins), dtype=np.float32)
+
+        for t in range(n_frames):
+            mag_t = mag[t]
+            lam   = noise_est * noise_est + np.float32(1e-10)
+            gamma = (mag_t * mag_t) / lam
+
+            xi    = _ad * (prev_clean * prev_clean / lam) + _mad * np.maximum(gamma - 1.0, 0.0)
+            g     = xi / (xi + 1.0)
+            g     = np.maximum(g, _b)
+
+            gains[t]   = g
+            prev_clean = g * mag_t
+
+            if float(gamma.mean()) > float(vad_snr_threshold):
+                noise_est = _aSp * noise_est + _mSp * mag_t
+            else:
+                noise_est = _aSi * noise_est + _mSi * mag_t
+
+        return gains
+
+
+# ── Main entry point ─────────────────────────────────────────────────────────
+
+def main():
+    parser = argparse.ArgumentParser(description='MMSE spectral subtraction pre-pass')
+    parser.add_argument('--input',                      required=True,
+                        help='Input WAV (32-bit float, 44.1 kHz)')
+    parser.add_argument('--output',                     required=True,
+                        help='Output WAV (32-bit float, 44.1 kHz)')
+    parser.add_argument('--alpha-dd',                   type=float, default=0.98,
+                        help='Decision-directed smoothing factor (default 0.98)')
+    parser.add_argument('--beta',                       type=float, default=0.05,
+                        help='Spectral floor / minimum Wiener gain (default 0.05)')
+    parser.add_argument('--strength',                   type=float, default=1.0,
+                        help='Suppression strength 0–1 (default 1.0; 0 = bypass)')
+    parser.add_argument('--transient-shaper',           action='store_true',
+                        help='Enable transient shaper for inter-phrase reverb tail suppression')
+    parser.add_argument('--transient-max-reduction-db', type=float, default=6.0,
+                        help='Transient shaper maximum gain reduction in dB (default 6.0)')
+    args = parser.parse_args()
+
+    from scipy.io import wavfile
+
+    sr, audio_np = wavfile.read(args.input)
+    audio_np = audio_np.astype(np.float32)
+
+    if audio_np.ndim == 1:
+        out = _process_channel(audio_np, args, sr)
+        wavfile.write(args.output, sr, out.astype(np.float32))
+    else:
+        # Stereo: process each channel independently to preserve spatial information
+        ch0 = _process_channel(audio_np[:, 0], args, sr)
+        ch1 = _process_channel(audio_np[:, 1], args, sr)
+        wavfile.write(args.output, sr,
+                      np.stack([ch0, ch1], axis=1).astype(np.float32))
+
+    print(
+        f'[spectral-sub] Done: alpha_dd={args.alpha_dd} beta={args.beta} '
+        f'strength={args.strength} transient_shaper={args.transient_shaper} '
+        f'numba={_HAS_NUMBA}',
+        flush=True,
+    )
+
+
+# ── Per-channel processing ────────────────────────────────────────────────────
+
+def _process_channel(audio, args, sr):
+    """Full MMSE + optional transient shaper pass on a single audio channel."""
+    from scipy.signal import stft, istft
+
+    n_overlap = N_FFT - HOP_LENGTH
+
+    # Forward STFT — boundary='reflect' avoids edge discontinuities; padded=True
+    # ensures the full signal is covered even when len(audio) % HOP_LENGTH != 0.
+    _, _, Zxx = stft(
+        audio, fs=sr, window='hann',
+        nperseg=N_FFT, noverlap=n_overlap,
+        boundary='reflect', padded=True,
+    )
+    # Zxx: (n_bins, n_frames) complex64
+    mag   = np.abs(Zxx).astype(np.float32)    # (n_bins, n_frames)
+    phase = np.angle(Zxx).astype(np.float32)  # (n_bins, n_frames)
+
+    # Transpose to (n_frames, n_bins) for the sequential frame loop
+    mag_T = np.ascontiguousarray(mag.T)
+    n_frames, n_bins = mag_T.shape
+
+    # ── MMSE Wiener gains ─────────────────────────────────────────────────────
+    gains = _mmse_loop(
+        mag_T, n_frames, n_bins,
+        np.float32(args.alpha_dd),
+        np.float32(args.beta),
+        ALPHA_NOISE_SPEECH,
+        ALPHA_NOISE_SILENCE,
+        VAD_SNR_THRESHOLD,
+    )  # (n_frames, n_bins)
+
+    # 3-bin frequency-axis median filter: kills isolated spectral spikes that
+    # survive the decision-directed estimator. Size (1,3) = 1 frame × 3 bins.
+    gains = _median_filter_3bin(gains)
+
+    # Blend MMSE gain with identity (passthrough) based on strength.
+    # strength=0 → no processing; strength=1 → full MMSE suppression.
+    if args.strength < 1.0:
+        gains = np.float32(1.0) + np.float32(args.strength) * (gains - np.float32(1.0))
+
+    # ── Transient shaper (optional, same STFT pass) ───────────────────────────
+    if args.transient_shaper:
+        t_gain = _compute_transient_gains(mag_T, sr, HOP_LENGTH,
+                                          args.transient_max_reduction_db)
+        # Scale transient gain by strength so strength=0 disables it fully
+        if args.strength < 1.0:
+            t_gain = np.float32(1.0) + np.float32(args.strength) * (t_gain - np.float32(1.0))
+        gains *= t_gain[:, np.newaxis]   # broadcast to (n_frames, n_bins)
+
+    # ── Reconstruct via ISTFT ─────────────────────────────────────────────────
+    # Apply combined gain to the magnitude; retain original phase.
+    gains_T = np.ascontiguousarray(gains.T)    # (n_bins, n_frames)
+    Zxx_out = gains_T * mag * np.exp(1j * phase.astype(np.complex64))
+
+    _, out = istft(
+        Zxx_out, fs=sr, window='hann',
+        nperseg=N_FFT, noverlap=n_overlap,
+        boundary=True,
+    )
+    # Trim to original length (STFT padding may extend the output slightly)
+    out = out[:len(audio)].astype(np.float32)
+    return out
+
+
+# ── DSP helpers ───────────────────────────────────────────────────────────────
+
+def _median_filter_3bin(gains):
+    """3-bin frequency-axis median filter over the gains array.
+
+    Replaces each bin's gain with the median of itself and its two neighbours.
+    Applied on the frequency axis only (size=(1,3)) so temporal coherence
+    established by the decision-directed estimator is preserved.
+    """
+    from scipy.ndimage import median_filter
+    return median_filter(gains, size=(1, 3), mode='reflect').astype(np.float32)
+
+
+def _compute_transient_gains(mag_T, sr, hop_length, max_reduction_db):
+    """Per-frame gain envelope for inter-phrase reverb tail suppression.
+
+    Uses a peak-hold envelope with slow exponential decay (~300 ms). When the
+    current frame energy drops more than ~12 dB below the held peak, additional
+    gain reduction is applied. This targets the decaying reverb tail after a
+    voiced phrase ends without touching the speech itself.
+
+    Returns a (n_frames,) float32 array in [max_reduction_linear, 1.0].
+    """
+    # Frame energy: RMS of magnitude spectrum per frame
+    frame_energy = np.sqrt(np.mean(mag_T ** 2, axis=1) + np.float32(1e-10))
+    n_frames = len(frame_energy)
+
+    # Frames per second at the configured hop length
+    fps = sr / hop_length   # ~86.1 fps at 44.1 kHz / 512
+
+    # Peak hold with ~300 ms exponential decay — long enough to span inter-word
+    # gaps without decaying into a running phrase, short enough to release after
+    # a genuine inter-phrase pause.
+    decay_frames = max(int(0.30 * fps), 1)
+    decay_coeff  = np.float32(np.exp(-1.0 / decay_frames))
+
+    max_red_lin  = np.float32(10.0 ** (-max_reduction_db / 20.0))
+    threshold    = np.float32(0.25)   # -12 dB below peak → begin attenuating
+
+    peak    = frame_energy[0]
+    t_gains = np.ones(n_frames, dtype=np.float32)
+
+    for t in range(n_frames):
+        e = frame_energy[t]
+        if e > peak:
+            peak = e              # Instantaneous attack — catch phrase onsets immediately
+        else:
+            peak = decay_coeff * peak   # Slow decay during reverb tail / silence
+
+        if peak > np.float32(1e-8):
+            ratio = e / peak
+            if ratio < threshold:
+                # Soft linear ramp: 1.0 at threshold, max_red_lin at 0.0
+                g = ratio / threshold
+                t_gains[t] = g * (np.float32(1.0) - max_red_lin) + max_red_lin
+
+    return t_gains
+
+
+if __name__ == '__main__':
+    main()

--- a/src/audio/presets.js
+++ b/src/audio/presets.js
@@ -209,6 +209,16 @@ export const PRESETS = {
     breathReducer: { max_reduction_db: 12 },
     // Slightly more aggressive — mouth clicks are a human review concern for ACX
     clickRemover: { thresholdSigma: 3.0, maxClickMs: 15 },
+    // MMSE spectral subtraction pre-pass (before DF3). Conservative settings for
+    // ACX: lower strength preserves the natural vocal character ACX human reviewers
+    // expect; transient shaper disabled to avoid any risk of gating room tone.
+    spectralSubtraction: {
+      enabled:              true,
+      alphaDd:              0.98,
+      beta:                 0.05,
+      strength:             0.7,
+      transientShaper:      false,
+    },
     // Stage 4 — Sibilance Suppressor. Sparse overrides; anything omitted
     // inherits from DEFAULT_PARAMS in server/scripts/sibilance_suppressor.py.
     // Conservative ACX tuning: lower depth and
@@ -318,6 +328,17 @@ export const PRESETS = {
     // deeper makes the performance feel over-edited.
     breathReducer: { max_reduction_db: 6 },
     clickRemover: { thresholdSigma: 3.5, maxClickMs: 15 },
+    // MMSE spectral subtraction pre-pass (before DF3). Full strength with transient
+    // shaper enabled — podcast listeners expect a processed, tight sound and benefit
+    // from inter-phrase reverb tail suppression.
+    spectralSubtraction: {
+      enabled:                 true,
+      alphaDd:                 0.98,
+      beta:                    0.05,
+      strength:                1.0,
+      transientShaper:         true,
+      transientMaxReductionDb: 6,
+    },
     // Stage 4 — Sibilance Suppressor. Slightly deeper reduction with a faster
     // attack matches the punchier, more processed podcast character; everything
     // else inherits from DEFAULT_PARAMS.
@@ -414,6 +435,16 @@ export const PRESETS = {
     breathReducer: { max_reduction_db: 10 },
     // Same rationale as ACX — voice actors also benefit from clean transients
     clickRemover: { thresholdSigma: 3.0, maxClickMs: 15 },
+    // MMSE spectral subtraction pre-pass (before DF3). Moderate strength; transient
+    // shaper disabled because voice-over often sits under music beds where any gating
+    // artifact becomes audible against the bed.
+    spectralSubtraction: {
+      enabled:              true,
+      alphaDd:              0.98,
+      beta:                 0.05,
+      strength:             0.8,
+      transientShaper:      false,
+    },
     // Stage 4 — Sibilance Suppressor. Broadcast-neutral tuning sits between
     // ACX and podcast: stricter detection than the defaults, lower ceiling
     // than ACX since voice-over often sits under music beds where deep cuts
@@ -511,6 +542,17 @@ export const PRESETS = {
     breathReducer: { max_reduction_db: 15 },
     // Conservative — unknown source material
     clickRemover: { thresholdSigma: 3.5, maxClickMs: 10 },
+    // MMSE spectral subtraction pre-pass (before DF3). Full strength with transient
+    // shaper enabled — unknown source material benefits from maximum diffuse noise and
+    // reverb tail reduction before DF3.
+    spectralSubtraction: {
+      enabled:                 true,
+      alphaDd:                 0.98,
+      beta:                    0.05,
+      strength:                1.0,
+      transientShaper:         true,
+      transientMaxReductionDb: 6,
+    },
     // Stage 4 — Sibilance Suppressor. Pragmatic assertive: lower broadband
     // trigger and selectivity catch more events, deeper reduction with a
     // narrower spreading kernel (sharpness 0.2) for surgical cuts on unknown
@@ -637,6 +679,17 @@ export const PRESETS = {
     airBoost: { gainDb: 0 },
     bweModel: 'ap_bwe',
     bwe: { enabled: false, postEq: { enabled: true, freq: 9000, q: 2, gainDb: -3 } },
+    // MMSE spectral subtraction pre-pass (before RNNoise NE-1). Moderate strength
+    // so residual room noise is reduced before RNNoise's stationary NR pass and
+    // Demucs separation. Transient shaper enabled to suppress reverb tails.
+    spectralSubtraction: {
+      enabled:                 true,
+      alphaDd:                 0.98,
+      beta:                    0.05,
+      strength:                0.8,
+      transientShaper:         true,
+      transientMaxReductionDb: 6,
+    },
   },
 
   clearervoice_eraser: {
@@ -719,6 +772,17 @@ export const PRESETS = {
     airBoost: { gainDb: 0 },
     bweModel: 'ap_bwe',
     bwe: { enabled: true, postEq: { enabled: true, freq: 9000, q: 2, gainDb: -4 } },
+    // MMSE spectral subtraction pre-pass (before RNNoise NE-1). Moderate strength
+    // reduces residual room noise before ClearerVoice SE processes the signal.
+    // Transient shaper enabled to suppress inter-phrase reverb tails.
+    spectralSubtraction: {
+      enabled:                 true,
+      alphaDd:                 0.98,
+      beta:                    0.05,
+      strength:                0.8,
+      transientShaper:         true,
+      transientMaxReductionDb: 6,
+    },
   },
 
 }


### PR DESCRIPTION
## Summary
Introduces a lightweight DSP pre-pass using MMSE decision-directed spectral subtraction to reduce diffuse noise and reverb energy before the main ML noise reduction models (DeepFilterNet3, RNNoise, DTLN). This lowers the problem complexity for the ML models and improves their output quality.

## Key Changes

- **New DSP module** (`server/scripts/spectral_subtraction.py`):
  - Implements MMSE decision-directed Wiener gain filtering with temporal coherence via decision-directed SNR estimation (alpha_dd parameter)
  - Includes spectral floor (beta) to prevent over-suppression and musical noise artifacts
  - Applies 3-bin frequency-axis median filter to eliminate isolated spectral spikes
  - Optional transient shaper for inter-phrase reverb tail suppression using peak-hold envelope with exponential decay
  - Dual implementation: Numba JIT-compiled version for ~10-20x speedup on long files, with automatic fallback to vectorized NumPy
  - Processes stereo channels independently to preserve spatial information
  - Operates on 2048-point FFT at 44.1 kHz (~46 ms resolution)

- **Pipeline integration** (`server/pipeline/enhancement.js`):
  - Added `runSpectralSubtraction()` function to invoke the Python script with configurable parameters
  - Integrated into the enhancement stage system

- **Stage orchestration** (`server/pipeline/stages.js`):
  - New `spectralSubtraction()` stage that runs after HPF and before main ML noise reduction
  - Respects preset configuration with enable/disable flag
  - Logs processing parameters and results

- **Preset configurations** (`src/audio/presets.js`):
  - Added spectral subtraction settings to all 6 presets with tuning appropriate to each use case:
    - **ACX**: Conservative (strength 0.7, transient shaper disabled) to preserve natural vocal character
    - **Podcast**: Full strength (1.0) with transient shaper enabled for tight, processed sound
    - **Voice-Over**: Moderate strength (0.8, transient shaper disabled) to avoid gating artifacts under music beds
    - **Generic**: Full strength with transient shaper for maximum diffuse noise/reverb reduction
    - **Music Eraser & ClearerVoice**: Moderate strength (0.8) with transient shaper enabled

- **Pipeline ordering** (`server/pipeline/pipelines.js`):
  - Spectral subtraction stage inserted after HPF and before main noise reduction stages

## Implementation Details

- **Musical noise prevention**: Achieved through three mechanisms:
  1. Decision-directed SNR estimation ensures temporally coherent gains
  2. Spectral floor prevents any bin from reaching zero gain
  3. Median filtering removes isolated spikes

- **VAD integration**: Energy-based voice activity detection using mean a posteriori SNR (gamma_mean) with threshold of 1.5 (~1.8 dB) to classify frames as speech or silence, enabling adaptive noise estimation

- **Strength blending**: The `strength` parameter (0–1) allows smooth interpolation between bypass (0) and full suppression (1), applied to both MMSE and transient shaper gains

- **Transient shaper**: Uses ~300 ms peak-hold decay to target reverb tails without affecting active speech, with configurable maximum reduction in dB

https://claude.ai/code/session_01HgNH7EDaaZw9VoB6hvxFSS