### PR TITLE
Add room presence convolution reverb stage to audio pipeline

### DIFF
--- a/server/pipeline/enhancement.js
+++ b/server/pipeline/enhancement.js
@@ -37,6 +37,7 @@ const RESONANCE_SCRIPT             = path.join(SCRIPTS_DIR, 'resonance_suppresso
 const SIBILANCE_SCRIPT             = path.join(SCRIPTS_DIR, 'sibilance_suppressor.py')
 const BREATH_REDUCER_SCRIPT        = path.join(SCRIPTS_DIR, 'breath_reducer.py')
 const SPECTRAL_SUBTRACTION_SCRIPT  = path.join(SCRIPTS_DIR, 'spectral_subtraction.py')
+const ROOM_PRESENCE_SCRIPT         = path.join(SCRIPTS_DIR, 'room_presence.py')
 
 // ── Enhancement stages ────────────────────────────────────────────────────────
 
@@ -463,4 +464,27 @@ export async function applyBreathReduction(inputPath, outputPath, presetId, fram
     if (paramsPath)  await rm(paramsPath,  { force: true })
     if (vadMaskPath) await rm(vadMaskPath, { force: true })
   }
+}
+
+// ── Room Presence ─────────────────────────────────────────────────────────────
+
+/**
+ * Convolution reverb with a synthetic IR — adds subtle acoustic space.
+ *
+ * @param {string} inputPath   32-bit float WAV at 44.1 kHz
+ * @param {string} outputPath  Pre-allocated output path (ctx.tmp('.wav'))
+ * @param {object} [params]
+ * @param {number} [params.wet=0.08]          Wet mix fraction (0.0–0.3)
+ * @param {number} [params.rt60Ms=80]         RT60 decay time in ms (20–200)
+ * @param {number} [params.preDelayMs=1.5]    Pre-delay in ms (0–5)
+ * @param {number} [params.diffusion=0.7]     Tail density/warmth (0.0–1.0)
+ * @returns {Promise<void>}
+ */
+export function runRoomPresence(inputPath, outputPath, params = {}) {
+  const args = ['--input', inputPath, '--output', outputPath]
+  if (params.wet        != null) args.push('--wet',          String(params.wet))
+  if (params.rt60Ms     != null) args.push('--rt60-ms',      String(params.rt60Ms))
+  if (params.preDelayMs != null) args.push('--pre-delay-ms', String(params.preDelayMs))
+  if (params.diffusion  != null) args.push('--diffusion',    String(params.diffusion))
+  return spawnPython(ROOM_PRESENCE_SCRIPT, args, 'RoomPresence')
 }

