### PR TITLE
Add energy-gated boundary expansion for Silero speech detection

### DIFF
--- a/server/pipeline/frameAnalysis.js
+++ b/server/pipeline/frameAnalysis.js
@@ -185,12 +185,13 @@ async function analyzeAudioFramesSilero(wavPath) {
 
   // Step 2: energy-gated 1-frame boundary expansion
   // Silero's get_speech_timestamps operates at 512-sample (32 ms) chunk
-  // boundaries at 16 kHz. Our pipeline frames are 25 ms long. When a word
-  // onset or offset falls mid-chunk, the reported segment boundary can be up
-  // to 32 ms off, causing the straddling frame to be labelled silence even
-  // though it contains real speech. Promote such frames to voiced only when
-  // their energy is above the noise floor — confirming measurable content
-  // rather than assuming speech unconditionally at every boundary.
+  // boundaries at 16 kHz. When a word onset or offset falls mid-chunk, the
+  // reported segment boundary can be up to 32 ms off, causing the straddling
+  // frame to be labelled silence even though it contains real speech. Promote
+  // such frames to voiced only when their energy is above the noise floor —
+  // confirming measurable content rather than assuming speech unconditionally
+  // at every boundary. (Frame duration is set by FRAME_DURATION_S in
+  // frame_config.json; the 32 ms Silero chunk boundary is fixed by the model.)
   // Use raw rmsToDbfs(frameRms[...]) rather than the rounded frames[].rmsDbfs
   // to avoid threshold flips for frames that land close to noiseFloorDbfs.
   // A Set snapshot of the original labels prevents cascade: expanding frame N

--- a/server/pipeline/frameAnalysis.js
+++ b/server/pipeline/frameAnalysis.js
@@ -185,20 +185,22 @@ async function analyzeAudioFramesSilero(wavPath) {
 
   // Step 2: energy-gated 1-frame boundary expansion
   // Silero's get_speech_timestamps operates at 512-sample (32 ms) chunk
-  // boundaries at 16 kHz. Our pipeline frames are 400 samples (25 ms). When
-  // a word onset or offset falls mid-chunk, the reported segment boundary can
-  // be up to 32 ms off, causing the straddling frame to be labelled silence
-  // even though it contains real speech. Promote such frames to voiced only
-  // when their energy is above the noise floor — confirming measurable content
+  // boundaries at 16 kHz. Our pipeline frames are 25 ms long. When a word
+  // onset or offset falls mid-chunk, the reported segment boundary can be up
+  // to 32 ms off, causing the straddling frame to be labelled silence even
+  // though it contains real speech. Promote such frames to voiced only when
+  // their energy is above the noise floor — confirming measurable content
   // rather than assuming speech unconditionally at every boundary.
+  // Use raw rmsToDbfs(frameRms[...]) rather than the rounded frames[].rmsDbfs
+  // to avoid threshold flips for frames that land close to noiseFloorDbfs.
   // A Set snapshot of the original labels prevents cascade: expanding frame N
   // cannot cause frame N+1 to also expand.
   const boundaryExpansionSet = new Set()
   for (let f = 0; f < numFrames; f++) {
     if (!frames[f].isSilence) {
-      if (f > 0             && frames[f - 1].isSilence && frames[f - 1].rmsDbfs > noiseFloorDbfs)
+      if (f > 0             && frames[f - 1].isSilence && rmsToDbfs(frameRms[f - 1]) > noiseFloorDbfs)
         boundaryExpansionSet.add(f - 1)
-      if (f < numFrames - 1 && frames[f + 1].isSilence && frames[f + 1].rmsDbfs > noiseFloorDbfs)
+      if (f < numFrames - 1 && frames[f + 1].isSilence && rmsToDbfs(frameRms[f + 1]) > noiseFloorDbfs)
         boundaryExpansionSet.add(f + 1)
     }
   }

--- a/server/pipeline/frameAnalysis.js
+++ b/server/pipeline/frameAnalysis.js
@@ -163,12 +163,11 @@ async function analyzeAudioFramesSilero(wavPath) {
   }
 
   // Stage C — merge Silero labels with energy values
+
+  // Step 1: build frames with initial Silero labels
   const sileroMap = new Map(sileroFrames.map(f => [f.index, f.isSilence]))
 
   const frames = []
-  let voicedSumSq = 0
-  let voicedFrameCount = 0
-
   for (let f = 0; f < numFrames; f++) {
     const rmsDbfs = rmsToDbfs(frameRms[f])
     // Silero label takes priority; energy threshold is fallback for any
@@ -182,8 +181,36 @@ async function analyzeAudioFramesSilero(wavPath) {
       rmsDbfs:       round2(rmsDbfs),
       isSilence,
     })
+  }
 
-    if (!isSilence) {
+  // Step 2: energy-gated 1-frame boundary expansion
+  // Silero's get_speech_timestamps operates at 512-sample (32 ms) chunk
+  // boundaries at 16 kHz. Our pipeline frames are 400 samples (25 ms). When
+  // a word onset or offset falls mid-chunk, the reported segment boundary can
+  // be up to 32 ms off, causing the straddling frame to be labelled silence
+  // even though it contains real speech. Promote such frames to voiced only
+  // when their energy is above the noise floor — confirming measurable content
+  // rather than assuming speech unconditionally at every boundary.
+  // A Set snapshot of the original labels prevents cascade: expanding frame N
+  // cannot cause frame N+1 to also expand.
+  const boundaryExpansionSet = new Set()
+  for (let f = 0; f < numFrames; f++) {
+    if (!frames[f].isSilence) {
+      if (f > 0             && frames[f - 1].isSilence && frames[f - 1].rmsDbfs > noiseFloorDbfs)
+        boundaryExpansionSet.add(f - 1)
+      if (f < numFrames - 1 && frames[f + 1].isSilence && frames[f + 1].rmsDbfs > noiseFloorDbfs)
+        boundaryExpansionSet.add(f + 1)
+    }
+  }
+  for (const f of boundaryExpansionSet) {
+    frames[f].isSilence = false
+  }
+
+  // Step 3: accumulate voiced energy from expanded labels
+  let voicedSumSq = 0
+  let voicedFrameCount = 0
+  for (let f = 0; f < numFrames; f++) {
+    if (!frames[f].isSilence) {
       voicedSumSq += frameRms[f] * frameRms[f]
       voicedFrameCount++
     }


### PR DESCRIPTION
## Summary
Improved speech/silence detection accuracy by adding an energy-gated boundary expansion step that corrects Silero's frame-boundary misalignment issues while avoiding false positives.

## Key Changes
- **Refactored frame analysis into three distinct steps:**
  1. Build initial frames with Silero labels
  2. Apply energy-gated boundary expansion (new)
  3. Accumulate voiced energy statistics

- **Implemented boundary expansion logic:**
  - Detects silence frames adjacent to voiced frames that may be mislabeled due to Silero's 512-sample (32 ms) chunk boundaries not aligning with our 400-sample (25 ms) pipeline frames
  - Promotes adjacent silence frames to voiced only when their RMS energy exceeds the noise floor, confirming real speech content rather than assuming speech unconditionally
  - Uses a Set snapshot of original labels to prevent cascading expansions

- **Moved voiced energy accumulation** to occur after boundary expansion, ensuring statistics reflect the corrected labels

## Implementation Details
The boundary expansion addresses a known limitation where Silero's `get_speech_timestamps()` operates at 512-sample boundaries, causing up to 32 ms misalignment with our 25 ms frames. When word onsets/offsets fall mid-chunk, adjacent frames can be incorrectly labeled as silence. The energy gate prevents false positives by only promoting frames with measurable acoustic content above the noise floor.

https://claude.ai/code/session_01YEJybpVHU4mAjWvUMqiCS6