### PR TITLE
Add clip-gain de-esser as alternative to compressor-based de-esser

### DIFF
--- a/server/pipeline/clipGainDeEsser.js
+++ b/server/pipeline/clipGainDeEsser.js
@@ -1,0 +1,169 @@
+/**
+ * Clip-gain de-esser pipeline module.
+ *
+ * Two-pass alternative to the compressor-based deEsser:
+ *
+ *   1. Detection — the shared sibilance detector is asked for the event map
+ *      with `min_duration_ms` set, so brief consonant stops and click
+ *      residuals are filtered out.
+ *   2. Gain pass — clip_gain_deesser.py reads the audio and the enriched
+ *      event map (per-event peak sample / dB / type), computes a per-event
+ *      target gain relative to the surrounding voiced RMS, and renders a
+ *      cosine-fade gain envelope that's multiplied against the file.
+ *
+ * No time constants. Each event gets a uniform gain reduction across its
+ * body, framed by half-Hann fades that prevent clicks at the boundaries.
+ */
+
+import { spawn }                 from 'child_process'
+import { fileURLToPath }         from 'url'
+import { readFile, writeFile, rm } from 'fs/promises'
+import os                        from 'os'
+import path                      from 'path'
+import { PYTHON as SHARED_PYTHON } from './spawnPython.js'
+
+const CLIP_GAIN_PYTHON = process.env.CLIP_GAIN_DEESSER_PYTHON ?? SHARED_PYTHON
+const NUM_THREADS      = process.env.TORCH_NUM_THREADS ?? String(os.cpus().length)
+
+const SCRIPTS_DIR  = path.join(path.dirname(fileURLToPath(import.meta.url)), '..', 'scripts')
+const SCRIPT_PATH  = path.join(SCRIPTS_DIR, 'clip_gain_deesser.py')
+
+/**
+ * @typedef {Object} ClipGainDeEsserConfig
+ * @property {boolean} [enabled]
+ * @property {number}  [naturalCeilingDb]
+ * @property {number}  [reductionRatio]
+ * @property {number}  [maxReductionDb]
+ * @property {number}  [contextWindowMs]
+ * @property {{
+ *   fricativeInMs?:  number,
+ *   fricativeOutMs?: number,
+ *   affricateInMs?:  number,
+ *   affricateOutMs?: number,
+ * }} [fades]
+ */
+
+/**
+ * Run the clip-gain de-esser.
+ *
+ * @param {string} inputPath
+ * @param {string} outputPath
+ * @param {string} eventsJsonPath   - Path to the event map written by
+ *                                    analyze_sibilance_events.py. The map's
+ *                                    events must include startSample,
+ *                                    endSample, peakSample, eventPeakDb,
+ *                                    eventType (i.e. produced by a detector
+ *                                    pass where `audio` was supplied).
+ * @param {ClipGainDeEsserConfig} config
+ * @param {Array}  [vadFrames]      - Frame list from frameAnalysis (used as
+ *                                    the voiced/silence reference for context
+ *                                    RMS measurement).
+ * @returns {Promise<object>}
+ */
+export async function applyClipGainDeEsser(
+  inputPath,
+  outputPath,
+  eventsJsonPath,
+  config,
+  vadFrames = null,
+) {
+  const fades = config.fades ?? {}
+  const args  = [
+    SCRIPT_PATH,
+    '--input',                  inputPath,
+    '--output',                 outputPath,
+    '--events-json',            eventsJsonPath,
+    '--natural-ceiling-db',     String(config.naturalCeilingDb     ?? 7.0),
+    '--reduction-ratio',        String(config.reductionRatio       ?? 0.55),
+    '--max-reduction-db',       String(config.maxReductionDb       ?? 7.0),
+    '--context-window-ms',      String(config.contextWindowMs      ?? 80.0),
+    '--fricative-fade-in-ms',   String(fades.fricativeInMs         ?? 3.0),
+    '--fricative-fade-out-ms',  String(fades.fricativeOutMs        ?? 4.0),
+    '--affricate-fade-in-ms',   String(fades.affricateInMs         ?? 1.5),
+    '--affricate-fade-out-ms',  String(fades.affricateOutMs        ?? 4.5),
+  ]
+
+  let vadMaskPath = null
+  if (vadFrames && vadFrames.length > 0) {
+    vadMaskPath = await writeTempJson(vadFrames)
+    args.push('--vad-mask-json', vadMaskPath)
+  }
+
+  try {
+    return await runScript(args)
+  } finally {
+    if (vadMaskPath) await rm(vadMaskPath, { force: true })
+  }
+}
+
+async function writeTempJson(payload) {
+  const { tempPath } = await import('../lib/ffmpeg.js')
+  const p = tempPath('.json')
+  await writeFile(p, JSON.stringify(payload))
+  return p
+}
+
+function runScript(args) {
+  return new Promise((resolve, reject) => {
+    const proc = spawn(CLIP_GAIN_PYTHON, args, {
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env: {
+        ...process.env,
+        OMP_NUM_THREADS:   NUM_THREADS,
+        MKL_NUM_THREADS:   NUM_THREADS,
+        TORCH_NUM_THREADS: NUM_THREADS,
+      },
+    })
+
+    let stdout = ''
+    let stderr = ''
+    let stdoutBuffer = ''
+
+    proc.stdout.on('data', chunk => {
+      const text   = chunk.toString()
+      stdout      += text
+      stdoutBuffer += text
+      const lines  = stdoutBuffer.split('\n')
+      stdoutBuffer = lines.pop()
+      for (const line of lines) {
+        if (line.trim() && !line.startsWith('JSON_RESULT:')) {
+          console.log(`[ClipGainDeEsser] ${line}`)
+        }
+      }
+    })
+
+    proc.stderr.on('data', chunk => {
+      stderr += chunk.toString()
+      if (stderr.length > 4000) stderr = stderr.slice(-4000)
+    })
+
+    proc.on('close', (code, signal) => {
+      if (stdoutBuffer.trim() && !stdoutBuffer.startsWith('JSON_RESULT:')) {
+        console.log(`[ClipGainDeEsser] ${stdoutBuffer.trim()}`)
+      }
+      if (stderr.trim() && code === 0) console.log(`[ClipGainDeEsser] ${stderr.trim()}`)
+
+      if (code === 0 && signal === null) {
+        const line = stdout.split('\n').find(l => l.startsWith('JSON_RESULT:'))
+        if (!line) {
+          reject(new Error('clip_gain_deesser: exited 0 but emitted no JSON_RESULT line'))
+          return
+        }
+        try {
+          resolve(JSON.parse(line.slice('JSON_RESULT:'.length)))
+        } catch (err) {
+          reject(new Error(`clip_gain_deesser: failed to parse JSON_RESULT: ${err.message}`))
+        }
+      } else {
+        const parts = []
+        if (code   !== null) parts.push(`code ${code}`)
+        if (signal !== null) parts.push(`signal ${signal}`)
+        reject(new Error(`clip_gain_deesser exited with ${parts.join(', ')}.\n${stderr.slice(-2000)}`))
+      }
+    })
+
+    proc.on('error', err => {
+      reject(new Error(`Failed to spawn clip_gain_deesser: ${err.message}`))
+    })
+  })
+}

