### PR TITLE
Add throat click attenuator stage for voiced speech

### DIFF
--- a/server/pipeline/enhancement.js
+++ b/server/pipeline/enhancement.js
@@ -32,6 +32,7 @@ const DEREVERB_SCRIPT              = path.join(SCRIPTS_DIR, 'dereverb.py')
 const AP_BWE_SCRIPT                = path.join(SCRIPTS_DIR, 'ap_bwe_extend.py')
 const LAVASR_SCRIPT                = path.join(SCRIPTS_DIR, 'lavasr_extend.py')
 const CLICK_REMOVER_SCRIPT         = path.join(SCRIPTS_DIR, 'click_remover.py')
+const THROAT_CLICK_SCRIPT          = path.join(SCRIPTS_DIR, 'throat_click_attenuator.py')
 const RESONANCE_SCRIPT             = path.join(SCRIPTS_DIR, 'resonance_suppressor.py')
 const BREATH_REDUCER_SCRIPT        = path.join(SCRIPTS_DIR, 'breath_reducer.py')
 const SPECTRAL_SUBTRACTION_SCRIPT  = path.join(SCRIPTS_DIR, 'spectral_subtraction.py')
@@ -183,6 +184,47 @@ export function runClickRemover(inputPath, outputPath, params = {}) {
   if (params.thresholdSigma != null) args.push('--threshold',    String(params.thresholdSigma))
   if (params.maxClickMs     != null) args.push('--max-click-ms', String(params.maxClickMs))
   return spawnPythonCapture(CLICK_REMOVER_SCRIPT, args, 'ClickRemover')
+}
+
+/**
+ * Throat click attenuator — LPC prediction-error detection + smooth gain
+ * attenuation of short resonant throat/palate clicks inside voiced speech.
+ * Runs after click_remover, on audio that has already passed through noise
+ * reduction, EQ, and compression. Captures and returns the JSON report.
+ *
+ * @param {string} inputPath    - 32-bit float WAV at 44.1 kHz
+ * @param {string} outputPath   - 32-bit float WAV at 44.1 kHz
+ * @param {string} vadSpansPath - JSON file: array of [start_sample, end_sample] voiced spans
+ * @param {object} [params]
+ * @param {number} [params.sensitivityDb]  - dB above voiced floor to nominate a candidate
+ * @param {number} [params.minEventMs]     - Minimum candidate duration (ms)
+ * @param {number} [params.maxEventMs]     - Maximum candidate duration (ms)
+ * @param {number} [params.contextMs]      - Pre-event voiced context for AR fitting (ms)
+ * @param {number} [params.arOrder]        - AR model order (default: 2 + sr/1000)
+ * @param {number} [params.nrmsThreshold]  - Normalised prediction error to confirm detection
+ * @param {number} [params.envWindowMs]    - RMS envelope smoothing window (ms)
+ * @param {number} [params.floorWindowMs]  - Adaptive floor median window (ms)
+ * @param {number} [params.attenuationDb]  - Attenuation depth (dB)
+ * @param {number} [params.attackMs]       - Gain attack time (ms)
+ * @param {number} [params.releaseMs]      - Gain release time (ms)
+ * @param {number} [params.padMs]          - Attenuation window padding (ms)
+ * @returns {Promise<object>} Parsed JSON report from the script
+ */
+export function runThroatClickAttenuator(inputPath, outputPath, vadSpansPath, params = {}) {
+  const args = [inputPath, outputPath, '--vad-spans', vadSpansPath]
+  if (params.sensitivityDb != null) args.push('--sensitivity-db', String(params.sensitivityDb))
+  if (params.minEventMs    != null) args.push('--min-event-ms',   String(params.minEventMs))
+  if (params.maxEventMs    != null) args.push('--max-event-ms',   String(params.maxEventMs))
+  if (params.contextMs     != null) args.push('--context-ms',     String(params.contextMs))
+  if (params.arOrder       != null) args.push('--ar-order',       String(params.arOrder))
+  if (params.nrmsThreshold != null) args.push('--nrms-threshold', String(params.nrmsThreshold))
+  if (params.envWindowMs   != null) args.push('--env-window-ms',  String(params.envWindowMs))
+  if (params.floorWindowMs != null) args.push('--floor-window-ms', String(params.floorWindowMs))
+  if (params.attenuationDb != null) args.push('--attenuation-db', String(params.attenuationDb))
+  if (params.attackMs      != null) args.push('--attack-ms',      String(params.attackMs))
+  if (params.releaseMs     != null) args.push('--release-ms',     String(params.releaseMs))
+  if (params.padMs         != null) args.push('--pad-ms',         String(params.padMs))
+  return spawnPythonCapture(THROAT_CLICK_SCRIPT, args, 'ThroatClickAttenuator')
 }
 
 // ── Resonance Suppressor ──────────────────────────────────────────────────────