--- a/server/pipeline/pipelines.js
+++ b/server/pipeline/pipelines.js
@@ -49,6 +49,7 @@ const STANDARD_PIPELINE = [
   stages.deEss,                   // De-Ess again after airBoost
   stages.enhancementEQ,
   //stages.roomTonePad,           // TO DO: Make configurable option; For ACX-only preset only; Changes file length
+  stages.roomPresence,           // Synthetic-IR convolution reverb; no-op when preset.roomPresence.enabled = false
   stages.normalize,
   stages.truePeakLimit,
   stages.measureAfter,
@@ -104,6 +105,7 @@ export const PIPELINES = {
     //stages.harmonicExciter,         // Adds presence/air harmonic content before normalization
 
     //Finalize
+    stages.roomPresence,             // Synthetic-IR convolution reverb; disabled in noise_eraser preset config
     stages.normalize,                // Loudness normalization
     stages.truePeakLimit,            // True peak limiting
     stages.measureAfter,
@@ -148,6 +150,7 @@ export const PIPELINES = {
     stages.airBoost,               // Stage 3b — no-op for clearervoice_eraser (air_boost_db = 0)
     //stages.harmonicExciter,         // Adds presence/air harmonic content before normalization
     stages.vocalSaturation,
+    stages.roomPresence,             // Synthetic-IR convolution reverb; disabled in clearervoice_eraser preset config
     stages.normalize,                // Loudness normalization
     stages.truePeakLimit,            // True peak limiting
     stages.measureAfter,

--- a/server/pipeline/stages.js
+++ b/server/pipeline/stages.js
@@ -42,7 +42,7 @@ import { analyzeAndDeEss } from './deEsser.js'
 import { applyCompression } from './compression.js'
 import { runSeparation, runClearerVoice } from './separation.js'
 import { readFile } from 'fs/promises'
-import { runHarmonicExciter, runVocalSaturation, runDereverb, runApBwe, runLavaSR, runClickRemover, applyResonanceSuppression, applySibilanceSuppression, applyBreathReduction, runSpectralSubtraction } from './enhancement.js'
+import { runHarmonicExciter, runVocalSaturation, runDereverb, runApBwe, runLavaSR, runClickRemover, applyResonanceSuppression, applySibilanceSuppression, applyBreathReduction, runSpectralSubtraction, runRoomPresence } from './enhancement.js'
 import { validateSeparation } from './separationValidation.js'
 import { applyAutoLeveler } from './autoLeveler.js'
 import { applyParallelCompression } from './parallelCompression.js'
@@ -843,6 +843,33 @@ export async function vocalSaturation(ctx) {
   ctx.currentPath = outPath
   ctx.results.vocalSaturation = { applied: true, drive, wetDry, bias, fc, f0 }
   await logLevel(ctx, 'after vocal saturation', ctx.currentPath, {})
+}
+
+// ── Stage: Room Presence (Stage 4c) ──────────────────────────────────────────
+// Convolution reverb with a synthetic IR. Placed after all corrective and
+// tonal processing so the reverb tail doesn't amplify residual noise, and
+// before loudness normalization so the tail doesn't trigger unexpected limiting.
+//
+// Skipped (no audio change) when preset.roomPresence.enabled is false.
+
+export async function roomPresence(ctx) {
+  const cfg = ctx.preset?.roomPresence ?? {}
+  if (cfg.enabled === false) {
+    ctx.results.roomPresence = { applied: false, reason: 'disabled by preset' }
+    ctx.log('[room-presence] disabled — skipped')
+    return
+  }
+
+  const wet        = cfg.wet        ?? 0.08
+  const rt60Ms     = cfg.rt60Ms     ?? 80
+  const preDelayMs = cfg.preDelayMs ?? 1.5
+  const diffusion  = cfg.diffusion  ?? 0.7
+
+  const outPath = ctx.tmp('.wav')
+  await runRoomPresence(ctx.currentPath, outPath, { wet, rt60Ms, preDelayMs, diffusion })
+  ctx.currentPath       = outPath
+  ctx.results.roomPresence = { applied: true, wet, rt60Ms, preDelayMs, diffusion }
+  ctx.log(`[room-presence] applied wet=${wet} rt60=${rt60Ms}ms pre_delay=${preDelayMs}ms diffusion=${diffusion}`)
 }
 
 // ── Stage: Normalize ──────────────────────────────────────────────────────────

--- a/server/scripts/room_presence.py
+++ b/server/scripts/room_presence.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""
+Room Presence stage — adds a subtle sense of acoustic space using convolution
+reverb with a synthetically generated impulse response.
+
+IR is constructed at runtime from parameters — no external IR files needed.
+Fixed random seed (42) ensures identical settings always produce the same room
+character across runs, which is important for consistent batch processing.
+
+Usage:
+  python3 room_presence.py --input <path> --output <path>
+                           [--wet 0.08]
+                           [--rt60-ms 80]
+                           [--pre-delay-ms 1.5]
+                           [--diffusion 0.7]
+
+Input/output: 32-bit float PCM WAV at 44.1 kHz (pipeline internal format).
+"""
+
+import argparse
+import sys
+
+import numpy as np
+import scipy.signal
+from scipy.io import wavfile
+
+PIPELINE_SR = 44100
+_RNG_SEED   = 42
+
+
+def _generate_ir(sr, rt60_ms, pre_delay_ms, diffusion):
+    """
+    Build a synthetic exponential-decay IR.
+
+    rt60_ms:      -60 dB decay time in milliseconds
+    pre_delay_ms: silence before reverb onset (keeps the onset tight)
+    diffusion:    0.0 = bright/sparse tail, 1.0 = dark/dense tail
+                  (controls low-pass cutoff of the noise tail)
+    """
+    rng = np.random.default_rng(seed=_RNG_SEED)
+
+    rt60_s        = rt60_ms      / 1000.0
+    pre_delay_s   = pre_delay_ms / 1000.0
+
+    # Tail long enough to capture full -60 dB decay
+    tail_samples      = int(sr * rt60_s * 2)
+    pre_delay_samples = int(sr * pre_delay_s)
+
+    # White noise tail
+    noise = rng.standard_normal(tail_samples).astype(np.float64)
+
+    # Low-pass to shape density/warmth: diffusion 0.0 → 8 kHz, 1.0 → 3 kHz
+    lp_cutoff = 8000.0 - diffusion * 5000.0
+    sos       = scipy.signal.butter(2, lp_cutoff / (sr / 2.0), btype='low', output='sos')
+    noise     = scipy.signal.sosfilt(sos, noise)
+
+    # Exponential decay: e^(-6.9 * t / RT60) for exact -60 dB at t = RT60
+    t      = np.arange(tail_samples) / sr
+    decay  = np.exp(-6.9 * t / rt60_s)
+    noise *= decay
+
+    # Assemble IR: pre-delay silence + decaying tail
+    ir = np.zeros(pre_delay_samples + tail_samples, dtype=np.float32)
+    ir[pre_delay_samples:] = noise.astype(np.float32)
+
+    # Normalise to unit energy so wet mix fraction is predictable
+    energy = np.sqrt(np.sum(ir ** 2)) + 1e-12
+    ir    /= energy
+
+    return ir
+
+
+def _apply_room_presence(audio, sr, wet, rt60_ms, pre_delay_ms, diffusion):
+    """Convolve audio with synthetic IR and wet/dry mix."""
+    ir         = _generate_ir(sr, rt60_ms, pre_delay_ms, diffusion)
+    # fftconvolve is O(N log N); trim output to input length
+    wet_signal = scipy.signal.fftconvolve(audio, ir)[:len(audio)]
+    output     = (1.0 - wet) * audio + wet * wet_signal.astype(np.float32)
+    return np.clip(output, -1.0, 1.0).astype(np.float32)
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Apply room presence convolution reverb')
+    parser.add_argument('--input',          required=True,              help='Input WAV (32-bit float, 44.1 kHz)')
+    parser.add_argument('--output',         required=True,              help='Output WAV (32-bit float, 44.1 kHz)')
+    parser.add_argument('--wet',            type=float, default=0.08,   help='Wet mix fraction 0.0–0.3 (default 0.08)')
+    parser.add_argument('--rt60-ms',        type=float, default=80.0,   help='RT60 decay time in ms, 20–200 (default 80)')
+    parser.add_argument('--pre-delay-ms',   type=float, default=1.5,    help='Pre-delay in ms, 0–5 (default 1.5)')
+    parser.add_argument('--diffusion',      type=float, default=0.7,    help='Tail density/warmth 0.0–1.0 (default 0.7)')
+    args = parser.parse_args()
+
+    sr, audio = wavfile.read(args.input)
+    if audio.dtype != np.float32:
+        print(f'[room_presence] ERROR: expected float32 audio, got {audio.dtype}', file=sys.stderr)
+        sys.exit(1)
+    if sr != PIPELINE_SR:
+        print(f'[room_presence] ERROR: expected {PIPELINE_SR} Hz, got {sr} Hz', file=sys.stderr)
+        sys.exit(1)
+
+    # Guard parameter ranges
+    wet        = float(np.clip(args.wet,          0.0,  0.3))
+    rt60_ms    = float(np.clip(args.rt60_ms,     20.0, 200.0))
+    pre_delay  = float(np.clip(args.pre_delay_ms, 0.0,   5.0))
+    diffusion  = float(np.clip(args.diffusion,    0.0,   1.0))
+
+    if audio.ndim == 1:
+        result = _apply_room_presence(audio, sr, wet, rt60_ms, pre_delay, diffusion)
+    else:
+        # Process each channel independently with the same IR
+        channels = [
+            _apply_room_presence(audio[:, ch], sr, wet, rt60_ms, pre_delay, diffusion)
+            for ch in range(audio.shape[1])
+        ]
+        result = np.stack(channels, axis=1)
+
+    wavfile.write(args.output, sr, result)
+    print(
+        f'[room_presence] applied wet={wet} rt60={rt60_ms}ms '
+        f'pre_delay={pre_delay}ms diffusion={diffusion}',
+        file=sys.stderr,
+    )
+
+
+if __name__ == '__main__':
+    main()

--- a/src/audio/presets.js
+++ b/src/audio/presets.js
@@ -227,6 +227,16 @@ export const PRESETS = {
       release_ms:           80.0,
       max_reduction_db:     8.0,
     },
+    // Stage 4c — Room Presence. Conservative for ACX: very low wet mix and
+    // short RT60 add just enough placement without risking ACX human review
+    // rejection for audible reverb.
+    roomPresence: {
+      enabled:     true,
+      wet:         0.05,
+      rt60Ms:      60,
+      preDelayMs:  1.0,
+      diffusion:   0.6,
+    },
   },
 
   podcast_ready: {
@@ -345,6 +355,15 @@ export const PRESETS = {
       depth:     0.7,
       attack_ms: 4.0,
     },
+    // Stage 4c — Room Presence. Default settings for podcast: standard wet mix
+    // and RT60 give an intimate small-room quality that suits conversational audio.
+    roomPresence: {
+      enabled:     true,
+      wet:         0.08,
+      rt60Ms:      80,
+      preDelayMs:  1.5,
+      diffusion:   0.7,
+    },
   },
 
   voice_ready: {
@@ -456,6 +475,16 @@ export const PRESETS = {
       release_ms:           70.0,
       max_reduction_db:     8.0,
     },
+    // Stage 4c — Room Presence. Slightly tighter than podcast defaults — voice
+    // actors need placement without obvious room character that would be
+    // audible under music beds.
+    roomPresence: {
+      enabled:     true,
+      wet:         0.06,
+      rt60Ms:      70,
+      preDelayMs:  1.5,
+      diffusion:   0.65,
+    },
   },
 
   general_clean: {
@@ -564,6 +593,15 @@ export const PRESETS = {
       release_ms:           50.0,
       max_reduction_db:     12.0,
       sharpness:            0.2,
+    },
+    // Stage 4c — Room Presence. Default settings for general_clean: unknown
+    // source material benefits from standard acoustic placement.
+    roomPresence: {
+      enabled:     true,
+      wet:         0.08,
+      rt60Ms:      80,
+      preDelayMs:  1.5,
+      diffusion:   0.7,
     },
   },
 
@@ -689,6 +727,9 @@ export const PRESETS = {
       transientShaper:         true,
       transientMaxReductionDb: 6,
     },
+    // Stage 4c — Room Presence disabled: Noise Eraser deliberately produces a
+    // "dry booth" quality. Adding room presence would contradict the preset goal.
+    roomPresence: { enabled: false },
   },
 
   clearervoice_eraser: {
@@ -782,6 +823,9 @@ export const PRESETS = {
       transientShaper:         true,
       transientMaxReductionDb: 6,
     },
+    // Stage 4c — Room Presence disabled: ClearerVoice Eraser produces a clean,
+    // dry enhanced signal. Adding room presence would contradict the preset goal.
+    roomPresence: { enabled: false },
   },
 
 }


### PR DESCRIPTION
## Summary
Introduces a new "Room Presence" audio processing stage that applies subtle convolution reverb using a synthetically generated impulse response. This stage adds a sense of acoustic space to audio without requiring external IR files.

## Key Changes

- **New Python script** (`server/scripts/room_presence.py`):
  - Generates synthetic exponential-decay impulse responses at runtime with configurable parameters
  - Uses fixed random seed (42) for deterministic, reproducible results across batch processing
  - Implements low-pass filtering on the noise tail to control diffusion/warmth (0.0–1.0)
  - Applies FFT-based convolution for efficient processing
  - Supports mono and multi-channel audio with per-channel processing
  - Validates input format (32-bit float PCM at 44.1 kHz)

- **Pipeline integration** (`server/pipeline/stages.js`):
  - New `roomPresence()` stage function positioned after tonal/corrective processing and before loudness normalization
  - Respects preset configuration with graceful no-op when disabled
  - Logs applied parameters for debugging and verification

- **Enhancement module** (`server/pipeline/enhancement.js`):
  - New `runRoomPresence()` function wraps the Python script execution
  - Accepts configurable parameters: wet mix, RT60 decay time, pre-delay, and diffusion

- **Preset configurations** (`src/audio/presets.js`):
  - Added `roomPresence` settings to all five main presets with tuned parameters:
    - **acx_mastering**: Conservative (wet=0.05, rt60=60ms) to avoid ACX review rejection
    - **podcast_ready**: Standard (wet=0.08, rt60=80ms) for intimate small-room quality
    - **voice_ready**: Tight (wet=0.06, rt60=70ms) for voice actors under music beds
    - **general_clean**: Standard (wet=0.08, rt60=80ms) for unknown source material
  - Disabled for **noise_eraser** and **clearervoice_eraser** presets to maintain their "dry booth" character

- **Pipeline ordering** (`server/pipeline/pipelines.js`):
  - Room Presence stage inserted after enhancement EQ and before loudness normalization
  - Positioned to prevent reverb tail from amplifying residual noise or triggering unexpected limiting

## Implementation Details

- **Synthetic IR generation**: Constructs impulse response from white noise with exponential decay envelope and low-pass filtering, avoiding dependency on external IR files
- **Parameter ranges**: All parameters are clipped to safe ranges (wet: 0.0–0.3, RT60: 20–200ms, pre-delay: 0–5ms, diffusion: 0.0–1.0)
- **Energy normalization**: IR is normalized to unit energy for predictable wet mix fractions
- **Deterministic processing**: Fixed RNG seed ensures identical settings always produce the same room character, critical for consistent batch processing

https://claude.ai/code/session_01PJDUXooFgHQTfqTGnTtCAb