--- a/server/pipeline/index.js
+++ b/server/pipeline/index.js
@@ -160,6 +160,7 @@ function buildReport(ctx) {
       ...(results.airBoost       && { air_boost:          formatAirBoostResult(results.airBoost) }),
       ...(results.roomTonePad    && { room_tone_padding:  formatRoomToneResult(results.roomTonePad) }),
       ...(results.deEss          && { de_esser:           formatDeEssResult(results.deEss) }),
+      ...(results.clipGainDeEsser && { clip_gain_de_esser: formatClipGainDeEsserResult(results.clipGainDeEsser) }),
       ...(results.autoLeveler         && { auto_leveler:         formatAutoLevelerResult(results.autoLeveler) }),
       ...(results.compression         && { compression:           formatCompressionResult(results.compression) }),
       ...(results.parallelCompression && { parallel_compression:  formatParallelCompressionResult(results.parallelCompression) }),
@@ -284,6 +285,28 @@ function formatDeEssResult(r) {
     p95_energy_db:    r.p95EnergyDb,
     mean_energy_db:   r.meanEnergyDb,
     trigger_reason:   r.triggerReason,
+  }
+}
+
+function formatClipGainDeEsserResult(r) {
+  if (!r) return null
+  if (!r.applied) {
+    return {
+      applied:        false,
+      skipped_reason: r.reason ?? null,
+      event_count:    r.eventCount ?? 0,
+    }
+  }
+  return {
+    applied:             true,
+    event_count:         r.eventCount,
+    treated_count:       r.treatedCount,
+    skipped_in_range:    r.skippedInRange,
+    skipped_no_context:  r.skippedNoContext,
+    max_reduction_db:    r.maxReductionDb,
+    natural_ceiling_db:  r.naturalCeilingDb,
+    reduction_ratio:     r.reductionRatio,
+    max_reduction_cap_db: r.maxReductionCapDb,
   }
 }
 

--- a/server/pipeline/pipelines.js
+++ b/server/pipeline/pipelines.js
@@ -39,6 +39,7 @@ const STANDARD_PIPELINE = [
   stages.bandwidthExtension,      // HF restoration/ enhacement (enabled per preset.bwe; no-op when disabled)
   stages.vocalSaturation,
   stages.vadGate,                 // Smooth VAD-driven silence-floor gate (no-op when preset.vadGate.enabled is false)
+  stages.clipGainDeEss,           // Clip-gain de-esser — per-event sibilant attenuation via cosine envelopes
   stages.remeasureFramesPostNr,   // Recalculate noise floor and update ctx.results.metrics before autoLevel + compression
   stages.compress,                // Serial compression
   stages.remeasureFramesPostNr,   // Refresh noise floor after compression so second NR skip-check is accurate

--- a/server/pipeline/stages.js
+++ b/server/pipeline/stages.js
@@ -39,6 +39,7 @@ import { analyzeSpectrum } from './enhancementEQ.js'
 import { applyRoomTonePadding } from './roomTone.js'
 import { generateQualityAdvisory } from './riskAssessment.js'
 import { analyzeAndDeEss } from './deEsser.js'
+import { applyClipGainDeEsser } from './clipGainDeEsser.js'
 import { applyCompression } from './compression.js'
 import { runSeparation, runClearerVoice } from './separation.js'
 import { writeFile } from 'fs/promises'
@@ -708,6 +709,75 @@ export async function deEss(ctx) {
     applied:   deEssResult.applied,
     f0:        deEssResult.f0Hz        !== null ? `${deEssResult.f0Hz}Hz`           : 'n/a',
     maxRed:    deEssResult.maxReductionDb !== null ? `${deEssResult.maxReductionDb}dB` : 'n/a',
+  })
+}
+
+// ── Stage: Clip-Gain De-esser ─────────────────────────────────────────────────
+// Alternative to the compressor-based de-esser. Two passes:
+//   1. Sibilance detection with min_duration_ms set so brief consonant stops
+//      and click residuals are filtered out before any gain is calculated.
+//   2. Per-event gain reduction relative to the surrounding voiced RMS,
+//      rendered as a cosine fade envelope and applied in a single vectorised
+//      multiply.
+//
+// Skips silently when preset.clipGainDeEsser is absent or .enabled is false,
+// or when the detector returns no events that survive the duration filter.
+
+export async function clipGainDeEss(ctx) {
+  const config = ctx.preset?.clipGainDeEsser
+  if (!config || config.enabled === false) {
+    ctx.results.clipGainDeEsser = { applied: false, reason: 'preset_not_configured' }
+    return
+  }
+
+  const minDurationMs = config.minDurationMs ?? 25
+
+  // Detection runs on the current (post-EQ, pre-compression) signal so the
+  // event peaks reflect the audio about to receive the gain pass. F0 contour
+  // is computed fresh because earlier stages may have shifted the spectrum
+  // since the last contour call.
+  const f0Contour = await getF0Contour(ctx)
+
+  // Merge the preset's sibilance detection block (if any) with the
+  // min_duration_ms override the clip-gain stage requires.
+  const detectionParams = {
+    ...(config.sibilanceDetection ?? {}),
+    min_duration_ms: minDurationMs,
+  }
+
+  const { events, path: eventsPath } = await analyzeSibilanceEvents(ctx, {
+    params:    detectionParams,
+    f0Contour,
+  })
+
+  if (!events?.events?.length) {
+    ctx.results.clipGainDeEsser = {
+      applied:    false,
+      reason:     'no_events',
+      eventCount: 0,
+    }
+    ctx.log(`[clip-gain-deess] No events ≥ ${minDurationMs}ms detected — skipped`)
+    return
+  }
+
+  const outPath = ctx.tmp('.wav')
+  const result  = await applyClipGainDeEsser(
+    ctx.currentPath,
+    outPath,
+    eventsPath,
+    config,
+    ctx.results.metrics?.frames ?? null,
+  )
+
+  if (result.applied) ctx.currentPath = outPath
+  ctx.results.clipGainDeEsser = result
+
+  await logLevel(ctx, 'after clip-gain de-esser', ctx.currentPath, {
+    applied:    result.applied,
+    treated:    `${result.treatedCount}/${result.eventCount}`,
+    skipInRng:  result.skippedInRange,
+    skipNoCtx:  result.skippedNoContext,
+    maxRed:     result.maxReductionDb != null ? `${result.maxReductionDb}dB` : 'n/a',
   })
 }
 