--- a/server/pipeline/index.js
+++ b/server/pipeline/index.js
@@ -24,6 +24,7 @@ const STAGE_REGISTRY = allStages
 const STAGE_FOR_CONFIG_KEY = {
   breathReducer:       'breathReduce',
   clickRemover:        'clickRemove',
+  throatClickAttenuator: 'throatClickAttenuate',
   compression:         'compress',
   parallelCompression: 'parallelCompress',
   autoLeveler:         'autoLevel',

--- a/server/pipeline/stages.js
+++ b/server/pipeline/stages.js
@@ -43,7 +43,7 @@ import { applyClipGainDeEsser } from './clipGainDeEsser.js'
 import { applyCompression } from './compression.js'
 import { runSeparation, runClearerVoice } from './separation.js'
 import { writeFile } from 'fs/promises'
-import { runHarmonicExciter, runVocalSaturation, runDereverb, runApBwe, runLavaSR, runClickRemover, applyResonanceSuppression, applyBreathReduction, runSpectralSubtraction, runRoomPresence } from './enhancement.js'
+import { runHarmonicExciter, runVocalSaturation, runDereverb, runApBwe, runLavaSR, runClickRemover, runThroatClickAttenuator, applyResonanceSuppression, applyBreathReduction, runSpectralSubtraction, runRoomPresence } from './enhancement.js'
 import { validateSeparation } from './separationValidation.js'
 import { applyAutoLeveler } from './autoLeveler.js'
 import { applyParallelCompression } from './parallelCompression.js'
@@ -239,6 +239,88 @@ export async function clickRemove(ctx) {
     `repaired=${report.total_clicks_repaired ?? '?'} ` +
     `skipped=${report.clicks_skipped ?? '?'} ` +
     `(threshold=${config.thresholdSigma}σ max=${config.maxClickMs}ms)`
+  )
+}
+
+// ── Stage: Throat click attenuator ────────────────────────────────────────────
+// Detects and attenuates short resonant throat/palate clicks (10–25 ms,
+// 1–4 kHz) embedded in voiced speech — distinct from the transient clicks
+// click_remover handles. These become audible only after compression and
+// normalisation raise quiet detail, so this stage runs late in the chain.
+//
+// Detection uses LPC prediction error: an AR model fitted on pre-event voiced
+// context cannot predict an aperiodic click, producing a normalised error
+// spike that survives even when the click is buried in loud speech. The stage
+// is VAD-gated — only voiced spans (built from the Silero frame labels in
+// ctx.results.metrics.frames) are searched, because the LPC detector needs
+// voiced context to fit a meaningful model.
+
+export async function throatClickAttenuate(ctx) {
+  const config = ctx.preset.throatClickAttenuator
+  if (!config) {
+    ctx.log('[throat-click] No throatClickAttenuator config on preset — skipped')
+    ctx.results.throatClickAttenuator = { applied: false, reason: 'not configured' }
+    return
+  }
+
+  // Build voiced spans from contiguous non-silence Silero VAD frames.
+  const frames = ctx.results.metrics?.frames
+  if (!frames?.length) {
+    ctx.log('[throat-click] No VAD frames available — skipped')
+    ctx.results.throatClickAttenuator = { applied: false, reason: 'no vad frames' }
+    return
+  }
+
+  const spans = []
+  let runStart = null
+  let runEnd   = null
+  for (const f of frames) {
+    if (!f.isSilence) {
+      if (runStart === null) runStart = f.offsetSamples
+      runEnd = f.offsetSamples + f.lengthSamples
+    } else if (runStart !== null) {
+      spans.push([runStart, runEnd])
+      runStart = null
+    }
+  }
+  if (runStart !== null) spans.push([runStart, runEnd])
+
+  if (spans.length === 0) {
+    ctx.log('[throat-click] No voiced spans — skipped')
+    ctx.results.throatClickAttenuator = { applied: false, reason: 'no voiced spans' }
+    return
+  }
+
+  const spansPath = ctx.tmp('.json')
+  await writeFile(spansPath, JSON.stringify(spans))
+
+  const outPath = ctx.tmp('.wav')
+  const report  = await runThroatClickAttenuator(ctx.currentPath, outPath, spansPath, {
+    sensitivityDb: config.sensitivityDb,
+    minEventMs:    config.minEventMs,
+    maxEventMs:    config.maxEventMs,
+    contextMs:     config.contextMs,
+    arOrder:       config.arOrder,
+    nrmsThreshold: config.nrmsThreshold,
+    envWindowMs:   config.envWindowMs,
+    floorWindowMs: config.floorWindowMs,
+    attenuationDb: config.attenuationDb,
+    attackMs:      config.attackMs,
+    releaseMs:     config.releaseMs,
+    padMs:         config.padMs,
+  })
+
+  ctx.currentPath = outPath
+  ctx.results.throatClickAttenuator = {
+    applied:           true,
+    clicks_detected:   report.clicks_detected   ?? null,
+    clicks_attenuated: report.clicks_attenuated ?? null,
+    channels:          report.channels          ?? null,
+  }
+  ctx.log(
+    `[throat-click] detected=${report.clicks_detected ?? '?'} ` +
+    `attenuated=${report.clicks_attenuated ?? '?'} ` +
+    `(voiced spans=${spans.length})`
   )
 }
 

