### PR TITLE
Refactor auto-leveler to dual-loop K-weighted LUFS architecture

### DIFF
--- a/server/pipeline/autoLeveler.js
+++ b/server/pipeline/autoLeveler.js
@@ -265,6 +265,13 @@ function linearInterpolateToSamples(hopValues, hopSamples, totalSamples) {
       out[i] = v0 + ((i - start) / hopSamples) * (v1 - v0)
     }
   }
+  // Fill any trailing samples beyond the last full hop with the last hop value
+  // (avoids an unintended 0 dB discontinuity at the end of the file)
+  const tailStart = numHops * hopSamples
+  if (numHops > 0 && tailStart < totalSamples) {
+    const lastVal = hopValues[numHops - 1]
+    for (let i = tailStart; i < totalSamples; i++) out[i] = lastVal
+  }
   return out
 }
 
@@ -389,9 +396,10 @@ export async function applyAutoLeveler(inputPath, outputPath, presetId, frameAna
   const windowTargetHops = Math.round(config.target_window_s * 1000 / HOP_MS)
   const L_target         = movingMedianVoiced(L_st, hopVoiced, windowTargetHops)
 
-  // Noise floor caps
+  // Noise floor caps — headroom is positive only when the measured noise floor is
+  // already below the target; if it is at or above the target, upward gain is 0.
   const noiseFloorDbfs   = frameAnalysis?.noiseFloorDbfs ?? -60
-  const nfHeadroom       = Math.max(0, Math.abs(noiseFloorDbfs - config.noise_floor_target_dbfs) - 3)
+  const nfHeadroom       = Math.max(0, (config.noise_floor_target_dbfs - noiseFloorDbfs) - 3)
   const maxAUpEff        = Math.min(config.loop_a.max_up_db, nfHeadroom)
   const maxBUpEff        = Math.min(config.loop_b.max_up_db, Math.max(0, nfHeadroom - maxAUpEff))
   const nfCapActive      = maxAUpEff < config.loop_a.max_up_db || maxBUpEff < config.loop_b.max_up_db
@@ -472,14 +480,14 @@ export async function applyAutoLeveler(inputPath, outputPath, presetId, frameAna
     skipped_reason: null,
     preset_params: {
       total_max_up_db:          maxUp,
-      total_max_down_db:        -maxDown,
+      total_max_down_db:        maxDown,
       target_window_s:          config.target_window_s,
       noise_floor_target_dbfs:  config.noise_floor_target_dbfs,
       loop_a: {
         deadband_db:  config.loop_a.deadband_db,
         knee_db:      config.loop_a.knee_db,
         max_up_db:    config.loop_a.max_up_db,
-        max_down_db:  -config.loop_a.max_down_db,
+        max_down_db:  config.loop_a.max_down_db,
         attack_ms:    config.loop_a.attack_ms,
         release_ms:   config.loop_a.release_ms,
       },
@@ -489,7 +497,7 @@ export async function applyAutoLeveler(inputPath, outputPath, presetId, frameAna
         ratio_up:         config.loop_b.ratio_up,
         ratio_down:       config.loop_b.ratio_down,
         max_up_db:        config.loop_b.max_up_db,
-        max_down_db:      -config.loop_b.max_down_db,
+        max_down_db:      config.loop_b.max_down_db,
         attack_ms:        config.loop_b.attack_ms,
         release_ms:       config.loop_b.release_ms,
       },

--- a/server/pipeline/autoLeveler.js
+++ b/server/pipeline/autoLeveler.js
@@ -1,531 +1,521 @@
 /**
- * Auto Leveler — VAD-gated gain riding stage (Stage 4b).
+ * Auto Leveler — Stage 4b, dual-loop gain riding architecture.
  *
- * Corrects within-file level variation by measuring each speech frame's local
- * level (via a centered ±700 ms sliding window) and applying gain to move it
- * toward the file's median speech RMS. Gain is rate-limited for smooth
- * transitions and held constant during silence frames.
+ * Two parallel control loops share a slow loudness target derived from a
+ * moving median of short-term (400 ms) K-weighted LUFS. Their gain contributions
+ * sum at sample rate, then clip to a per-preset total cap.
  *
- * Only activated when within-file RMS standard deviation exceeds
- * DRIFT_THRESHOLD_DB (3 dB). For files with consistent levels the stage is a
- * no-op (passes through unchanged audio and logs a skip reason).
+ *   Loop A (drift):   slow 1:1 correction with deadband + cubic-knee transition
+ *   Loop B (perf):    asymmetric ratio compression for larger excursions
+ *
+ * Both loops use one-pole IIR envelope followers and do NOT reset at unvoiced
+ * boundaries — the target is held flat through silence, so the gain curve
+ * continues smoothly without VAD-boundary pops.
  *
  * Chain position: immediately before the Compression stage.
- * Input: VAD mask from silenceAnalysis (silencePreDeEss in the pipeline).
+ * Input: frameAnalysis from analyzeFramesRaw / remeasureFramesPostNr.
  */
 
 import { readWavAllChannels } from './wavReader.js'
 import { writeWavChannels }   from './wavWriter.js'
 import { PRESETS }            from '../presets.js'
 
-const SAMPLE_RATE           = 44100
-const FRAME_DURATION_S      = 0.1    // 100 ms — must match silenceAnalysis frame size
-const FRAME_SAMPLES         = Math.round(FRAME_DURATION_S * SAMPLE_RATE)  // 4410
+const HOP_MS       = 100
+const FRAME_MS     = 25   // Silero VAD frame duration (matches frameAnalysis.js FRAME_DURATION_S * 1000)
 
-const ANALYSIS_WINDOW_FRAMES = 15    // 15 × 100 ms = 1.5 seconds of speech content
-const ANALYSIS_WINDOW_STRIDE = 5     // ~67% overlap — dense knots for responsive tracking
-const MIN_SEGMENT_FRAMES     = 5     // 5 × 100 ms = 500 ms — discard shorter segments
-const DRIFT_THRESHOLD_DB     = 3.0   // σ > 3 dB triggers leveler
-const NOISE_FLOOR_CHECK_DBFS = -58   // post-application safety check
+// VAD hysteresis parameters
+const VAD_MIN_VOICED_MS   = 200
+const VAD_MIN_UNVOICED_MS = 300
 
-const FADE_IN_SAMPLES  = Math.round(0.030 * SAMPLE_RATE)  // 30 ms speech onset
-const LOCAL_LEVEL_RADIUS     = 4     // ±4 frames (±400 ms) centered window for local level
-const LOOKAHEAD_FRAMES       = 4     // 4 × 100 ms = 400 ms forward lookahead for gain riding
-const CORRECTION_STRENGTH    = 0.60  // 60% correction toward median per frame
+// Skip condition thresholds
+const MIN_FILE_DURATION_S   = 20
+const MIN_VOICED_DURATION_S = 15
+const LEVELED_STD_THRESHOLD = 1.5   // dB — both std_st and std_mt below this → skip
 
-// ── Main API ──────────────────────────────────────────────────────────────────
+// ─── K-weighting filter (EBU R128 / ITU-R BS.1770-4) ─────────────────────────
 
-/**
- * Apply VAD-gated gain riding to an audio file.
- *
- * @param {string} inputPath    - 32-bit float WAV (internal format)
- * @param {string} outputPath   - Output WAV path
- * @param {string} presetId
- * @param {import('./frameAnalysis.js').FrameAnalysis} frameAnalysis
- * @returns {AutoLevelerResult}
- *
- * @typedef {Object} AutoLevelerResult
- * @property {boolean} applied
- * @property {string}  [reason]                  - Skip reason when applied=false
- * @property {string}  [activation_reason]        - 'drift_detected' when applied=true
- * @property {number}  [pre_leveling_rms_std_db]
- * @property {number}  [post_leveling_rms_std_db]
- * @property {number}  [median_target_rms_dbfs]
- * @property {number}  [max_gain_applied_db]
- * @property {number}  [min_gain_applied_db]
- * @property {number}  [segments_analyzed]
- * @property {number}  [gain_capped_segments]
- * @property {boolean} [gain_capped]              - true if any segment hit the cap
- * @property {boolean} [noise_floor_risk]         - true if noise floor check exceeded
- * @property {boolean} [leveling_effective]       - true if post σ ≤ 2.5 dB
- */
-export async function applyAutoLeveler(inputPath, outputPath, presetId, frameAnalysis) {
-  const config = PRESETS[presetId]?.autoLeveler
-
-  if (!config) {
-    await copyThrough(inputPath, outputPath)
-    return { applied: false, reason: 'preset_not_applicable' }
+function computeKWeightingCoefficients(sampleRate) {
+  // Stage 1: high-shelf pre-filter
+  const K1  = Math.tan(Math.PI * 1681.974450955533 / sampleRate)
+  const Vh  = Math.pow(10.0, 3.999843853973347 / 20.0)
+  const Vb  = Math.pow(Vh, 0.4996667741545416)
+  const Q1  = 0.7071752369554196
+  const a0s = 1.0 + K1 / Q1 + K1 * K1
+  const s1  = {
+    b: [
+      (Vh + Vb * K1 / Q1 + K1 * K1) / a0s,
+      2.0 * (K1 * K1 - Vh) / a0s,
+      (Vh - Vb * K1 / Q1 + K1 * K1) / a0s,
+    ],
+    a: [
+      1.0,
+      2.0 * (K1 * K1 - 1.0) / a0s,
+      (1.0 - K1 / Q1 + K1 * K1) / a0s,
+    ],
   }
 
-  const { channels, sampleRate } = await readWavAllChannels(inputPath)
-  const analysisSamples = channels[0]
-
-  // ── Step 1: Build speech analysis windows ─────────────────────────────────
-
-  const speechFrames = buildSpeechFrameList(frameAnalysis)
-
-  if (speechFrames.length < ANALYSIS_WINDOW_FRAMES) {
-    await copyThrough(inputPath, outputPath)
-    return { applied: false, reason: 'insufficient_speech_content', pre_leveling_rms_std_db: null }
+  // Stage 2: high-pass filter at 38.135 Hz
+  const K2  = Math.tan(Math.PI * 38.13547087602444 / sampleRate)
+  const Q2  = 0.5003270373238773
+  const a0h = 1.0 + K2 / Q2 + K2 * K2
+  const s2  = {
+    b: [1.0 / a0h, -2.0 / a0h, 1.0 / a0h],
+    a: [1.0, 2.0 * (K2 * K2 - 1.0) / a0h, (1.0 - K2 / Q2 + K2 * K2) / a0h],
   }
 
-  const windows = buildAnalysisWindows(speechFrames, analysisSamples)
-
-  if (windows.length < 2) {
-    await copyThrough(inputPath, outputPath)
-    return { applied: false, reason: 'insufficient_speech_content', pre_leveling_rms_std_db: null }
-  }
-
-  // ── Step 2: Drift detection ───────────────────────────────────────────────
-
-  const rmsDbValues = windows.map(w => w.rmsDb)
-  const preStdDb    = computeStdDev(rmsDbValues)
-
-  if (preStdDb <= DRIFT_THRESHOLD_DB) {
-    await copyThrough(inputPath, outputPath)
-    return {
-      applied: false,
-      reason: 'level_variation_within_threshold',
-      pre_leveling_rms_std_db: round2(preStdDb),
-    }
-  }
-
-  // ── Step 3: Target and gain computation ───────────────────────────────────
-
-  const medianRmsDb = computeMedian(rmsDbValues)
-  const { maxGainDb, maxRateDbPerS } = config
-  const maxRateDbPerFrame = maxRateDbPerS * FRAME_DURATION_S
-
-  // ── Step 4: Per-frame gain envelope ────────────────────────────────────────
-  //
-  // Simple direct algorithm:
-  //   1. Measure each speech frame's RMS
-  //   2. Estimate local level via centered sliding window of speech frame RMS
-  //   3. Compute desired gain = (median − localLevel) × correctionStrength
-  //   4. Clamp to ±maxGainDb
-  //   5. Rate-limit frame-to-frame changes
-  //   6. Hold gain during silence frames
-
-  const numFrames = Math.ceil(analysisSamples.length / FRAME_SAMPLES)
-  const { frameGains, gainCappedSegments } = buildFrameGainsDirect(
-    frameAnalysis, numFrames, analysisSamples, medianRmsDb, maxGainDb, maxRateDbPerFrame,
-  )
-
-  // ── Step 5: Apply gain with VAD gating ────────────────────────────────────
-
-  const n = analysisSamples.length
-  const { gainCurve, noiseFloorRisk } = buildSampleGainCurve(
-    frameGains, frameAnalysis, n, analysisSamples, maxRateDbPerFrame,
-  )
-
-  const processedChannels = channels.map(ch => applyGainCurve(ch, gainCurve))
-
-  await writeWavChannels(processedChannels, sampleRate, outputPath)
-
-  // ── Step 6: Post-application validation ───────────────────────────────────
-
-  const postWindows = buildAnalysisWindows(speechFrames, processedChannels[0])
-  const postRmsDb   = postWindows.map(w => w.rmsDb)
-  const postStdDb   = postRmsDb.length >= 2 ? computeStdDev(postRmsDb) : null
-
-  let maxGainApplied = -Infinity;
-  let minGainApplied = Infinity;
-  for (let i = 0; i < gainCurve.length; i++) {
-    const g = gainCurve[i];
-    if (g > maxGainApplied) maxGainApplied = g;
-    if (g < minGainApplied) minGainApplied = g;
-  }
-  // gainCurve stores linear multipliers; convert back for reporting
-  const maxGainDb_applied = maxGainApplied > 0 ? round2(20 * Math.log10(maxGainApplied)) : 0
-  const minGainDb_applied = minGainApplied > 0 ? round2(20 * Math.log10(minGainApplied)) : 0
-
-  return {
-    applied:                    true,
-    activation_reason:          'drift_detected',
-    pre_leveling_rms_std_db:    round2(preStdDb),
-    post_leveling_rms_std_db:   postStdDb !== null ? round2(postStdDb) : null,
-    median_target_rms_dbfs:     round2(medianRmsDb),
-    max_gain_applied_db:        maxGainDb_applied,
-    min_gain_applied_db:        minGainDb_applied,
-    segments_analyzed:          windows.length,
-    gain_capped_segments:       gainCappedSegments,
-    gain_capped:                gainCappedSegments > 0,
-    noise_floor_risk:           noiseFloorRisk,
-    leveling_effective:         postStdDb !== null && postStdDb <= 2.5,
-  }
+  return { stage1: s1, stage2: s2 }
 }
 
-// ── Speech frame helpers ──────────────────────────────────────────────────────
-
-/**
- * Extract the ordered list of speech (voiced) frames from silenceAnalysis,
- * discarding contiguous segments shorter than MIN_SEGMENT_FRAMES.
- *
- * @param {import('./frameAnalysis.js').FrameAnalysis} sa
- * @returns {import('./frameAnalysis.js').FrameInfo[]}
- */
-function buildSpeechFrameList(sa) {
-  if (!sa || sa.frames.length === 0) return []
-
-  // Group frames into contiguous speech segments
-  const segments = []  // each: array of FrameInfo
-  let current    = null
-
-  for (const frame of sa.frames) {
-    if (!frame.isSilence) {
-      if (!current) current = []
-      current.push(frame)
-    } else {
-      if (current) { segments.push(current); current = null }
-    }
-  }
-  if (current) segments.push(current)
-
-  // Discard short segments
-  const validSegments = segments.filter(seg => seg.length >= MIN_SEGMENT_FRAMES)
-  return validSegments.flat()
-}
-
-/**
- * Build 3-second analysis windows from speech frames.
- * Each window covers ANALYSIS_WINDOW_FRAMES voiced frames.
- * Returns per-window RMS (dBFS) and center sample position.
- *
- * @param {import('./frameAnalysis.js').FrameInfo[]} speechFrames
- * @param {Float32Array} samples - Channel 0 audio samples
- * @returns {{ rmsDb: number, centerSample: number }[]}
- */
-function buildAnalysisWindows(speechFrames, samples) {
-  const windows = []
-  const total   = speechFrames.length
-
-  let i = 0
-  while (i + ANALYSIS_WINDOW_FRAMES <= total) {
-    const windowFrames = speechFrames.slice(i, i + ANALYSIS_WINDOW_FRAMES)
-    const rmsDb        = computeWindowRms(windowFrames, samples)
-    const centerSample = computeWindowCenter(windowFrames)
-    windows.push({ rmsDb, centerSample })
-    i += ANALYSIS_WINDOW_STRIDE  // 50% overlap for smoother gain profile
-  }
-
-  // Include a partial final window if there are leftover frames (>= 10 frames = 1 s)
-  if (i < total && (total - i) >= 10) {
-    const windowFrames = speechFrames.slice(i)
-    const rmsDb        = computeWindowRms(windowFrames, samples)
-    const centerSample = computeWindowCenter(windowFrames)
-    windows.push({ rmsDb, centerSample })
-  }
-
-  return windows
-}
-
-/**
- * Compute unweighted RMS in dBFS over a set of frames.
- */
-function computeWindowRms(frames, samples) {
-  let sumSq = 0
-  let count = 0
-  for (const frame of frames) {
-    const start = frame.offsetSamples
-    const end   = Math.min(start + frame.lengthSamples, samples.length)
-    for (let i = start; i < end; i++) {
-      sumSq += samples[i] * samples[i]
-      count++
-    }
-  }
-  if (count === 0) return -120
-  const rms = Math.sqrt(sumSq / count)
-  return rms > 0 ? 20 * Math.log10(rms) : -120
-}
-
-/**
- * Return the wall-clock center sample of a group of frames.
- */
-function computeWindowCenter(frames) {
-  const firstStart = frames[0].offsetSamples
-  const lastEnd    = frames[frames.length - 1].offsetSamples + frames[frames.length - 1].lengthSamples
-  return Math.round((firstStart + lastEnd) / 2)
-}
-
-// ── Frame-level gain envelope ─────────────────────────────────────────────────
-
-/**
- * Build a per-frame gain array using a direct local-level algorithm.
- *
- * For each speech frame:
- *   1. Measure the frame's RMS
- *   2. Compute a local level estimate from a centered sliding window of
- *      nearby speech frames (±LOCAL_LEVEL_RADIUS, RMS-averaged in linear domain)
- *   3. Desired gain = (median − localLevel) × CORRECTION_STRENGTH
- *   4. Clamp to ±maxGainDb
- *   5. Rate-limit frame-to-frame changes to maxRateDbPerFrame
- *   6. Hold the last speech gain during silence frames
- *
- * @param {import('./frameAnalysis.js').FrameAnalysis} sa
- * @param {number}       numFrames
- * @param {Float32Array} samples         - Channel 0 audio samples
- * @param {number}       medianRmsDb     - Median target RMS (dBFS)
- * @param {number}       maxGainDb       - Maximum gain magnitude (dB)
- * @param {number}       maxRateDbPerFrame - Max gain change per frame (dB)
- * @returns {{ frameGains: Float32Array, gainCappedSegments: number }}
- */
-function buildFrameGainsDirect(sa, numFrames, samples, medianRmsDb, maxGainDb, maxRateDbPerFrame) {
-  // Step A: Compute per-frame RMS (dBFS) and speech flag for all frames
-  const frameRmsDb  = new Float32Array(numFrames).fill(-120)
-  const frameSpeech = new Uint8Array(numFrames)  // 1 = speech, 0 = silence
-  for (let f = 0; f < numFrames; f++) {
-    const frame = sa.frames[f]
-    if (frame && !frame.isSilence) {
-      frameRmsDb[f]  = computeFrameRms(frame, samples)
-      frameSpeech[f] = 1
-    }
-  }
-
-  // Step B: Compute desired gain for each speech frame using a centered
-  // sliding window of SPEECH FRAMES ONLY for local level estimation
-  const desiredGains = new Float32Array(numFrames).fill(NaN)
-  let gainCappedSegments = 0
-
-  for (let f = 0; f < numFrames; f++) {
-    if (!frameSpeech[f]) continue
-
-    // Centered sliding window: only include speech frames in the average
-    let sumLinSq = 0, count = 0
-    for (let k = f - LOCAL_LEVEL_RADIUS; k <= f + LOCAL_LEVEL_RADIUS; k++) {
-      if (k >= 0 && k < numFrames && frameSpeech[k]) {
-        const linRms = Math.pow(10, frameRmsDb[k] / 20)
-        sumLinSq += linRms * linRms
-        count++
-      }
-    }
-
-    if (count === 0) { desiredGains[f] = 0; continue }
-
-    const localRmsDb = 10 * Math.log10(sumLinSq / count)
-    const rawGain = (medianRmsDb - localRmsDb) * CORRECTION_STRENGTH
-    const clamped = Math.max(-maxGainDb, Math.min(maxGainDb, rawGain))
-    if (Math.abs(rawGain) > maxGainDb) gainCappedSegments++
-    desiredGains[f] = clamped
-  }
-
-  // Step C: Resolve silence holds — fill silence frames with nearest speech gain
-  const targets = new Float32Array(numFrames)
-  let lastSpeech = 0
-  for (let f = 0; f < numFrames; f++) {
-    if (!Number.isNaN(desiredGains[f])) lastSpeech = desiredGains[f]
-    targets[f] = lastSpeech
-  }
-
-  // Step D: Forward pass with lookahead rate limiting
-  //
-  // At each frame the rate limiter slews toward the target LOOKAHEAD_FRAMES
-  // ahead rather than the current frame's target. This means the gain starts
-  // moving toward an upcoming level change before it arrives, so the curve is
-  // already close to correct by the time the phrase begins — no lag, no
-  // backward pass needed.
-  //
-  // A directional clamp is applied using each frame's own target as the
-  // direction signal. This guarantees the rate-limited curve can never make a
-  // bad situation worse: if the lookahead target briefly pulls the gain the
-  // wrong way during a transition, the clamp pins it at 0 dB rather than
-  // actively attenuating a quiet frame or boosting a loud one.
-
-  const frameGains = new Float32Array(numFrames)
-  let current = 0
-  for (let f = 0; f < numFrames; f++) {
-    const lookaheadIdx = Math.min(f + LOOKAHEAD_FRAMES, numFrames - 1)
-    const delta = targets[lookaheadIdx] - current
-    if (Math.abs(delta) > maxRateDbPerFrame) {
-      current += maxRateDbPerFrame * Math.sign(delta)
-    } else {
-      current = targets[lookaheadIdx]
-    }
-    // Directional clamp: floor below-median gains at 0 dB, ceiling above-median
-    // gains at 0 dB, so the leveler may fall short but never goes backwards.
-    frameGains[f] = targets[f] >= 0 ? Math.max(0, current) : Math.min(0, current)
-  }
-
-  return { frameGains, gainCappedSegments }
-}
-
-/**
- * Compute RMS in dBFS for a single frame.
- */
-function computeFrameRms(frame, samples) {
-  const start = frame.offsetSamples
-  const end   = Math.min(start + frame.lengthSamples, samples.length)
-  let sumSq = 0, count = 0
-  for (let i = start; i < end; i++) {
-    sumSq += samples[i] * samples[i]
-    count++
-  }
-  if (count === 0) return -120
-  const rms = Math.sqrt(sumSq / count)
-  return rms > 0 ? 20 * Math.log10(rms) : -120
-}
-
-// ── Sample-level gain curve with VAD gating ───────────────────────────────────
-
-/**
- * Build a per-sample linear gain curve applying:
- *   - Speech frames: spline gain from frameGains (linearly interpolated within frame)
- *   - Silence frames: held gain from last speech frame
- *   - 30 ms fade-in at silence→speech transitions
- *   - 20 ms fade-out at speech→silence transitions
- *
- * Also performs the post-application noise floor check.
- *
- * @param {Float32Array} frameGains     - dB per frame
- * @param {import('./frameAnalysis.js').FrameAnalysis} sa
- * @param {number} n                    - total sample count
- * @param {Float32Array} samples        - Original channel 0 samples (for noise floor check)
- * @param {number}       maxRatePerFrame - Max gain change per frame (dB), for pre-fade clamping
- * @returns {{ gainCurve: Float32Array, noiseFloorRisk: boolean }}
- */
-function buildSampleGainCurve(frameGains, sa, n, samples, maxRatePerFrame) {
-  // Build a per-sample gain (linear, not dB) using the frame-level dB gains
-  // with linear sub-frame interpolation and VAD-gated hold behavior.
-  const gainCurve = new Float32Array(n)
-
-  // Precompute isSpeech lookup per frame index
-  const isSpeechMap = new Map()
-  if (sa && sa.frames) {
-    for (const frame of sa.frames) {
-      isSpeechMap.set(frame.index, !frame.isSilence)
-    }
-  }
-
-  function isSpeech(frameIdx) {
-    return isSpeechMap.get(frameIdx) === true
-  }
-
-  const numFrames = frameGains.length
-
-  // Identify speech segment boundaries for fade logic
-  const isStart = new Uint8Array(numFrames)
-  for (let f = 0; f < numFrames; f++) {
-    if (isSpeech(f)) {
-      if (f === 0 || !isSpeech(f - 1)) isStart[f] = 1
-    }
-  }
-
-  // Walk through all samples and assign gains
+function applyBiquad(samples, b, a) {
+  const n = samples.length
+  const out = new Float64Array(n)
+  let x1 = 0, x2 = 0, y1 = 0, y2 = 0
   for (let i = 0; i < n; i++) {
-    const frameIdx = Math.floor(i / FRAME_SAMPLES)
-    const cFrameIdx = Math.min(frameIdx, numFrames - 1)
+    const x0 = samples[i]
+    const y0 = b[0] * x0 + b[1] * x1 + b[2] * x2 - a[1] * y1 - a[2] * y2
+    out[i] = y0
+    x2 = x1; x1 = x0
+    y2 = y1; y1 = y0
+  }
+  return out
+}
 
-    if (!isSpeech(cFrameIdx)) {
-      // Silence: hold at frameGains value
-      let finalGainDb = frameGains[cFrameIdx]
+function applyKWeighting(samples, sampleRate) {
+  const { stage1, stage2 } = computeKWeightingCoefficients(sampleRate)
+  return applyBiquad(applyBiquad(samples, stage1.b, stage1.a), stage2.b, stage2.a)
+}
 
-      // Pre-fade (lookahead) into the next speech segment
-      // Ramps toward the target gain during the last 30ms of silence,
-      // but clamps the target so the ramp doesn't exceed the rate limit.
-      const nextFrameIdx = cFrameIdx + 1
-      if (nextFrameIdx < numFrames && isStart[nextFrameIdx]) {
-        const segStartSample = nextFrameIdx * FRAME_SAMPLES
-        const preFadePos = segStartSample - i
-        if (preFadePos <= FADE_IN_SAMPLES) {
-          const alpha = 1 - (preFadePos / FADE_IN_SAMPLES)
-          // Clamp the pre-fade target so total ramp over FADE_IN duration
-          // respects the per-frame rate limit (scaled to fade duration)
-          const fadeDurationFrames = FADE_IN_SAMPLES / FRAME_SAMPLES
-          const maxFadeDb = maxRatePerFrame * Math.max(fadeDurationFrames, 1)
-          const rawTarget = frameGains[nextFrameIdx]
-          const delta = rawTarget - finalGainDb
-          const clampedTarget = finalGainDb + Math.max(-maxFadeDb, Math.min(maxFadeDb, delta))
-          finalGainDb = finalGainDb + alpha * (clampedTarget - finalGainDb)
-        }
-      }
+// ─── LUFS sliding-window curve (voiced hops only) ─────────────────────────────
 
-      gainCurve[i] = dbToLinear(finalGainDb)
+function computeLufsCurve(kwSamples, hopVoiced, windowSamples, hopSamples) {
+  const n       = kwSamples.length
+  const numHops = hopVoiced.length
+
+  // Running power sum for O(1) window queries
+  const powerSum = new Float64Array(n + 1)
+  for (let i = 0; i < n; i++) {
+    powerSum[i + 1] = powerSum[i] + kwSamples[i] * kwSamples[i]
+  }
+
+  const halfWin = Math.floor(windowSamples / 2)
+  const curve   = new Float64Array(numHops)
+
+  for (let h = 0; h < numHops; h++) {
+    if (!hopVoiced[h]) {
+      curve[h] = NaN
       continue
     }
-
-    // Speech frame: use linearly interpolated frame gains
-    const posInFrame = i - cFrameIdx * FRAME_SAMPLES
-    const nextFrameIdx = Math.min(cFrameIdx + 1, numFrames - 1)
-    const t     = posInFrame / FRAME_SAMPLES
-    const gainDb = (1 - t) * frameGains[cFrameIdx] + t * frameGains[nextFrameIdx]
-
-    gainCurve[i] = dbToLinear(gainDb)
+    const center = h * hopSamples + Math.floor(hopSamples / 2)
+    const start  = Math.max(0, center - halfWin)
+    const end    = Math.min(n, center + halfWin)
+    if (end <= start) { curve[h] = NaN; continue }
+    const meanSq = (powerSum[end] - powerSum[start]) / (end - start)
+    curve[h] = meanSq > 0 ? -0.691 + 10.0 * Math.log10(meanSq) : NaN
   }
 
-  // Post-application noise floor check: measure actual processed level in
-  // silence frames (original sample × gain curve) to detect if the leveler
-  // has amplified the noise floor above the safety threshold.
-  let noiseFloorRisk = false
-  if (sa && sa.frames && samples) {
-    for (const frame of sa.frames) {
-      if (!frame.isSilence) continue
-      const start = frame.offsetSamples
-      const end   = Math.min(start + frame.lengthSamples, n)
-      if (end <= start) continue
+  return curve
+}
 
-      let sumSq = 0
-      for (let i = start; i < end; i++) {
-        const processed = samples[i] * gainCurve[i]
-        sumSq += processed * processed
-      }
-      const rms   = Math.sqrt(sumSq / (end - start))
-      const rmsDb = rms > 0 ? 20 * Math.log10(rms) : -120
-      if (rmsDb > NOISE_FLOOR_CHECK_DBFS) {
-        noiseFloorRisk = true
+// ─── VAD conditioning with hysteresis ─────────────────────────────────────────
+
+function applyVadHysteresis(frames, sampleRate) {
+  if (!frames || frames.length === 0) return new Uint8Array(0)
+
+  const frameSamples  = frames[0].lengthSamples ?? Math.round(FRAME_MS * 0.001 * sampleRate)
+  const frameMs       = (frameSamples / sampleRate) * 1000
+  const minVoicedF    = Math.max(1, Math.round(VAD_MIN_VOICED_MS   / frameMs))
+  const minUnvoicedF  = Math.max(1, Math.round(VAD_MIN_UNVOICED_MS / frameMs))
+  const n             = frames.length
+
+  // Convert binary isSilence flags to raw voiced array
+  const raw = new Uint8Array(n)
+  for (let f = 0; f < n; f++) raw[f] = (!frames[f].isSilence) ? 1 : 0
+
+  const voiced = new Uint8Array(raw)
+
+  // Pass 1: drop voiced segments shorter than minVoicedF (false positives)
+  let f = 0
+  while (f < n) {
+    if (voiced[f] === 1) {
+      let e = f
+      while (e < n && voiced[e] === 1) e++
+      if (e - f < minVoicedF) for (let k = f; k < e; k++) voiced[k] = 0
+      f = e
+    } else {
+      f++
+    }
+  }
+
+  // Pass 2: bridge unvoiced gaps shorter than minUnvoicedF (false negatives)
+  f = 0
+  while (f < n) {
+    if (voiced[f] === 0) {
+      let e = f
+      while (e < n && voiced[e] === 0) e++
+      if (e - f < minUnvoicedF) for (let k = f; k < e; k++) voiced[k] = 1
+      f = e
+    } else {
+      f++
+    }
+  }
+
+  return voiced
+}
+
+// Expand per-frame voiced mask to per-hop (any voiced frame in hop → voiced hop)
+function frameVoicedToHopVoiced(framedVoiced, framesPerHop, numHops) {
+  const hopVoiced = new Uint8Array(numHops)
+  for (let h = 0; h < numHops; h++) {
+    const f0 = h * framesPerHop
+    for (let k = 0; k < framesPerHop; k++) {
+      if (f0 + k < framedVoiced.length && framedVoiced[f0 + k]) {
+        hopVoiced[h] = 1
         break
       }
     }
   }
-
-  return { gainCurve, noiseFloorRisk }
+  return hopVoiced
 }
+
+// ─── Fill NaN (unvoiced hops) with last valid value ───────────────────────────
+
+function fillUnvoiced(curve, fallback = -23.0) {
+  const filled = new Float64Array(curve)
+  let last = fallback
+  for (let h = 0; h < filled.length; h++) {
+    if (!Number.isNaN(filled[h])) {
+      last = filled[h]
+    } else {
+      filled[h] = last
+    }
+  }
+  return filled
+}
+
+// ─── Moving median of L_st over voiced hops only ─────────────────────────────
+
+function movingMedianVoiced(L_st, hopVoiced, windowHops, minDataHops = 10) {
+  const numHops = L_st.length
+  const target  = new Float64Array(numHops)
+  let   lastTarget = NaN
+
+  for (let h = 0; h < numHops; h++) {
+    const winStart = Math.max(0, h - windowHops + 1)
+    const buf = []
+    for (let k = winStart; k <= h; k++) {
+      if (hopVoiced[k] && !Number.isNaN(L_st[k])) buf.push(L_st[k])
+    }
+    if (buf.length >= minDataHops) {
+      buf.sort((a, b) => a - b)
+      const mid = Math.floor(buf.length / 2)
+      lastTarget = buf.length % 2 === 0
+        ? (buf[mid - 1] + buf[mid]) / 2
+        : buf[mid]
+    }
+    target[h] = Number.isNaN(lastTarget) ? -23.0 : lastTarget
+  }
+
+  return target
+}
+
+// ─── Loop A: drift correction with deadband + cubic knee ──────────────────────
+
+function shapeDrift(delta, deadband, knee, maxUp, maxDown) {
+  const abs_d  = Math.abs(delta)
+  const sign_d = delta >= 0 ? 1 : -1
+  let g
+
+  if (abs_d < deadband) {
+    g = 0
+  } else if (abs_d <= deadband + knee) {
+    const x        = (abs_d - deadband) / knee      // 0..1
+    const smoothed = x * x * (3 - 2 * x)            // smoothstep
+    g = sign_d * smoothed * (abs_d - deadband)
+  } else {
+    g = sign_d * (abs_d - deadband)
+  }
+
+  return g > 0 ? Math.min(g, maxUp) : Math.max(g, -maxDown)
+}
+
+// ─── Loop B: asymmetric ratio compression ─────────────────────────────────────
+
+function shapeCompression(delta, deadbandUp, deadbandDown, ratioUp, ratioDown, maxUp, maxDown) {
+  if (delta > 0) {
+    if (delta < deadbandUp) return 0
+    return Math.min((delta - deadbandUp) / ratioUp, maxUp)
+  } else {
+    const abs_d = -delta
+    if (abs_d < deadbandDown) return 0
+    return Math.max(-((abs_d - deadbandDown) / ratioDown), -maxDown)
+  }
+}
+
+// ─── Interpolate hop-rate values to sample rate ───────────────────────────────
+
+function linearInterpolateToSamples(hopValues, hopSamples, totalSamples) {
+  const numHops = hopValues.length
+  const out     = new Float32Array(totalSamples)
+  for (let h = 0; h < numHops; h++) {
+    const start = h * hopSamples
+    const end   = Math.min(start + hopSamples, totalSamples)
+    const v0    = hopValues[h]
+    const v1    = h + 1 < numHops ? hopValues[h + 1] : hopValues[h]
+    for (let i = start; i < end; i++) {
+      out[i] = v0 + ((i - start) / hopSamples) * (v1 - v0)
+    }
+  }
+  return out
+}
+
+// ─── One-pole IIR envelope follower ──────────────────────────────────────────
+
+function envelopeFollow(target, attackMs, releaseMs, sampleRate) {
+  const alpha_a = 1.0 - Math.exp(-1.0 / (attackMs  * 0.001 * sampleRate))
+  const alpha_r = 1.0 - Math.exp(-1.0 / (releaseMs * 0.001 * sampleRate))
+  const n       = target.length
+  const out     = new Float32Array(n)
+  let   prev    = 0.0
+  for (let i = 0; i < n; i++) {
+    prev   += (target[i] > prev ? alpha_a : alpha_r) * (target[i] - prev)
+    out[i]  = prev
+  }
+  return out
+}
+
+// ─── Statistics helpers ───────────────────────────────────────────────────────
+
+function computeStdVoiced(curve, hopVoiced) {
+  const vals = []
+  for (let h = 0; h < curve.length; h++) {
+    if (hopVoiced[h] && !Number.isNaN(curve[h])) vals.push(curve[h])
+  }
+  if (vals.length < 2) return 0
+  const mean = vals.reduce((s, v) => s + v, 0) / vals.length
+  return Math.sqrt(vals.reduce((s, v) => s + (v - mean) ** 2, 0) / vals.length)
+}
+
+// Compute 20*log10(rms(10^(G/20))) over voiced samples only
+function rmsGainOverVoiced(G_smoothed, hopVoiced, hopSamples) {
+  let sumSq = 0, count = 0
+  const numHops = hopVoiced.length
+  for (let h = 0; h < numHops; h++) {
+    if (!hopVoiced[h]) continue
+    const start = h * hopSamples
+    const end   = Math.min(start + hopSamples, G_smoothed.length)
+    for (let i = start; i < end; i++) {
+      const lin = Math.pow(10, G_smoothed[i] / 20.0)
+      sumSq += lin * lin
+      count++
+    }
+  }
+  if (count === 0) return 0
+  return 20 * Math.log10(Math.sqrt(sumSq / count))
+}
+
+// ─── Preset config lookup ─────────────────────────────────────────────────────
+
+function getAutoLevelerConfig(presetId) {
+  return PRESETS[presetId]?.autoLeveler ?? null
+}
+
+// ─── Main API ─────────────────────────────────────────────────────────────────
 
 /**
- * Apply a per-sample linear gain curve to a channel.
+ * Apply dual-loop VAD-gated gain riding to an audio file.
+ *
+ * @param {string} inputPath   - 32-bit float WAV
+ * @param {string} outputPath  - Output WAV path
+ * @param {string} presetId
+ * @param {import('./frameAnalysis.js').FrameAnalysis} frameAnalysis
+ * @returns {AutoLevelerResult}
  */
-function applyGainCurve(samples, gainCurve) {
-  const n      = samples.length
-  const output = new Float32Array(n)
-  for (let i = 0; i < n; i++) {
-    output[i] = samples[i] * (i < gainCurve.length ? gainCurve[i] : 1.0)
+export async function applyAutoLeveler(inputPath, outputPath, presetId, frameAnalysis) {
+  if (presetId === 'noise_eraser') {
+    await copyThrough(inputPath, outputPath)
+    return { applied: false, skipped_reason: 'preset_excluded' }
   }
-  return output
+
+  const config = getAutoLevelerConfig(presetId)
+  if (!config) {
+    await copyThrough(inputPath, outputPath)
+    return { applied: false, skipped_reason: 'preset_excluded' }
+  }
+
+  const { channels, sampleRate } = await readWavAllChannels(inputPath)
+  const audio = channels[0]
+  const n     = audio.length
+
+  // Duration check
+  const durationS = n / sampleRate
+  if (durationS < MIN_FILE_DURATION_S) {
+    await copyThrough(inputPath, outputPath)
+    return { applied: false, skipped_reason: 'duration_too_short' }
+  }
+
+  // 4b-1: VAD conditioning
+  const framedVoiced = applyVadHysteresis(frameAnalysis?.frames ?? [], sampleRate)
+  const hopSamples   = Math.round(HOP_MS * 0.001 * sampleRate)
+  const numHops      = Math.floor(n / hopSamples)
+
+  const frameSamples = frameAnalysis?.frames?.[0]?.lengthSamples
+    ?? Math.round(FRAME_MS * 0.001 * sampleRate)
+  const framesPerHop = Math.max(1, Math.round(hopSamples / frameSamples))
+  const hopVoiced    = frameVoicedToHopVoiced(framedVoiced, framesPerHop, numHops)
+
+  // Voiced duration check
+  const voicedHops = hopVoiced.reduce((s, v) => s + v, 0)
+  if (voicedHops * HOP_MS * 0.001 < MIN_VOICED_DURATION_S) {
+    await copyThrough(inputPath, outputPath)
+    return { applied: false, skipped_reason: 'insufficient_voiced_audio' }
+  }
+
+  // 4b-2: K-weighted LUFS curves (voiced hops only)
+  const kwSamples = applyKWeighting(audio, sampleRate)
+  const windowSt  = Math.round(400  * 0.001 * sampleRate)
+  const windowMt  = Math.round(1500 * 0.001 * sampleRate)
+  const L_st      = computeLufsCurve(kwSamples, hopVoiced, windowSt, hopSamples)
+  const L_mt      = computeLufsCurve(kwSamples, hopVoiced, windowMt, hopSamples)
+
+  // Skip check after loudness measurement
+  const stdSt = computeStdVoiced(L_st, hopVoiced)
+  const stdMt = computeStdVoiced(L_mt, hopVoiced)
+  if (stdSt < LEVELED_STD_THRESHOLD && stdMt < LEVELED_STD_THRESHOLD) {
+    await copyThrough(inputPath, outputPath)
+    return { applied: false, skipped_reason: 'file_already_leveled' }
+  }
+
+  // 4b-3: Slow target — moving median over voiced hops
+  const windowTargetHops = Math.round(config.target_window_s * 1000 / HOP_MS)
+  const L_target         = movingMedianVoiced(L_st, hopVoiced, windowTargetHops)
+
+  // Noise floor caps
+  const noiseFloorDbfs   = frameAnalysis?.noiseFloorDbfs ?? -60
+  const nfHeadroom       = Math.max(0, Math.abs(noiseFloorDbfs - config.noise_floor_target_dbfs) - 3)
+  const maxAUpEff        = Math.min(config.loop_a.max_up_db, nfHeadroom)
+  const maxBUpEff        = Math.min(config.loop_b.max_up_db, Math.max(0, nfHeadroom - maxAUpEff))
+  const nfCapActive      = maxAUpEff < config.loop_a.max_up_db || maxBUpEff < config.loop_b.max_up_db
+
+  // 4b-4a: Loop A correction shaping (drift)
+  const L_st_filled = fillUnvoiced(L_st)
+  const G_A_hops    = new Float64Array(numHops)
+  for (let h = 0; h < numHops; h++) {
+    G_A_hops[h] = shapeDrift(
+      L_target[h] - L_st_filled[h],
+      config.loop_a.deadband_db,
+      config.loop_a.knee_db,
+      maxAUpEff,
+      config.loop_a.max_down_db,
+    )
+  }
+
+  // 4b-4b: Loop B correction shaping (performance compression)
+  const L_mt_filled = fillUnvoiced(L_mt)
+  const G_B_hops    = new Float64Array(numHops)
+  for (let h = 0; h < numHops; h++) {
+    G_B_hops[h] = shapeCompression(
+      L_target[h] - L_mt_filled[h],
+      config.loop_b.deadband_up_db,
+      config.loop_b.deadband_down_db,
+      config.loop_b.ratio_up,
+      config.loop_b.ratio_down,
+      maxBUpEff,
+      config.loop_b.max_down_db,
+    )
+  }
+
+  // 4b-5: Interpolate to sample rate and apply envelope followers
+  const G_A_sr       = linearInterpolateToSamples(G_A_hops, hopSamples, n)
+  const G_B_sr       = linearInterpolateToSamples(G_B_hops, hopSamples, n)
+  const G_A_smoothed = envelopeFollow(G_A_sr, config.loop_a.attack_ms, config.loop_a.release_ms, sampleRate)
+  const G_B_smoothed = envelopeFollow(G_B_sr, config.loop_b.attack_ms, config.loop_b.release_ms, sampleRate)
+
+  // 4b-6: Sum, cap, apply
+  const maxUp   = config.total_max_up_db
+  const maxDown = config.total_max_down_db
+
+  const processedChannels = channels.map(ch => {
+    const out = new Float32Array(n)
+    for (let i = 0; i < n; i++) {
+      const G = Math.max(-maxDown, Math.min(maxUp, G_A_smoothed[i] + G_B_smoothed[i]))
+      out[i] = ch[i] * Math.pow(10, G / 20.0)
+    }
+    return out
+  })
+
+  await writeWavChannels(processedChannels, sampleRate, outputPath)
+
+  // Post-processing measurements for logging
+  const kwOut    = applyKWeighting(processedChannels[0], sampleRate)
+  const L_st_out = computeLufsCurve(kwOut, hopVoiced, windowSt, hopSamples)
+  const L_mt_out = computeLufsCurve(kwOut, hopVoiced, windowMt, hopSamples)
+  const outStdSt = computeStdVoiced(L_st_out, hopVoiced)
+  const outStdMt = computeStdVoiced(L_mt_out, hopVoiced)
+
+  // Gain stats
+  let aMaxUp = -Infinity, aMaxDown = Infinity
+  let bMaxUp = -Infinity, bMaxDown = Infinity
+  let tMaxUp = -Infinity, tMaxDown = Infinity
+
+  for (let i = 0; i < n; i++) {
+    if (G_A_smoothed[i] > aMaxUp)   aMaxUp   = G_A_smoothed[i]
+    if (G_A_smoothed[i] < aMaxDown) aMaxDown = G_A_smoothed[i]
+    if (G_B_smoothed[i] > bMaxUp)   bMaxUp   = G_B_smoothed[i]
+    if (G_B_smoothed[i] < bMaxDown) bMaxDown = G_B_smoothed[i]
+    const G = Math.max(-maxDown, Math.min(maxUp, G_A_smoothed[i] + G_B_smoothed[i]))
+    if (G > tMaxUp)   tMaxUp   = G
+    if (G < tMaxDown) tMaxDown = G
+  }
+
+  return {
+    applied:       true,
+    skipped_reason: null,
+    preset_params: {
+      total_max_up_db:          maxUp,
+      total_max_down_db:        -maxDown,
+      target_window_s:          config.target_window_s,
+      noise_floor_target_dbfs:  config.noise_floor_target_dbfs,
+      loop_a: {
+        deadband_db:  config.loop_a.deadband_db,
+        knee_db:      config.loop_a.knee_db,
+        max_up_db:    config.loop_a.max_up_db,
+        max_down_db:  -config.loop_a.max_down_db,
+        attack_ms:    config.loop_a.attack_ms,
+        release_ms:   config.loop_a.release_ms,
+      },
+      loop_b: {
+        deadband_up_db:   config.loop_b.deadband_up_db,
+        deadband_down_db: config.loop_b.deadband_down_db,
+        ratio_up:         config.loop_b.ratio_up,
+        ratio_down:       config.loop_b.ratio_down,
+        max_up_db:        config.loop_b.max_up_db,
+        max_down_db:      -config.loop_b.max_down_db,
+        attack_ms:        config.loop_b.attack_ms,
+        release_ms:       config.loop_b.release_ms,
+      },
+    },
+    measurements: {
+      input_loudness_st_std_db:  round2(stdSt),
+      input_loudness_mt_std_db:  round2(stdMt),
+      output_loudness_st_std_db: round2(outStdSt),
+      output_loudness_mt_std_db: round2(outStdMt),
+      loop_a_max_gain_up_db:     round2(aMaxUp   === -Infinity ? 0 : aMaxUp),
+      loop_a_max_gain_down_db:   round2(aMaxDown ===  Infinity ? 0 : aMaxDown),
+      loop_a_rms_gain_db:        round2(rmsGainOverVoiced(G_A_smoothed, hopVoiced, hopSamples)),
+      loop_b_max_gain_up_db:     round2(bMaxUp   === -Infinity ? 0 : bMaxUp),
+      loop_b_max_gain_down_db:   round2(bMaxDown ===  Infinity ? 0 : bMaxDown),
+      loop_b_rms_gain_db:        round2(rmsGainOverVoiced(G_B_smoothed, hopVoiced, hopSamples)),
+      total_max_gain_up_db:      round2(tMaxUp   === -Infinity ? 0 : tMaxUp),
+      total_max_gain_down_db:    round2(tMaxDown ===  Infinity ? 0 : tMaxDown),
+      noise_floor_cap_active:    nfCapActive,
+    },
+  }
 }
 
-// ── Statistics helpers ────────────────────────────────────────────────────────
-
-function computeMedian(values) {
-  const sorted = [...values].sort((a, b) => a - b)
-  const mid    = Math.floor(sorted.length / 2)
-  return sorted.length % 2 === 0
-    ? (sorted[mid - 1] + sorted[mid]) / 2
-    : sorted[mid]
-}
-
-function computeStdDev(values) {
-  if (values.length < 2) return 0
-  const mean = values.reduce((s, v) => s + v, 0) / values.length
-  const variance = values.reduce((s, v) => s + (v - mean) ** 2, 0) / values.length
-  return Math.sqrt(variance)
-}
-
-// ── Utility helpers ───────────────────────────────────────────────────────────
-
-function dbToLinear(db) {
-  return Math.pow(10, db / 20)
-}
+// ─── Utilities ────────────────────────────────────────────────────────────────
 
 function round2(n) {
-  return n !== null && n !== undefined ? Math.round(n * 100) / 100 : null
+  return typeof n === 'number' && isFinite(n) ? Math.round(n * 100) / 100 : null
 }
 
 async function copyThrough(inputPath, outputPath) {

--- a/server/pipeline/index.js
+++ b/server/pipeline/index.js
@@ -291,21 +291,15 @@ function formatAutoLevelerResult(r) {
   if (!r) return null
   if (!r.applied) {
     return {
-      applied: false,
-      reason: r.reason ?? null,
-      ...(r.pre_leveling_rms_std_db != null && { pre_leveling_rms_std_db: r.pre_leveling_rms_std_db }),
+      applied:        false,
+      skipped_reason: r.skipped_reason ?? null,
     }
   }
   return {
-    applied:                    true,
-    activation_reason:          r.activation_reason,
-    pre_leveling_rms_std_db:    r.pre_leveling_rms_std_db,
-    post_leveling_rms_std_db:   r.post_leveling_rms_std_db,
-    median_target_rms_dbfs:     r.median_target_rms_dbfs,
-    max_gain_applied_db:        r.max_gain_applied_db,
-    min_gain_applied_db:        r.min_gain_applied_db,
-    segments_analyzed:          r.segments_analyzed,
-    gain_capped_segments:       r.gain_capped_segments,
+    applied:        true,
+    skipped_reason: null,
+    preset_params:  r.preset_params,
+    measurements:   r.measurements,
   }
 }
 

--- a/server/pipeline/riskAssessment.js
+++ b/server/pipeline/riskAssessment.js
@@ -148,19 +148,20 @@ export async function generateQualityAdvisory(
   // These are only generated when the leveler actually ran (applied: true).
   const levelerResult = pipelineContext.autoLeveler
   if (levelerResult?.applied) {
-    if (levelerResult.gain_capped) {
+    if (levelerResult.measurements?.noise_floor_cap_active) {
       flags.push({
-        id: 'leveler_gain_capped',
+        id: 'leveler_nf_capped',
         severity: 'info',
-        message: 'Some sections had large level differences that could not be fully corrected. Manual gain adjustment may help these sections.',
+        message: 'Upward gain limited to protect noise floor. Some quiet passages remain quieter than the target.',
       })
     }
 
-    if (levelerResult.noise_floor_risk) {
+    const outStd = levelerResult.measurements?.output_loudness_st_std_db
+    if (typeof outStd === 'number' && outStd < 1.0) {
       flags.push({
-        id: 'leveler_noise_floor_risk',
+        id: 'leveler_overcorrected',
         severity: 'review',
-        message: 'Auto leveling may have affected the noise floor in quiet sections. Verify the noise floor before export.',
+        message: 'Output dynamics may sound flattened. Listen carefully before submitting.',
       })
     }
   }

--- a/server/pipeline/stages.js
+++ b/server/pipeline/stages.js
@@ -672,20 +672,19 @@ export async function autoLevel(ctx) {
     ctx.presetId,
     ctx.results.metrics,
   )
-  ctx.currentPath      = levelerPath
+  ctx.currentPath         = levelerPath
   ctx.results.autoLeveler = result
 
   if (result.applied) {
+    const m = result.measurements
     ctx.log(
-      `[auto-leveler] Applied — pre σ=${result.pre_leveling_rms_std_db}dB ` +
-      `post σ=${result.post_leveling_rms_std_db}dB ` +
-      `target=${result.median_target_rms_dbfs}dBFS ` +
-      `gain=[${result.min_gain_applied_db}, ${result.max_gain_applied_db}]dB ` +
-      `capped=${result.gain_capped_segments} ` +
-      `nf_risk=${result.noise_floor_risk}`
+      `[auto-leveler] Applied — in σ(st)=${m.input_loudness_st_std_db}dB ` +
+      `out σ(st)=${m.output_loudness_st_std_db}dB ` +
+      `G_total=[${m.total_max_gain_down_db}, ${m.total_max_gain_up_db}]dB ` +
+      `nf_cap=${m.noise_floor_cap_active}`
     )
   } else {
-    ctx.log(`[auto-leveler] Skipped — ${result.reason}${result.pre_leveling_rms_std_db != null ? ` (σ=${result.pre_leveling_rms_std_db}dB)` : ''}`)
+    ctx.log(`[auto-leveler] Skipped — ${result.skipped_reason}`)
   }
 }
 

--- a/src/audio/presets.js
+++ b/src/audio/presets.js
@@ -87,7 +87,7 @@ export function resolveOutputProfileId(id) {
  * @property {string} defaultOutputProfile
  * @property {boolean} lockedOutputProfile
  * @property {{ enabled: boolean, strength: 'light'|'medium'|'heavy', preserve_early: boolean }} dereverb
- * @property {{ maxGainDb: number, maxRateDbPerS: number }} autoLeveler
+ * @property {{ total_max_up_db: number, total_max_down_db: number, target_window_s: number, noise_floor_target_dbfs: number, loop_a: object, loop_b: object } | null} autoLeveler
  * @property {'demucs'|'convtasnet'} [separationModel]   - Noise Eraser only
  * @property {'mossformer2_48k'|'frcrn_16k'} [clearervoiceModel]   - ClearerVoice Eraser only
  * @property {{ enabled: boolean, postEq?: { enabled: boolean, freq?: number, q?: number, gainDb: number } }} bwe - Bandwidth extension (AP-BWE); enabled for NE presets, disabled for standard presets. postEq applies a narrow bell cut after BWE to tame sibilance introduced by HF synthesis.
@@ -124,8 +124,21 @@ export const PRESETS = {
       preserve_early: true,
     },
     autoLeveler: {
-      maxGainDb:     20.0,
-      maxRateDbPerS: 10.0,
+      total_max_up_db:         5.0,
+      total_max_down_db:       6.0,
+      target_window_s:         60,
+      noise_floor_target_dbfs: -60,
+      loop_a: {
+        deadband_db: 2.0, knee_db: 1.5,
+        max_up_db: 4.0, max_down_db: 5.0,
+        attack_ms: 300, release_ms: 2000,
+      },
+      loop_b: {
+        deadband_up_db: 4.0, deadband_down_db: 3.0,
+        ratio_up: 2.0, ratio_down: 2.5,
+        max_up_db: 2.5, max_down_db: 3.0,
+        attack_ms: 200, release_ms: 1000,
+      },
     },
     saturation: {
       drive: 1.8,
@@ -275,8 +288,21 @@ export const PRESETS = {
       preserve_early: true,
     },
     autoLeveler: {
-      maxGainDb:     20.0,
-      maxRateDbPerS: 10.0,
+      total_max_up_db:         6.0,
+      total_max_down_db:       8.0,
+      target_window_s:         45,
+      noise_floor_target_dbfs: -50,
+      loop_a: {
+        deadband_db: 1.5, knee_db: 1.0,
+        max_up_db: 5.0, max_down_db: 6.0,
+        attack_ms: 200, release_ms: 1200,
+      },
+      loop_b: {
+        deadband_up_db: 3.0, deadband_down_db: 2.5,
+        ratio_up: 2.5, ratio_down: 3.0,
+        max_up_db: 3.0, max_down_db: 4.0,
+        attack_ms: 150, release_ms: 800,
+      },
     },
     saturation: {
       drive: 2.0,
@@ -380,8 +406,21 @@ export const PRESETS = {
       preserve_early: false,
     },
     autoLeveler: {
-      maxGainDb:     4.0,
-      maxRateDbPerS: 10.0,
+      total_max_up_db:         5.0,
+      total_max_down_db:       6.0,
+      target_window_s:         60,
+      noise_floor_target_dbfs: -55,
+      loop_a: {
+        deadband_db: 2.0, knee_db: 1.5,
+        max_up_db: 4.0, max_down_db: 5.0,
+        attack_ms: 300, release_ms: 2000,
+      },
+      loop_b: {
+        deadband_up_db: 4.0, deadband_down_db: 3.0,
+        ratio_up: 2.0, ratio_down: 2.5,
+        max_up_db: 2.5, max_down_db: 3.0,
+        attack_ms: 200, release_ms: 1000,
+      },
     },
     saturation: {
       drive: 2.0,
@@ -491,8 +530,21 @@ export const PRESETS = {
       preserve_early: false,
     },
     autoLeveler: {
-      maxGainDb:     8.0,
-      maxRateDbPerS: 10.0,
+      total_max_up_db:         8.0,
+      total_max_down_db:       10.0,
+      target_window_s:         30,
+      noise_floor_target_dbfs: -50,
+      loop_a: {
+        deadband_db: 1.5, knee_db: 1.0,
+        max_up_db: 6.0, max_down_db: 8.0,
+        attack_ms: 200, release_ms: 1000,
+      },
+      loop_b: {
+        deadband_up_db: 3.0, deadband_down_db: 2.5,
+        ratio_up: 2.5, ratio_down: 3.0,
+        max_up_db: 3.5, max_down_db: 4.5,
+        attack_ms: 150, release_ms: 700,
+      },
     },
     saturation: {
       drive: 2.0,
@@ -596,10 +648,7 @@ export const PRESETS = {
       strength: 'heavy',
       preserve_early: false,
     },
-    autoLeveler: {
-      maxGainDb:     4.0,
-      maxRateDbPerS: 10.0,
-    },
+    autoLeveler: null,
     saturation: {
       drive: 5,
       wetDry: 0.20,
@@ -734,8 +783,21 @@ export const PRESETS = {
     // Both models are downloaded from HuggingFace on first use.
     clearervoiceModel: 'mossformer2_48k',
     autoLeveler: {
-      maxGainDb:     8.0,
-      maxRateDbPerS: 10.0,
+      total_max_up_db:         6.0,
+      total_max_down_db:       8.0,
+      target_window_s:         45,
+      noise_floor_target_dbfs: -50,
+      loop_a: {
+        deadband_db: 1.5, knee_db: 1.0,
+        max_up_db: 5.0, max_down_db: 6.0,
+        attack_ms: 200, release_ms: 1200,
+      },
+      loop_b: {
+        deadband_up_db: 3.0, deadband_down_db: 2.5,
+        ratio_up: 2.5, ratio_down: 3.0,
+        max_up_db: 3.0, max_down_db: 4.0,
+        attack_ms: 150, release_ms: 800,
+      },
     },
     saturation: {
       drive: 2.0,


### PR DESCRIPTION
## Summary

Completely redesigned the auto-leveler stage (4b) from a simple RMS-based gain riding system to a sophisticated dual-loop control architecture using K-weighted LUFS measurements. The new system provides independent drift correction and performance compression loops that work in parallel, with improved loudness tracking and noise floor protection.

## Key Changes

- **Loudness Measurement**: Replaced frame-level RMS analysis with K-weighted LUFS curves (EBU R128 / ITU-R BS.1770-4 standard) computed over 400 ms (short-term) and 1500 ms (medium-term) windows
- **Dual-Loop Architecture**:
  - **Loop A (drift)**: Slow 1:1 correction with deadband and cubic-knee transition for gentle, continuous level tracking
  - **Loop B (performance)**: Asymmetric ratio compression for handling larger excursions with independent up/down ratios
- **VAD Hysteresis**: Implemented proper voice activity detection conditioning with configurable minimum voiced/unvoiced segment durations to eliminate false positives/negatives
- **Envelope Following**: Both loops use one-pole IIR envelope followers (attack/release times) that do NOT reset at VAD boundaries, ensuring smooth gain curves without pops
- **Noise Floor Protection**: Dynamic gain caps based on measured noise floor with configurable headroom, preventing amplification of background noise
- **Skip Conditions**: Added duration checks (minimum 20s file, 15s voiced audio) and skip when input loudness standard deviation is already below 1.5 dB
- **Preset Configuration**: Updated all preset configs with new dual-loop parameters (deadbands, knees, ratios, attack/release times, per-loop caps) replacing the old simple `maxGainDb`/`maxRateDbPerS` model

## Implementation Details

- K-weighting implemented as cascaded biquad filters (high-shelf pre-filter + high-pass filter at 38.135 Hz)
- LUFS computation uses running power sum for O(1) window queries
- Moving median target derived from voiced hops only, with configurable window size per preset
- Gain contributions from both loops sum at sample rate, then clipped to total cap before linear interpolation to sample rate
- Comprehensive measurement output including per-loop gain statistics, input/output loudness standard deviations, and noise floor cap status
- Result formatting updated to report measurements and preset parameters instead of legacy RMS-based metrics

## Files Modified

- `server/pipeline/autoLeveler.js`: Complete rewrite of algorithm and implementation
- `src/audio/presets.js`: Updated all 6 applicable presets with new dual-loop configuration structure
- `server/pipeline/index.js`: Updated result formatting for new measurement schema
- `server/pipeline/stages.js`: Updated logging to report new metrics
- `server/pipeline/riskAssessment.js`: Updated quality advisory flags for noise floor cap status

https://claude.ai/code/session_015i451CYXD2zA1qizQdwcKN