--- a/server/pipeline/stages.js
+++ b/server/pipeline/stages.js
@@ -732,10 +732,13 @@ export async function clipGainDeEss(ctx) {
 
   const minDurationMs = config.minDurationMs ?? 25
 
-  // Detection runs on the current (post-EQ, pre-compression) signal so the
-  // event peaks reflect the audio about to receive the gain pass. F0 contour
-  // is computed fresh because earlier stages may have shifted the spectrum
-  // since the last contour call.
+  // Detection runs on the pre-compression signal — per the spec, this stage
+  // sits before the pre-compression remeasurement. Stages that further shape
+  // sibilants (airBoost, enhancementEQ) come AFTER this point in
+  // STANDARD_PIPELINE, so any HF lift they apply does not feed back into
+  // the gain calculation here; the de-essed result still passes through them
+  // downstream. F0 contour is computed fresh because earlier stages may have
+  // shifted the spectrum since the last contour call.
   const f0Contour = await getF0Contour(ctx)
 
   // Merge the preset's sibilance detection block (if any) with the

--- a/server/scripts/analyze_sibilance_events.py
+++ b/server/scripts/analyze_sibilance_events.py
@@ -64,6 +64,12 @@ if __name__ == "__main__":
         audio = audio.astype(np.float32) / np.iinfo(audio.dtype).max
     else:
         audio = audio.astype(np.float32)
+    # Detection runs on mono; fold stereo down before handing the array to
+    # analyze_sibilance_events (which rejects ndim > 1). Presets whose
+    # channelOutput is 'preserve' may legitimately still be stereo at the
+    # point a downstream stage runs the detector.
+    if audio.ndim == 2:
+        audio = audio.mean(axis=1).astype(np.float32)
 
     with open(args.f0_contour_json) as fh:
         f0_contour = json.load(fh)

--- a/server/scripts/clip_gain_deesser.py
+++ b/server/scripts/clip_gain_deesser.py
@@ -52,15 +52,27 @@ logger = logging.getLogger(__name__)
 # Helpers
 # ---------------------------------------------------------------------------
 
-def _read_wav_mono_float32(path: str):
+def _read_wav_float32(path: str):
+    """
+    Returns (sr, audio_2d, was_stereo). audio_2d has shape (n_samples, n_channels);
+    mono inputs come back as (n_samples, 1) so the same code path handles both.
+    Channel preservation matters for presets whose channelOutput is 'preserve'.
+    """
     sr, audio = wavfile.read(path)
-    if audio.ndim == 2:
-        audio = audio.mean(axis=1)
     if np.issubdtype(audio.dtype, np.integer):
         audio = audio.astype(np.float32) / np.iinfo(audio.dtype).max
     else:
         audio = audio.astype(np.float32)
-    return sr, audio
+    if audio.ndim == 1:
+        return sr, audio[:, None], False
+    return sr, audio, True
+
+
+def _mono_view(audio_2d: np.ndarray) -> np.ndarray:
+    """Mono mixdown for detection / context-RMS measurement only."""
+    if audio_2d.shape[1] == 1:
+        return audio_2d[:, 0]
+    return audio_2d.mean(axis=1).astype(np.float32)
 
 
 def _build_sibilant_sample_mask(events: list, n_samples: int) -> np.ndarray:
@@ -181,12 +193,14 @@ def _render_event_envelope(
     body_start = min(n, event_start + fade_in)
     body_end   = max(body_start, event_end - fade_out + 1)
 
-    # Fade-in: unity at event_start, gain_linear at body_start
+    # Fade-in: unity at event_start, gain_linear at body_start. ramp goes
+    # 0 -> 1 across the fade window, so seg interpolates from 1.0 down to
+    # gain_linear (zero derivative at both endpoints).
     if fade_in > 0 and event_start < n:
         a = max(0, event_start)
         b = min(n, event_start + fade_in)
         if b > a:
-            ramp = _cosine_fade(b - a, rising=False)  # 1 -> 0 in normalised form
+            ramp = _cosine_fade(b - a, rising=True)
             seg  = (1.0 - ramp) * 1.0 + ramp * gain_linear
             multiplier[a:b] *= seg.astype(multiplier.dtype)
 
@@ -227,8 +241,13 @@ def main() -> int:
     parser.add_argument("--affricate-fade-out-ms", type=float, default=4.5)
     args = parser.parse_args()
 
-    sr, audio = _read_wav_mono_float32(args.input)
-    n_samples = audio.shape[0]
+    sr, audio_2d, was_stereo = _read_wav_float32(args.input)
+    n_samples = audio_2d.shape[0]
+    # Detection / context-RMS / event-peak comparison all run on a mono
+    # mixdown so a centred sibilant doesn't get measured twice. The gain
+    # envelope is later applied to every channel, preserving stereo layout
+    # for presets where channelOutput is 'preserve'.
+    audio = _mono_view(audio_2d)
 
     with open(args.events_json, "r") as fh:
         event_map = json.load(fh)
@@ -327,9 +346,11 @@ def main() -> int:
             "gainDb":       round(gain_db, 2),
         })
 