--- a/server/scripts/click_remover.py
+++ b/server/scripts/click_remover.py
@@ -32,48 +32,15 @@ import soundfile as sf
 from scipy.ndimage import median_filter, uniform_filter1d
 from scipy.signal import butter, sosfilt
 
+from wavely_ar_utils import burg_ar_coeffs, ar_forward_predict
+
 
 # ---------------------------------------------------------------------------
 # Burg AR interpolation
+#
+# burg_ar_coeffs() and ar_forward_predict() live in wavely_ar_utils.py so the
+# throat click attenuator can reuse the same model fitting.
 # ---------------------------------------------------------------------------
-
-def burg_ar_coeffs(x, order):
-    """
-    Estimate AR model coefficients using the Burg method.
-    x     : 1-D float64 array of clean signal samples
-    order : AR model order
-    Returns 1-D array of AR coefficients [a1, a2, ..., a_order].
-    """
-    n = len(x)
-    if n <= order:
-        raise ValueError(f"Context length ({n}) must exceed AR order ({order})")
-
-    ef = x.copy().astype(np.float64)
-    eb = x.copy().astype(np.float64)
-    a  = np.zeros(order, dtype=np.float64)
-
-    for m in range(order):
-        num = -2.0 * np.dot(ef[m + 1:], eb[m : n - 1])
-        den = (np.dot(ef[m + 1:], ef[m + 1:])
-               + np.dot(eb[m : n - 1], eb[m : n - 1]))
-        if den < 1e-12:
-            break
-        km = num / den
-
-        a_new      = a.copy()
-        a_new[m]   = km
-        if m > 0:
-            a_new[:m] = a[:m] + km * a[m - 1 :: -1]
-        a = a_new
-
-        ef_new = ef[m + 1:] + km * eb[m : n - 1]
-        eb_new = eb[m : n - 1] + km * ef[m + 1:]
-
-        ef[m + 1:] = ef_new
-        eb[m + 1:] = eb_new
-
-    return a
-
 
 def ar_interpolate(signal, click_start, click_end, context_samples, ar_order):
     """
@@ -104,24 +71,13 @@ def ar_interpolate(signal, click_start, click_end, context_samples, ar_order):
     # Forward prediction from left context
     if left_order >= 1:
         a_fwd = burg_ar_coeffs(left_ctx, left_order)
-        fwd   = np.zeros(click_len, dtype=np.float64)
-        buf   = left_ctx[-left_order:].tolist()
-        for i in range(click_len):
-            pred   = -np.dot(a_fwd, buf[-left_order:][::-1])
-            pred   = np.clip(pred, -max_val, max_val)
-            fwd[i] = pred
-            buf.append(pred)
+        fwd   = ar_forward_predict(left_ctx, a_fwd, click_len, max_val=max_val)
 
-    # Backward prediction from right context (reverse signal)
+    # Backward prediction from right context (reverse signal, then re-reverse)
     if right_order >= 1:
         a_bwd = burg_ar_coeffs(right_ctx[::-1], right_order)
-        bwd   = np.zeros(click_len, dtype=np.float64)
-        buf   = right_ctx[:right_order][::-1].tolist()
-        for i in range(click_len):
-            pred                    = -np.dot(a_bwd, buf[-right_order:][::-1])
-            pred                    = np.clip(pred, -max_val, max_val)
-            bwd[click_len - 1 - i]  = pred
-            buf.append(pred)
+        bwd   = ar_forward_predict(right_ctx[::-1], a_bwd, click_len,
+                                   max_val=max_val)[::-1]
 
     # If neither side produced a usable prediction, leave the region untouched.
     if fwd is None and bwd is None:

--- a/server/scripts/throat_click_attenuator.py
+++ b/server/scripts/throat_click_attenuator.py
@@ -1,0 +1,419 @@
+"""
+throat_click_attenuator.py
+Throat / palate click attenuation for voiced speech/narration audio.
+
+Detects and attenuates short resonant throat and palate clicks occurring
+mid-sentence inside voiced speech (10-25ms, 1-4kHz dominant, gradual onset).
+These are distinct from electrical/lip clicks (handled by click_remover.py)
+and mouth rumbles (handled by the mouth noise stage).
+
+Detection:  LPC prediction error. An AR model fitted on pre-event voiced
+            context cannot predict an aperiodic throat click, producing a
+            sharp spike in normalised prediction error that remains
+            discriminating even when the click is embedded in loud voiced
+            speech — where spectral-shape features collapse.
+
+Repair:     Smooth gain attenuation with an asymmetric attack/release
+            envelope. AR interpolation is not used: the gradual 10-13ms
+            onset corrupts the AR training context, and at 10-25ms the
+            interpolated signal would be perceptibly wrong.
+
+Pipeline position: After click_remover.py, on audio that has already passed
+                   through noise reduction and any upstream EQ.
+
+Shared dependency: AR/Burg utilities are imported from wavely_ar_utils.py.
+
+Usage:
+    python throat_click_attenuator.py input.wav output.wav --vad-spans spans.json
+    python throat_click_attenuator.py in.wav out.wav --vad-spans spans.json \\
+        --nrms-threshold 3.0 --attenuation-db 16
+
+    spans.json — JSON array of [start_sample, end_sample] voiced spans
+                 (from Silero VAD).
+
+Output:
+    Processed WAV written to output path.
+    JSON report printed to stdout.
+"""
+
+import argparse
+import json
+import sys
+import numpy as np
+import soundfile as sf
+from scipy.ndimage import uniform_filter1d, median_filter
+
+from wavely_ar_utils import burg_ar_coeffs, ar_forward_predict
+
+EPS = 1e-12
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _clamp_spans(vad_spans, n):
+    """Clamp (start, end) spans to [0, n] and drop empty/invalid ones."""
+    spans = []
+    for span in vad_spans:
+        s = max(0, int(span[0]))
+        e = min(n, int(span[1]))
+        if e > s:
+            spans.append((s, e))
+    return spans
+
+
+def _mask_to_regions(mask):
+    """Convert a boolean array to a list of (start, end) tuples."""
+    regions  = []
+    in_region = False
+    start     = 0
+    for i, flagged in enumerate(mask):
+        if flagged and not in_region:
+            start     = i
+            in_region = True
+        elif not flagged and in_region:
+            regions.append((start, i))
+            in_region = False
+    if in_region:
+        regions.append((start, len(mask)))
+    return regions
+
+
+def _sliding_median_floor(env, window_samp, sr):
+    """
+    Adaptive floor: sliding median of the envelope.
+
+    The median is computed on a decimated copy of the envelope (~1ms
+    resolution) and interpolated back to full resolution. The floor is
+    slowly varying, so decimation keeps the cost bounded on long spans
+    without changing the result meaningfully.
+    """
+    window_samp = max(1, window_samp | 1)  # force odd
+    if len(env) <= window_samp:
+        return np.full_like(env, float(np.median(env)))
+
+    decim = max(1, int(sr) // 1000)
+    if decim == 1:
+        return median_filter(env, size=window_samp, mode='reflect')
+
+    dec_env   = env[::decim]
+    dec_win   = max(1, (window_samp // decim) | 1)
+    dec_floor = median_filter(dec_env, size=dec_win, mode='reflect')
+
+    full_idx = np.arange(len(env))
+    dec_idx  = np.arange(len(dec_env)) * decim
+    return np.interp(full_idx, dec_idx, dec_floor)
+
+
+def _merge_intervals(intervals):
+    """Merge a list of [start, end] intervals; returns sorted, merged list."""
+    if not intervals:
+        return []
+    intervals = sorted([list(iv) for iv in intervals])
+    merged = [intervals[0]]
+    for s, e in intervals[1:]:
+        if s <= merged[-1][1]:
+            merged[-1][1] = max(merged[-1][1], e)
+        else:
+            merged.append([s, e])
+    return merged
+
+
+# ---------------------------------------------------------------------------
+# Detection
+# ---------------------------------------------------------------------------
+
+def detect_throat_clicks(
+    signal,
+    sr,
+    vad_spans,               # list of (start_sample, end_sample) from Silero VAD
+    sensitivity_db  = 10.0,  # dB above voiced floor to nominate candidate
+    min_event_ms    = 8.0,   # Minimum candidate duration
+    max_event_ms    = 30.0,  # Maximum candidate duration
+    context_ms      = 25.0,  # Pre-event voiced context for AR model fitting
+    ar_order        = None,  # Defaults to 2 + sr // 1000
+    nrms_threshold  = 2.5,   # Normalised prediction error to confirm detection
+    env_window_ms   = 5.0,   # RMS envelope smoothing for nomination
+    floor_window_ms = 150.0, # Adaptive floor window (voiced samples only)
+):
+    """
+    Detect throat clicks in a mono float signal.
+
+    Returns
+    -------
+    detected    : list of (start_sample, end_sample) confirmed regions
+    diagnostics : dict with candidate counts and per-candidate skip reasons
+    """
+    sig = np.asarray(signal, dtype=np.float64)
+    n   = len(sig)
+
+    if ar_order is None:
+        ar_order = 2 + int(sr) // 1000
+    ar_order = int(ar_order)
+
+    context_samp      = int(round(sr * context_ms      / 1000.0))
+    min_event_samp    = int(round(sr * min_event_ms    / 1000.0))
+    max_event_samp    = int(round(sr * max_event_ms    / 1000.0))
+    env_window_samp   = max(1, int(round(sr * env_window_ms   / 1000.0)))
+    floor_window_samp = max(1, int(round(sr * floor_window_ms / 1000.0)))
+
+    spans = _clamp_spans(vad_spans, n)
+
+    detected      = []
+    candidates    = 0
+    nominated     = 0
+    skipped_dur   = 0
+    skipped_ctx   = 0
+    confirmed     = 0
+
+    for span_start, span_end in spans:
+        span = sig[span_start:span_end]
+        if len(span) < env_window_samp + 2:
+            continue
+
+        # ── Step 2: candidate nomination ────────────────────────────────
+        # 5ms RMS envelope. All samples in a voiced span are voiced, so a
+        # plain sliding median over the span satisfies the "voiced samples
+        # only" requirement for the adaptive floor.
+        env   = np.sqrt(uniform_filter1d(span ** 2, size=env_window_samp,
+                                         mode='nearest'))
+        floor = _sliding_median_floor(env, floor_window_samp, sr)
+        thresh = floor * (10.0 ** (sensitivity_db / 20.0))
+
+        for c0, c1 in _mask_to_regions(env > thresh):
+            candidates += 1
+            cand_len = c1 - c0
+
+            # Duration filter — rejects electrical clicks and
+            # consonant-length events.
+            if cand_len < min_event_samp or cand_len > max_event_samp:
+                skipped_dur += 1
+                continue
+            nominated += 1
+
+            abs_start = span_start + c0
+            abs_end   = span_start + c1
+
+            # ── Step 3: LPC prediction error gate ───────────────────────
+            # Require context_ms of voiced context immediately before the
+            # candidate, entirely inside the same voiced span.
+            if abs_start - context_samp < span_start:
+                skipped_ctx += 1
+                continue
+
+            context = sig[abs_start - context_samp:abs_start]
+            if len(context) <= ar_order:
+                skipped_ctx += 1
+                continue
+
+            coeffs     = burg_ar_coeffs(context, ar_order)
+            prediction = ar_forward_predict(context, coeffs, cand_len)
+            error      = sig[abs_start:abs_end] - prediction
+
+            ctx_rms = np.sqrt(np.mean(context ** 2))
+            err_rms = np.sqrt(np.mean(error ** 2))
+            nrms    = err_rms / (ctx_rms + EPS)
+
+            if nrms > nrms_threshold:
+                detected.append((abs_start, abs_end))
+                confirmed += 1
+
+    diagnostics = {
+        "voiced_spans":          len(spans),
+        "candidate_regions":     candidates,
+        "nominated_in_range":    nominated,
+        "skipped_duration":      skipped_dur,
+        "skipped_no_context":    skipped_ctx,
+        "confirmed":             confirmed,
+    }
+    return detected, diagnostics
+
+
+# ---------------------------------------------------------------------------
+# Attenuation
+# ---------------------------------------------------------------------------
+
+def apply_attenuation(
+    signal,
+    detected_regions,        # list of (start_sample, end_sample)
+    sr,
+    attenuation_db  = 20.0,
+    attack_ms       = 12.0,
+    release_ms      = 25.0,
+    pad_ms          = 4.0,
+):
+    """
+    Attenuate detected regions with a smooth asymmetric gain envelope.
+    Returns a new float32 array; the input is not modified.
+    """
+    sig = np.array(signal, dtype=np.float64, copy=True)
+    n   = len(sig)
+    if n == 0 or not detected_regions:
+        return sig.astype(np.float32)
+
+    pad        = int(round(sr * pad_ms / 1000.0))
+    atten_gain = 10.0 ** (-attenuation_db / 20.0)
+
+    # Padded + merged target regions.
+    padded = [[max(0, s - pad), min(n, e + pad)] for s, e in detected_regions]
+    merged = _merge_intervals(padded)
+
+    # Target gain: 1.0 outside detected regions, atten_gain inside.
+    target = np.ones(n, dtype=np.float64)
+    for s, e in merged:
+        target[s:e] = atten_gain
+
+    attack_coef  = np.exp(-1.0 / (sr * attack_ms  / 1000.0))
+    release_coef = np.exp(-1.0 / (sr * release_ms / 1000.0))
+
+    # The envelope follower is run only in windows around each region.
+    # Outside those windows the gain is saturated at 1.0, so a local pass is
+    # exact and far cheaper than a full-signal sample loop. Each window is
+    # padded by ~6 time constants so the gain has fully settled to 1.0 at
+    # the window edges.
+    settle  = max(1, int(round(6.0 * max(attack_ms, release_ms) / 1000.0 * sr)))
+    windows = _merge_intervals([[max(0, s - settle), min(n, e + settle)]
+                                for s, e in merged])
+
+    gain = np.ones(n, dtype=np.float64)
+    for ws, we in windows:
+        current = 1.0
+        for i in range(ws, we):
+            tgt  = target[i]
+            coef = attack_coef if tgt < current else release_coef
+            current   = tgt + coef * (current - tgt)
+            gain[i]   = current
+
+    sig *= gain
+    return sig.astype(np.float32)
+
+
+# ---------------------------------------------------------------------------
+# Multi-channel file wrapper
+# ---------------------------------------------------------------------------
+
+def process_file(input_path, output_path, vad_spans,
+                  detect_params=None, attenuate_params=None):
+    """
+    Read input file, attenuate throat clicks in each channel independently
+    (using the same VAD spans), write output. Returns the combined report.
+    """
+    detect_params    = detect_params    or {}
+    attenuate_params = attenuate_params or {}
+
+    audio, sr = sf.read(input_path, dtype='float32', always_2d=True)
+
+    channels_out = []
+    combined_report = {
+        "sample_rate":       sr,
+        "channels":          [],
+        "clicks_detected":   0,
+        "clicks_attenuated": 0,
+    }
+
+    for ch in range(audio.shape[1]):
+        detected, diag = detect_throat_clicks(
+            audio[:, ch], sr, vad_spans, **detect_params
+        )
+        processed = apply_attenuation(
+            audio[:, ch], detected, sr, **attenuate_params
+        )
+        channels_out.append(processed)
+
+        regions = [
+            {
+                "start_ms":    round(s / sr * 1000, 2),
+                "end_ms":      round(e / sr * 1000, 2),
+                "duration_ms": round((e - s) / sr * 1000, 2),
+            }
+            for s, e in detected
+        ]
+        combined_report["channels"].append({
+            f"channel_{ch}": {
+                "clicks_detected":   len(detected),
+                "detected_regions":  regions,
+                "diagnostics":       diag,
+            }
+        })
+        combined_report["clicks_detected"]   += len(detected)
+        combined_report["clicks_attenuated"] += len(detected)
+
+    sf.write(output_path, np.stack(channels_out, axis=1), sr, subtype='FLOAT')
+    return combined_report
+
+
+# ---------------------------------------------------------------------------
+# CLI entry point
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Throat / palate click attenuator for voiced speech"
+    )
+    parser.add_argument("input",  help="Input WAV path")
+    parser.add_argument("output", help="Output WAV path")
+    parser.add_argument("--vad-spans", required=True,
+        help="JSON file: array of [start_sample, end_sample] voiced spans")
+    # Detection
+    parser.add_argument("--sensitivity-db", type=float, default=None,
+        help="dB above voiced floor to nominate a candidate (default: 10).")
+    parser.add_argument("--min-event-ms",   type=float, default=None,
+        help="Minimum candidate duration in ms (default: 8).")
+    parser.add_argument("--max-event-ms",   type=float, default=None,
+        help="Maximum candidate duration in ms (default: 30).")
+    parser.add_argument("--context-ms",     type=float, default=None,
+        help="Pre-event voiced context for AR fitting in ms (default: 25).")
+    parser.add_argument("--ar-order",       type=int,   default=None,
+        help="AR model order (default: 2 + sr // 1000).")
+    parser.add_argument("--nrms-threshold", type=float, default=None,
+        help="Normalised prediction error to confirm detection (default: 2.5).")
+    parser.add_argument("--env-window-ms",  type=float, default=None,
+        help="RMS envelope smoothing window for nomination in ms (default: 5).")
+    parser.add_argument("--floor-window-ms", type=float, default=None,
+        help="Adaptive floor median window in ms (default: 150).")
+    # Attenuation
+    parser.add_argument("--attenuation-db", type=float, default=None,
+        help="Attenuation depth in dB (default: 20).")
+    parser.add_argument("--attack-ms",      type=float, default=None,
+        help="Gain attack time in ms (default: 12).")
+    parser.add_argument("--release-ms",     type=float, default=None,
+        help="Gain release time in ms (default: 25).")
+    parser.add_argument("--pad-ms",         type=float, default=None,
+        help="Attenuation window padding in ms (default: 4).")
+    args = parser.parse_args()
+
+    with open(args.vad_spans) as fh:
+        vad_spans = json.load(fh)
+
+    detect_params = {
+        k: v for k, v in {
+            "sensitivity_db":  args.sensitivity_db,
+            "min_event_ms":    args.min_event_ms,
+            "max_event_ms":    args.max_event_ms,
+            "context_ms":      args.context_ms,
+            "ar_order":        args.ar_order,
+            "nrms_threshold":  args.nrms_threshold,
+            "env_window_ms":   args.env_window_ms,
+            "floor_window_ms": args.floor_window_ms,
+        }.items() if v is not None
+    }
+    attenuate_params = {
+        k: v for k, v in {
+            "attenuation_db": args.attenuation_db,
+            "attack_ms":      args.attack_ms,
+            "release_ms":     args.release_ms,
+            "pad_ms":         args.pad_ms,
+        }.items() if v is not None
+    }
+
+    report = process_file(
+        args.input,
+        args.output,
+        vad_spans,
+        detect_params=detect_params,
+        attenuate_params=attenuate_params,
+    )
+
+    print(json.dumps(report, indent=2))
+    sys.exit(0)

--- a/server/scripts/wavely_ar_utils.py
+++ b/server/scripts/wavely_ar_utils.py
@@ -1,0 +1,78 @@
+"""
+wavely_ar_utils.py
+Shared autoregressive (AR) modelling utilities for Wavely audio stages.
+
+Burg-method AR coefficient estimation and forward prediction. Extracted from
+click_remover.py so that throat_click_attenuator.py can reuse the same model
+fitting without duplicating the implementation.
+
+  click_remover.py            — burg_ar_coeffs + ar_forward_predict, for
+                                 forward/backward AR interpolation of clicks.
+  throat_click_attenuator.py  — burg_ar_coeffs + ar_forward_predict, for
+                                 prediction-error measurement only.
+"""
+
+import numpy as np
+
+
+def burg_ar_coeffs(x, order):
+    """
+    Estimate AR model coefficients using the Burg method.
+    x     : 1-D float64 array of clean signal samples
+    order : AR model order
+    Returns 1-D array of AR coefficients [a1, a2, ..., a_order].
+    """
+    n = len(x)
+    if n <= order:
+        raise ValueError(f"Context length ({n}) must exceed AR order ({order})")
+
+    ef = x.copy().astype(np.float64)
+    eb = x.copy().astype(np.float64)
+    a  = np.zeros(order, dtype=np.float64)
+
+    for m in range(order):
+        num = -2.0 * np.dot(ef[m + 1:], eb[m : n - 1])
+        den = (np.dot(ef[m + 1:], ef[m + 1:])
+               + np.dot(eb[m : n - 1], eb[m : n - 1]))
+        if den < 1e-12:
+            break
+        km = num / den
+
+        a_new      = a.copy()
+        a_new[m]   = km
+        if m > 0:
+            a_new[:m] = a[:m] + km * a[m - 1 :: -1]
+        a = a_new
+
+        ef_new = ef[m + 1:] + km * eb[m : n - 1]
+        eb_new = eb[m : n - 1] + km * ef[m + 1:]
+
+        ef[m + 1:] = ef_new
+        eb[m + 1:] = eb_new
+
+    return a
+
+
+def ar_forward_predict(context, ar_coeffs, n_samples, max_val=None):
+    """
+    Run AR model forward for n_samples using context as the initial buffer.
+    Returns predicted signal array of length n_samples.
+
+    Used by click_remover.py for interpolation (combined with backward
+    prediction and crossfade) and by throat_click_attenuator.py for
+    prediction error measurement only.
+
+    max_val : Optional safety clip. Pass the context amplitude envelope
+              maximum when used for interpolation. Not needed for error
+              measurement.
+    """
+    order = len(ar_coeffs)
+    buf = list(context[-order:])
+    out = np.zeros(n_samples, dtype=np.float64)
+    for i in range(n_samples):
+        pred = -np.dot(ar_coeffs, buf[-order:][::-1])
+        if max_val is not None:
+            pred = np.clip(pred, -max_val, max_val)
+        out[i] = pred
+        buf.append(pred)
+    return out

--- a/src/audio/presets.js
+++ b/src/audio/presets.js
@@ -249,6 +249,17 @@ export const PRESETS = {
       */
       "correctiveEQ",
       { clickRemover: { thresholdSigma: 3.0, maxClickMs: 15 } },
+      {
+        // Conservative — ACX human reviewers expect an unprocessed character.
+        throatClickAttenuator: {
+          sensitivityDb: 10,
+          nrmsThreshold: 3.0,
+          attenuationDb: 14,
+          attackMs: 12,
+          releaseMs: 25,
+          padMs: 4,
+        },
+      },
       /*
       {
         resonanceSuppressor: [
@@ -446,6 +457,16 @@ export const PRESETS = {
       },
       "correctiveEQ",
       {
+        throatClickAttenuator: {
+          sensitivityDb: 10,
+          nrmsThreshold: 2.5,
+          attenuationDb: 20,
+          attackMs: 12,
+          releaseMs: 25,
+          padMs: 4,
+        },
+      },
+      {
         roomPresence: {
           enabled: true,
           wet: 0.08,
@@ -602,6 +623,16 @@ export const PRESETS = {
         },
       },
       "correctiveEQ",
+      {
+        throatClickAttenuator: {
+          sensitivityDb: 10,
+          nrmsThreshold: 2.5,
+          attenuationDb: 18,
+          attackMs: 12,
+          releaseMs: 25,
+          padMs: 4,
+        },
+      },
       {
         roomPresence: {
           enabled: true,


### PR DESCRIPTION
## Summary

Adds a new audio processing stage that detects and attenuates short resonant throat/palate clicks (10–25 ms, 1–4 kHz) embedded in voiced speech. This complements the existing click_remover stage, which handles transient electrical and lip clicks. The throat click attenuator runs late in the processing chain after compression and normalization, where these subtle artifacts become audible.

## Key Changes

- **New Python script `throat_click_attenuator.py`**: Implements LPC prediction-error detection and smooth gain attenuation
  - Detection uses Burg AR method to fit an autoregressive model on pre-event voiced context; aperiodic clicks produce a normalised prediction error spike that discriminates even when embedded in loud speech
  - Attenuation applies an asymmetric attack/release envelope (12 ms attack, 25 ms release) rather than AR interpolation, which would corrupt the AR training context and produce perceptible artifacts at 10–25 ms durations
  - VAD-gated: only searches voiced spans (built from Silero frame labels) since the LPC detector requires meaningful voiced context

- **New shared utility module `wavely_ar_utils.py`**: Extracts Burg AR coefficient estimation and forward prediction functions
  - Eliminates duplication between click_remover.py and throat_click_attenuator.py
  - Both stages now import `burg_ar_coeffs()` and `ar_forward_predict()` from this module

- **Refactored `click_remover.py`**: Removes inline AR implementations and imports from wavely_ar_utils.py
  - Simplifies backward prediction by using the shared `ar_forward_predict()` utility with signal reversal

- **New pipeline stage `throatClickAttenuate()` in `stages.js`**:
  - Builds voiced spans from contiguous non-silence Silero VAD frames in `ctx.results.metrics.frames`
  - Writes spans to a temporary JSON file and invokes the Python script
  - Captures detection and attenuation counts in the results report
  - Logs summary metrics (voiced spans, clicks detected/attenuated)

- **New export function `runThroatClickAttenuator()` in `enhancement.js`**:
  - Spawns the Python script with configurable parameters for detection sensitivity, event duration bounds, AR model order, and attenuation envelope
  - Parses and returns the JSON report

- **Preset configuration in `presets.js`**:
  - Adds throatClickAttenuator config to ACX Audiobook, Podcast Ready, and Voice Ready presets
  - Conservative settings for ACX (sensitivity 10 dB, threshold 3.0, attenuation 14 dB) to preserve unprocessed character
  - Slightly more aggressive for Podcast Ready and Voice Ready (threshold 2.5, attenuation 18–20 dB)

- **Pipeline registry in `index.js`**: Registers the new stage in STAGE_FOR_CONFIG_KEY

## Implementation Details

- **Detection pipeline**: RMS envelope nomination (5 ms window) → duration filtering (8–30 ms) → LPC prediction error gate (requires 25 ms clean voiced context)
- **Adaptive floor**: Sliding median computed on decimated envelope (~1 ms resolution) to keep cost bounded on long spans
- **Attenuation**: Smooth gain envelope follower with separate attack and release time constants, applied only in windowed regions around detected events (padded by ~6 time constants for settling)
- **Multi-channel support**: Processes each channel independently using the same VAD spans
- **CLI interface**: Accepts input/output paths, VAD spans JSON, and optional parameter overrides for all detection and attenuation settings

https://claude.ai/code/session_0171CQSA9zYtAASXCETYC1Yw