-    # Vectorised single-pass apply.
-    processed = (audio.astype(np.float32) * multiplier).astype(np.float32)
-    wavfile.write(args.output, sr, processed)
+    # Vectorised single-pass apply. Multiplier is per-sample, broadcast
+    # across channels so stereo layout is preserved.
+    processed_2d = (audio_2d.astype(np.float32) * multiplier[:, None]).astype(np.float32)
+    out = processed_2d[:, 0] if not was_stereo else processed_2d
+    wavfile.write(args.output, sr, out)
 
     summary = {
         "applied":            len(treated_events) > 0,

--- a/server/scripts/clip_gain_deesser.py
+++ b/server/scripts/clip_gain_deesser.py
@@ -1,0 +1,352 @@
+"""
+clip_gain_deesser.py
+Clip-gain de-esser. Per-event gain reduction rendered as a cosine fade
+envelope multiplied against the audio. No time constants, no compressor
+sidechain -- two discrete passes:
+
+  1. Read the sibilance event map (produced by analyze_sibilance_events.py
+     with min_duration_ms set so brief consonant stops are filtered out).
+  2. For each event compute a target gain reduction relative to the RMS of
+     surrounding voiced (non-sibilant) speech, then accumulate a cosine fade
+     envelope into a per-sample multiplier array. The whole array is applied
+     to the audio in a single vectorised pass.
+
+Inputs (CLI):
+  --input             32-bit float mono WAV at 44.1 kHz
+  --output            Output WAV (mono float32)
+  --events-json       Event map JSON (must contain per-event peak metadata:
+                      startSample/endSample/peakSample/peakRelativePosition/
+                      eventPeakDb/eventType). Produced by
+                      analyze_sibilance_events.py with min_duration_ms >= 25.
+  --vad-mask-json     Optional frame-list JSON (offsetSamples, lengthSamples,
+                      isSilence). Used to identify voiced frames for the
+                      context RMS measurement. When absent the script falls
+                      back to "any frame that is not part of a sibilant event"
+                      as the voiced context.
+  --natural-ceiling-db
+  --reduction-ratio
+  --max-reduction-db
+  --context-window-ms (default 80)
+  --fricative-fade-in-ms / --fricative-fade-out-ms
+  --affricate-fade-in-ms / --affricate-fade-out-ms
+
+Output: rewrites the WAV with the gain envelope applied. Emits a single
+JSON_RESULT: line summarising treated event counts and max reduction.
+
+Dependencies: numpy, scipy
+"""
+
+import argparse
+import json
+import logging
+import sys
+
+import numpy as np
+from scipy.io import wavfile
+
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _read_wav_mono_float32(path: str):
+    sr, audio = wavfile.read(path)
+    if audio.ndim == 2:
+        audio = audio.mean(axis=1)
+    if np.issubdtype(audio.dtype, np.integer):
+        audio = audio.astype(np.float32) / np.iinfo(audio.dtype).max
+    else:
+        audio = audio.astype(np.float32)
+    return sr, audio
+
+
+def _build_sibilant_sample_mask(events: list, n_samples: int) -> np.ndarray:
+    """Boolean mask over samples where any sibilant event is active."""
+    mask = np.zeros(n_samples, dtype=bool)
+    for ev in events:
+        s = max(0, int(ev.get("startSample", 0)))
+        e = min(n_samples - 1, int(ev.get("endSample", s)))
+        if e >= s:
+            mask[s : e + 1] = True
+    return mask
+
+
+def _build_voiced_sample_mask(vad_frames: list, n_samples: int):
+    """Boolean mask over samples that VAD flagged as voiced (isSilence false)."""
+    if vad_frames is None:
+        return None
+    mask = np.zeros(n_samples, dtype=bool)
+    for fr in vad_frames:
+        if fr.get("isSilence"):
+            continue
+        s = int(fr["offsetSamples"])
+        e = min(n_samples, s + int(fr["lengthSamples"]))
+        if e > s:
+            mask[s:e] = True
+    return mask
+
+
+def _context_rms_db(
+    audio: np.ndarray,
+    event_start: int,
+    event_end: int,
+    window_samples: int,
+    sibilant_mask: np.ndarray,
+    voiced_mask,
+) -> float:
+    """
+    Mean-square energy of the voiced non-sibilant samples in a ±window around
+    the event. Returns None when no usable context is found (utterance bounded
+    by sibilants or silence on both sides).
+
+    Flexible window: takes whatever voiced non-sibilant samples are available
+    on either side of the event, so utterance-initial and utterance-final
+    sibilants fall back to the single available side cleanly.
+    """
+    n = audio.shape[0]
+    pre_start  = max(0, event_start - window_samples)
+    pre_end    = event_start
+    post_start = event_end + 1
+    post_end   = min(n, event_end + 1 + window_samples)
+
+    def _slice_mask(start, end):
+        if end <= start:
+            return None
+        m = np.ones(end - start, dtype=bool)
+        m &= ~sibilant_mask[start:end]
+        if voiced_mask is not None:
+            m &= voiced_mask[start:end]
+        return m
+
+    samples = []
+    pre_m = _slice_mask(pre_start, pre_end)
+    if pre_m is not None and pre_m.any():
+        samples.append(audio[pre_start:pre_end][pre_m])
+    post_m = _slice_mask(post_start, post_end)
+    if post_m is not None and post_m.any():
+        samples.append(audio[post_start:post_end][post_m])
+
+    if not samples:
+        return None
+    ctx = np.concatenate(samples)
+    if ctx.size == 0:
+        return None
+    rms = float(np.sqrt(np.mean(ctx.astype(np.float64) ** 2)) + 1e-12)
+    return 20.0 * np.log10(rms + 1e-12)
+
+
+def _cosine_fade(length: int, *, rising: bool) -> np.ndarray:
+    """
+    Half-Hann (cosine) ramp of `length` samples from 0->1 (rising) or 1->0
+    (falling). Zero derivative at both endpoints — avoids the click a linear
+    fade produces at its inflection point.
+    """
+    if length <= 0:
+        return np.zeros(0, dtype=np.float32)
+    t = np.linspace(0.0, np.pi, length, endpoint=True, dtype=np.float64)
+    ramp = (1.0 - np.cos(t)) * 0.5
+    if not rising:
+        ramp = 1.0 - ramp
+    return ramp.astype(np.float32)
+
+
+def _render_event_envelope(
+    multiplier:    np.ndarray,
+    event_start:   int,
+    event_end:     int,
+    gain_linear:   float,
+    fade_in:       int,
+    fade_out:      int,
+) -> None:
+    """
+    Accumulate an event's gain envelope into the file-wide multiplier array
+    (initialised to 1.0).
+
+    Shape:
+        Unity ──┐                              ┌── Unity
+                └── [cosine fade] ── [flat] ── [cosine fade]
+                                      ↑
+                                gain_linear held
+                                across body
+
+    To accumulate multiple overlapping events correctly we MULTIPLY the
+    rendered envelope into the array (rather than overwrite). Overlapping
+    events compound, which is the right behaviour: two simultaneous sibilants
+    should both contribute to reduction.
+    """
+    n = multiplier.shape[0]
+    body_start = min(n, event_start + fade_in)
+    body_end   = max(body_start, event_end - fade_out + 1)
+
+    # Fade-in: unity at event_start, gain_linear at body_start
+    if fade_in > 0 and event_start < n:
+        a = max(0, event_start)
+        b = min(n, event_start + fade_in)
+        if b > a:
+            ramp = _cosine_fade(b - a, rising=False)  # 1 -> 0 in normalised form
+            seg  = (1.0 - ramp) * 1.0 + ramp * gain_linear
+            multiplier[a:b] *= seg.astype(multiplier.dtype)
+
+    # Flat body
+    if body_end > body_start:
+        a = max(0, body_start)
+        b = min(n, body_end)
+        if b > a:
+            multiplier[a:b] *= gain_linear
+
+    # Fade-out: gain_linear at body_end, unity at event_end + 1
+    if fade_out > 0 and event_end + 1 <= n:
+        a = max(0, event_end - fade_out + 1)
+        b = min(n, event_end + 1)
+        if b > a:
+            ramp = _cosine_fade(b - a, rising=True)  # 0 -> 1
+            seg  = (1.0 - ramp) * gain_linear + ramp * 1.0
+            multiplier[a:b] *= seg.astype(multiplier.dtype)
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Clip-gain de-esser.")
+    parser.add_argument("--input",          required=True)
+    parser.add_argument("--output",         required=True)
+    parser.add_argument("--events-json",    required=True)
+    parser.add_argument("--vad-mask-json",  default=None)
+    parser.add_argument("--natural-ceiling-db", type=float, default=7.0)
+    parser.add_argument("--reduction-ratio",    type=float, default=0.55)
+    parser.add_argument("--max-reduction-db",   type=float, default=7.0)
+    parser.add_argument("--context-window-ms",  type=float, default=80.0)
+    parser.add_argument("--fricative-fade-in-ms",  type=float, default=3.0)
+    parser.add_argument("--fricative-fade-out-ms", type=float, default=4.0)
+    parser.add_argument("--affricate-fade-in-ms",  type=float, default=1.5)
+    parser.add_argument("--affricate-fade-out-ms", type=float, default=4.5)
+    args = parser.parse_args()
+
+    sr, audio = _read_wav_mono_float32(args.input)
+    n_samples = audio.shape[0]
+
+    with open(args.events_json, "r") as fh:
+        event_map = json.load(fh)
+    events = event_map.get("events", []) or []
+
+    vad_frames = None
+    if args.vad_mask_json:
+        with open(args.vad_mask_json, "r") as fh:
+            vad_frames = json.load(fh)
+
+    sibilant_mask = _build_sibilant_sample_mask(events, n_samples)
+    voiced_mask   = _build_voiced_sample_mask(vad_frames, n_samples)
+
+    window_samples = max(1, int(round((args.context_window_ms / 1000.0) * sr)))
+
+    multiplier        = np.ones(n_samples, dtype=np.float32)
+    treated_events    = []
+    skipped_in_range  = 0
+    skipped_no_ctx    = 0
+    max_reduction_db  = 0.0
+
+    for ev in events:
+        # Reject events without the sample-domain peak metadata. The
+        # caller (sibilance_detector.build_events_map) emits these fields
+        # only when `audio` was passed in; this script can't synthesize
+        # them itself.
+        if "startSample" not in ev or "eventPeakDb" not in ev:
+            logger.warning(
+                "clip_gain_deesser: event missing peak metadata — skipping"
+            )
+            continue
+
+        s = max(0, int(ev["startSample"]))
+        e = min(n_samples - 1, int(ev["endSample"]))
+        if e <= s:
+            continue
+
+        event_peak_db = float(ev["eventPeakDb"])
+        ev_type       = ev.get("eventType", "fricative")
+
+        ctx_rms_db = _context_rms_db(
+            audio, s, e,
+            window_samples,
+            sibilant_mask,
+            voiced_mask,
+        )
+        if ctx_rms_db is None:
+            skipped_no_ctx += 1
+            continue
+
+        excess_db = event_peak_db - (ctx_rms_db + args.natural_ceiling_db)
+        if excess_db <= 0:
+            skipped_in_range += 1
+            continue
+
+        gain_db = -min(excess_db * args.reduction_ratio, args.max_reduction_db)
+        gain_linear = float(10.0 ** (gain_db / 20.0))
+
+        if ev_type == "affricate":
+            fade_in_ms  = args.affricate_fade_in_ms
+            fade_out_ms = args.affricate_fade_out_ms
+        else:
+            fade_in_ms  = args.fricative_fade_in_ms
+            fade_out_ms = args.fricative_fade_out_ms
+
+        fade_in_samples  = max(1, int(round((fade_in_ms  / 1000.0) * sr)))
+        fade_out_samples = max(1, int(round((fade_out_ms / 1000.0) * sr)))
+
+        # Ensure the fades fit inside the event. If the event is too short to
+        # hold both fades, scale them down proportionally so each still gets
+        # some samples and the flat body collapses to zero length cleanly.
+        total_fades = fade_in_samples + fade_out_samples
+        event_len   = e - s + 1
+        if total_fades > event_len:
+            scale = event_len / float(total_fades)
+            fade_in_samples  = max(1, int(fade_in_samples  * scale))
+            fade_out_samples = max(1, int(fade_out_samples * scale))
+
+        _render_event_envelope(
+            multiplier,
+            event_start = s,
+            event_end   = e,
+            gain_linear = gain_linear,
+            fade_in     = fade_in_samples,
+            fade_out    = fade_out_samples,
+        )
+
+        max_reduction_db = max(max_reduction_db, abs(gain_db))
+        treated_events.append({
+            "startSec":     round(s / sr, 4),
+            "endSec":       round((e + 1) / sr, 4),
+            "durationMs":   round((e - s + 1) * 1000.0 / sr, 1),
+            "eventType":    ev_type,
+            "eventPeakDb":  round(event_peak_db, 2),
+            "contextRmsDb": round(ctx_rms_db, 2),
+            "gainDb":       round(gain_db, 2),
+        })
+
+    # Vectorised single-pass apply.
+    processed = (audio.astype(np.float32) * multiplier).astype(np.float32)
+    wavfile.write(args.output, sr, processed)
+
+    summary = {
+        "applied":            len(treated_events) > 0,
+        "eventCount":         len(events),
+        "treatedCount":       len(treated_events),
+        "skippedInRange":     skipped_in_range,
+        "skippedNoContext":   skipped_no_ctx,
+        "maxReductionDb":     round(max_reduction_db, 2) if treated_events else 0.0,
+        "treatedEvents":      treated_events,
+        "naturalCeilingDb":   args.natural_ceiling_db,
+        "reductionRatio":     args.reduction_ratio,
+        "maxReductionCapDb":  args.max_reduction_db,
+    }
+    print("JSON_RESULT:" + json.dumps(summary), flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO, stream=sys.stdout, format="%(message)s")
+    sys.exit(main())

--- a/server/scripts/sibilance_detector.py
+++ b/server/scripts/sibilance_detector.py
@@ -457,6 +457,11 @@ def analyze_sibilance_events(
                 seed_f0 = float(v)
                 break
 
+    # Resolve detection params up-front so they're available both to the
+    # detector below and to the empty-audio guard a few lines down.
+    resolved        = resolve_params(params)
+    min_duration_ms = float(resolved.get("min_duration_ms", 0.0) or 0.0)
+
     detector = SibilanceDetector(
         sample_rate=sample_rate,
         n_fft=n_fft,
@@ -475,8 +480,6 @@ def analyze_sibilance_events(
     #     get a consistent shape.
     #   - Short input (≤ pad samples): fall back to 'edge' padding (repeats
     #     the boundary sample), valid for any non-empty array.
-    resolved = resolve_params(params)
-    min_duration_ms = float(resolved.get("min_duration_ms", 0.0) or 0.0)
 
     if n_samples == 0:
         logger.warning("analyze_sibilance_events: empty audio — returning empty event map")

--- a/server/scripts/sibilance_detector.py
+++ b/server/scripts/sibilance_detector.py
@@ -66,7 +66,20 @@ DEFAULT_PARAMS = {
     "broadband_trigger_db": 10.0,
     "ema_time_constant_ms": 300.0,
     "warmup_frames":        25,
+    # Minimum event duration (ms). Events shorter than this are dropped from
+    # the returned event map entirely. Default 0 preserves backward
+    # compatibility for stages that share the detector (airBoost,
+    # resonanceSuppressor). The clip-gain de-esser sets ~25 ms so it never
+    # treats brief consonant stops or click residuals as sibilants.
+    "min_duration_ms":      0.0,
 }
+
+
+# Threshold below which an event is classified as an affricate (the percussive
+# burst portion of /tʃ/, /dʒ/, etc.) rather than a steady-state fricative. Used
+# downstream by the clip-gain de-esser to pick fade-in/-out lengths so the full
+# reduction lands before the affricate's transient peak.
+AFFRICATE_PEAK_POSITION = 0.35
 
 
 def resolve_params(overrides: dict = None) -> dict:
@@ -108,12 +121,21 @@ def build_events_map(
     sample_rate:      int,
     n_fft:            int,
     hop_length:       int,
+    audio:            np.ndarray = None,
+    min_duration_ms:  float = 0.0,
 ) -> dict:
     """
     Build the canonical sibilance event-map JSON payload.
 
     Output shape matches what air_boost_masked.py and resonance_suppressor.py
-    consume (sibilantFrameIndices + f0.perFrame + STFT geometry).
+    consume (sibilantFrameIndices + f0.perFrame + STFT geometry). When `audio`
+    is provided each event is also enriched with sample-domain peak metadata
+    (startSample/endSample/peakSample/peakRelativePosition/eventPeakDb/eventType)
+    consumed by the clip-gain de-esser.
+
+    When `min_duration_ms > 0`, events shorter than that threshold are dropped
+    and the corresponding frame indices are removed from `sibilantFrameIndices`
+    so the returned map is internally consistent.
     """
     events = []
     if sibilant_indices:
@@ -129,16 +151,63 @@ def build_events_map(
         events.append((run_start, prev))
 
     frame_period_sec = hop_length / sample_rate
-    event_objs = [
-        {
+
+    n_samples = int(audio.shape[0]) if audio is not None else None
+
+    event_objs    = []
+    kept_runs     = []
+    for s, e in events:
+        duration_ms = (e + 1 - s) * frame_period_sec * 1000.0
+        if min_duration_ms > 0 and duration_ms < min_duration_ms:
+            continue
+
+        obj = {
             "startFrame": int(s),
             "endFrame":   int(e),
             "startSec":   round(s * frame_period_sec, 4),
             "endSec":     round((e + 1) * frame_period_sec, 4),
-            "durationMs": round((e + 1 - s) * frame_period_sec * 1000.0, 1),
+            "durationMs": round(duration_ms, 1),
         }
-        for s, e in events
-    ]
+
+        if audio is not None and n_samples is not None and n_samples > 0:
+            start_sample = max(0, int(s) * hop_length)
+            end_sample   = min(n_samples - 1, (int(e) + 1) * hop_length - 1)
+            if end_sample <= start_sample:
+                end_sample = min(n_samples - 1, start_sample + 1)
+
+            seg = audio[start_sample : end_sample + 1]
+            if seg.size > 0:
+                local_peak_idx = int(np.argmax(np.abs(seg)))
+                peak_sample    = start_sample + local_peak_idx
+                peak_value     = float(np.abs(seg[local_peak_idx]))
+                peak_db        = 20.0 * np.log10(peak_value + 1e-12)
+            else:
+                peak_sample = start_sample
+                peak_db     = -120.0
+
+            span = max(1, end_sample - start_sample)
+            peak_rel_pos = float(peak_sample - start_sample) / float(span)
+            event_type   = "affricate" if peak_rel_pos < AFFRICATE_PEAK_POSITION else "fricative"
+
+            obj.update({
+                "startSample":          int(start_sample),
+                "endSample":            int(end_sample),
+                "peakSample":           int(peak_sample),
+                "peakRelativePosition": round(peak_rel_pos, 4),
+                "eventPeakDb":          round(peak_db, 2),
+                "eventType":            event_type,
+            })
+
+        event_objs.append(obj)
+        kept_runs.append((s, e))
+
+    # When events were filtered out, sync sibilantFrameIndices so downstream
+    # consumers that read raw frame indices see a consistent view.
+    if min_duration_ms > 0 and len(kept_runs) != len(events):
+        kept_indices = []
+        for s, e in kept_runs:
+            kept_indices.extend(range(int(s), int(e) + 1))
+        sibilant_indices = kept_indices
 
     return {
         "sampleRate":           sample_rate,
@@ -392,7 +461,7 @@ def analyze_sibilance_events(
         sample_rate=sample_rate,
         n_fft=n_fft,
         hop_length=hop_length,
-        params=resolve_params(params),
+        params=resolved,
         f0=seed_f0,
     )
 
@@ -406,6 +475,9 @@ def analyze_sibilance_events(
     #     get a consistent shape.
     #   - Short input (≤ pad samples): fall back to 'edge' padding (repeats
     #     the boundary sample), valid for any non-empty array.
+    resolved = resolve_params(params)
+    min_duration_ms = float(resolved.get("min_duration_ms", 0.0) or 0.0)
+
     if n_samples == 0:
         logger.warning("analyze_sibilance_events: empty audio — returning empty event map")
         return build_events_map(
@@ -416,6 +488,8 @@ def analyze_sibilance_events(
             sample_rate      = sample_rate,
             n_fft            = n_fft,
             hop_length       = hop_length,
+            audio            = audio,
+            min_duration_ms  = min_duration_ms,
         )
 
     pad_mode = "reflect" if n_samples > pad else "edge"
@@ -467,6 +541,8 @@ def analyze_sibilance_events(
         sample_rate      = sample_rate,
         n_fft            = n_fft,
         hop_length       = hop_length,
+        audio            = audio,
+        min_duration_ms  = min_duration_ms,
     )
 
     logger.info(

--- a/src/audio/presets.js
+++ b/src/audio/presets.js
@@ -302,6 +302,24 @@ export const PRESETS = {
       maxReduction: 12,
       ratio: 3,
     },
+    // Clip-gain de-esser — ACX Audiobook tuning. Transparent: low ceiling
+    // but a hard 6 dB reduction cap so even spikes never get hammered enough
+    // to call attention to the de-esser. 25 ms duration filter excludes
+    // consonant stops and click residuals.
+    clipGainDeEsser: {
+      enabled: true,
+      naturalCeilingDb: 6.5,
+      reductionRatio:   0.55,
+      maxReductionDb:   6.0,
+      minDurationMs:    25,
+      contextWindowMs:  80,
+      fades: {
+        fricativeInMs:  3.0,
+        fricativeOutMs: 4.0,
+        affricateInMs:  1.5,
+        affricateOutMs: 4.5,
+      },
+    },
     roomPresence: {
       enabled: true,
       wet: 0.10, // 0.12 - reverb tail sits ~17dB below direct
@@ -347,6 +365,24 @@ export const PRESETS = {
       trigger: 6,
       maxReduction: 4,
       ratio: 6.7,
+    },
+    // Clip-gain de-esser — Podcast Ready tuning. Higher ceiling (more
+    // permissive of bright sibilants because podcast voices sit further
+    // forward) but a slightly larger cap so loud /s/ on a peaky mic still
+    // gets pulled in.
+    clipGainDeEsser: {
+      enabled: true,
+      naturalCeilingDb: 8.0,
+      reductionRatio:   0.55,
+      maxReductionDb:   8.0,
+      minDurationMs:    25,
+      contextWindowMs:  80,
+      fades: {
+        fricativeInMs:  3.0,
+        fricativeOutMs: 4.0,
+        affricateInMs:  1.5,
+        affricateOutMs: 4.5,
+      },
     },
     channelOutput: "preserve",
     defaultOutputProfile: "podcast",
@@ -489,6 +525,25 @@ export const PRESETS = {
       trigger: 8,
       maxReduction: 5,
       ratio: 6.7,
+    },
+    // Clip-gain de-esser — Voice Ready tuning. Broadcast-neutral character:
+    // moderate ceiling and cap, identical fade shape to ACX. Voice Ready
+    // outputs typically sit under music beds, so leaving sibilance present
+    // and natural rather than dulling it is worth a slightly higher ceiling
+    // than ACX.
+    clipGainDeEsser: {
+      enabled: true,
+      naturalCeilingDb: 7.0,
+      reductionRatio:   0.55,
+      maxReductionDb:   7.0,
+      minDurationMs:    25,
+      contextWindowMs:  80,
+      fades: {
+        fricativeInMs:  3.0,
+        fricativeOutMs: 4.0,
+        affricateInMs:  1.5,
+        affricateOutMs: 4.5,
+      },
     },
     channelOutput: "mono",
     defaultOutputProfile: "acx",
@@ -639,6 +694,23 @@ export const PRESETS = {
       trigger: 6,
       maxReduction: 8,
       ratio: 6.7,
+    },
+    // Clip-gain de-esser — General Clean tuning. Slightly more aggressive
+    // ratio (0.60) since this preset accepts heavier processing in exchange
+    // for handling unknown source material safely.
+    clipGainDeEsser: {
+      enabled: true,
+      naturalCeilingDb: 7.0,
+      reductionRatio:   0.60,
+      maxReductionDb:   8.0,
+      minDurationMs:    25,
+      contextWindowMs:  80,
+      fades: {
+        fricativeInMs:  3.0,
+        fricativeOutMs: 4.0,
+        affricateInMs:  1.5,
+        affricateOutMs: 4.5,
+      },
     },
     channelOutput: "preserve",
     defaultOutputProfile: "podcast",


### PR DESCRIPTION
## Summary

Introduces a new clip-gain de-esser stage as an alternative to the existing compressor-based de-esser. This is a two-pass approach: sibilance detection with duration filtering, followed by per-event gain reduction rendered as cosine-fade envelopes and applied in a single vectorized multiply. No time constants or compressor sidechain.

## Key Changes

- **New Python script** (`server/scripts/clip_gain_deesser.py`): Core de-esser implementation
  - Reads sibilance event map with per-event peak metadata (startSample, endSample, peakSample, eventPeakDb, eventType)
  - Computes target gain reduction relative to surrounding voiced (non-sibilant) RMS
  - Renders cosine-fade envelopes (half-Hann ramps) to prevent clicks at event boundaries
  - Supports separate fade parameters for fricatives vs. affricates
  - Applies gain envelope in a single vectorized pass

- **New Node.js pipeline module** (`server/pipeline/clipGainDeEsser.js`): Orchestrates the Python script
  - Spawns the de-esser process with configurable parameters
  - Handles optional VAD mask JSON for voiced/silence context
  - Parses JSON_RESULT output and returns processing summary

- **Enhanced sibilance detector** (`server/scripts/sibilance_detector.py`):
  - Added `min_duration_ms` parameter to filter out brief consonant stops and click residuals
  - New `AFFRICATE_PEAK_POSITION` threshold (0.35) to classify events as affricates vs. fricatives based on peak position within the event
  - When `audio` is provided to `build_events_map()`, enriches events with sample-domain peak metadata (startSample, endSample, peakSample, peakRelativePosition, eventPeakDb, eventType)
  - Syncs `sibilantFrameIndices` when events are filtered by duration so downstream consumers see a consistent view

- **New pipeline stage** (`server/pipeline/stages.js`): `clipGainDeEss()` function
  - Runs sibilance detection with `min_duration_ms` override (default 25 ms)
  - Skips silently when preset config is absent or disabled, or when no events survive duration filter
  - Passes VAD frame data as voiced context reference
  - Logs treatment summary (event count, skip reasons, max reduction)

- **Preset configurations** (`src/audio/presets.js`): Added `clipGainDeEsser` config to all four presets
  - ACX Audiobook: 6.5 dB ceiling, 6.0 dB cap (transparent)
  - Podcast Ready: 8.0 dB ceiling, 8.0 dB cap (more permissive)
  - Voice Ready: 7.0 dB ceiling, 7.0 dB cap (broadcast-neutral)
  - General Clean: 7.0 dB ceiling, 8.0 dB cap, 0.60 ratio (slightly more aggressive)
  - All presets: 25 ms duration filter, 80 ms context window, consistent fade shapes

- **Pipeline integration** (`server/pipeline/pipelines.js`): Added `clipGainDeEss` stage to standard pipeline (runs post-EQ, pre-compression)

- **Report formatting** (`server/pipeline/index.js`): Added `formatClipGainDeEsserResult()` to include de-esser results in processing report

## Implementation Details

- **Event filtering**: Events shorter than `min_duration_ms` are dropped entirely from the event map and removed from `sibilantFrameIndices` to maintain consistency
- **Affricate detection**: Events with peak position < 0.35 (early in the event) are classified as affricates and receive shorter fade-in times (1.5 ms vs. 3.0 ms) so full reduction lands before the transient peak
- **Context RMS measurement**: Flexible window that takes whatever voiced non-sibilant samples are available on

https://claude.ai/code/session_01LE9GYm4APZNbGkRbCDCYGN