### PR TITLE
Add predictive pre-attenuation to airBoost

### DIFF
--- a/server/pipeline/airBoost.js
+++ b/server/pipeline/airBoost.js
@@ -32,7 +32,7 @@
 import { spawn }           from 'child_process'
 import { fileURLToPath }  from 'url'
 import path               from 'path'
-import { readFile, rm }   from 'fs/promises'
+import { readFile }       from 'fs/promises'
 import { applyParametricEQ, tempPath, removeTmp } from '../lib/ffmpeg.js'
 import { remeasureFrames }    from './frameAnalysis.js'
 import { PYTHON, spawnPython } from './spawnPython.js'
@@ -109,11 +109,12 @@ function bandsReport(gainDb) {
 function round4(x) { return Math.round(x * 10000) / 10000 }
 
 /**
- * Shape the precut analyser's payload into the result-object fragment that
- * gets merged into ctx.results.airBoost. Always emits a `precut` key so the
- * report shows whether the analysis ran and (if not) why it was skipped.
+ * Diagnostic fragment about the precut analysis — always safe to merge, even
+ * into a skipped-stage result. Does NOT include `pre_attenuation`; that field
+ * is added separately by the success path because it represents a filter the
+ * stage actually applied to audio.
  */
-function buildPrecutReport(precut, precutErr) {
+function buildPrecutDiagnostic(precut, precutErr) {
   if (!precut) return { precut: { ran: false, reason: 'no_preset_context' } }
   if (precutErr) {
     return { precut: { ran: false, reason: 'script_error', error: precutErr } }
@@ -129,11 +130,6 @@ function buildPrecutReport(precut, precutErr) {
     }
   }
   return {
-    pre_attenuation: {
-      f_hz:    precut.center_hz,
-      q:       precut.q,
-      gain_db: precut.gain_db,
-    },
     precut: {
       ran:                       true,
       applied:                   true,
@@ -266,7 +262,7 @@ export async function applyAirBoost(inputPath, outputPath, gainDb, outputProfile
       applied:           false,
       requested_gain_db: requestedGainDb,
       skip_reason:       'precut_consumed_all_gain',
-      ...buildPrecutReport(precut, precutErr),
+      ...buildPrecutDiagnostic(precut, precutErr),
     }
   }
 
@@ -289,7 +285,7 @@ export async function applyAirBoost(inputPath, outputPath, gainDb, outputProfile
         applied:           false,
         requested_gain_db: requestedGainDb,
         skip_reason:       'noise_floor_unresolvable',
-        ...buildPrecutReport(precut, precutErr),
+        ...buildPrecutDiagnostic(precut, precutErr),
       }
     }
   }
@@ -302,7 +298,14 @@ export async function applyAirBoost(inputPath, outputPath, gainDb, outputProfile
     acx_constrained:           isAcx && currentGain < (requestedGainDb - gainReductionDb),
     model:                     'maag_eq4_approximation_v1_unverified',
     bands:                     bandsReport(currentGain),
-    ...buildPrecutReport(precut, precutErr),
+    ...(precut?.applied && {
+      pre_attenuation: {
+        f_hz:    precut.center_hz,
+        q:       precut.q,
+        gain_db: precut.gain_db,
+      },
+    }),
+    ...buildPrecutDiagnostic(precut, precutErr),
   }
 }
 

--- a/server/pipeline/airBoost.js
+++ b/server/pipeline/airBoost.js
@@ -32,16 +32,22 @@
 import { spawn }           from 'child_process'
 import { fileURLToPath }  from 'url'
 import path               from 'path'
-import { applyParametricEQ } from '../lib/ffmpeg.js'
+import { readFile, rm }   from 'fs/promises'
+import { applyParametricEQ, tempPath, removeTmp } from '../lib/ffmpeg.js'
 import { remeasureFrames }    from './frameAnalysis.js'
-import { PYTHON }         from './spawnPython.js'
+import { PYTHON, spawnPython } from './spawnPython.js'
+import { getReferenceCurvePath } from './referenceEQ.js'
 
-const SCRIPTS_DIR  = path.join(path.dirname(fileURLToPath(import.meta.url)), '..', 'scripts')
-const MASK_SCRIPT  = path.join(SCRIPTS_DIR, 'air_boost_masked.py')
+const SCRIPTS_DIR    = path.join(path.dirname(fileURLToPath(import.meta.url)), '..', 'scripts')
+const MASK_SCRIPT    = path.join(SCRIPTS_DIR, 'air_boost_masked.py')
+const PRECUT_SCRIPT  = path.join(SCRIPTS_DIR, 'air_boost_precut.py')
 
 const ACX_NOISE_FLOOR_CEILING = -60   // dBFS — ACX hard ceiling
 const ACX_PRE_CHECK_LIMIT     = -61   // dBFS — skip if already this close before boost
 const REDUCTION_STEP_DB       = 0.25  // dB per iteration of the ACX reduction loop
+
+const DEFAULT_PRECUT_MAX_CUT_DB    = 6.0
+const DEFAULT_PRECUT_MIN_EXCESS_DB = 1.0
 
 // ─── Filter model ────────────────────────────────────────────────────────────
 //
@@ -103,16 +109,108 @@ function bandsReport(gainDb) {
 function round4(x) { return Math.round(x * 10000) / 10000 }
 
 /**
+ * Shape the precut analyser's payload into the result-object fragment that
+ * gets merged into ctx.results.airBoost. Always emits a `precut` key so the
+ * report shows whether the analysis ran and (if not) why it was skipped.
+ */
+function buildPrecutReport(precut, precutErr) {
+  if (!precut) return { precut: { ran: false, reason: 'no_preset_context' } }
+  if (precutErr) {
+    return { precut: { ran: false, reason: 'script_error', error: precutErr } }
+  }
+  if (!precut.applied) {
+    return {
+      precut: {
+        ran:             true,
+        applied:         false,
+        reason:          precut.reason,
+        n_speech_frames: precut.n_speech_frames,
+      },
+    }
+  }
+  return {
+    pre_attenuation: {
+      f_hz:    precut.center_hz,
+      q:       precut.q,
+      gain_db: precut.gain_db,
+    },
+    precut: {
+      ran:                       true,
+      applied:                   true,
+      gain_db_reduction:         precut.gain_db_reduction ?? 0,
+      peak_excess_db:            precut.peak_excess_db,
+      excess_curve_db:           precut.excess_curve_db,
+      excess_curve_freqs_hz:     precut.excess_curve_freqs_hz,
+      reference_corpus_version:  precut.reference_corpus_version,
+      reference_spec_version:    precut.reference_spec_version,
+    },
+  }
+}
+
+/**
+ * Run the predictive pre-attenuation analysis (air_boost_precut.py).
+ *
+ * Measures the current spectrum, predicts the post-airBoost magnitude in the
+ * 6-16 kHz region, and sizes a single bell cut sized to bring any predicted
+ * excess down to the preset's referenceEQ target curve. Returns a normalised
+ * object regardless of whether a cut is applied.
+ *
+ * Gated on reference-curve presence: with no curve at
+ * data/reference_curves/{presetId}.json this is a clean no-op (mirroring how
+ * referenceEQ itself behaves while the corpus is being built).
+ */
+async function runPrecutAnalysis(inputPath, gainDb, presetId, precutConfig, noiseFloorDbfs) {
+  if (precutConfig?.enabled === false) {
+    return { applied: false, reason: 'precut_disabled' }
+  }
+  const curvePath = await getReferenceCurvePath(presetId)
+  if (!curvePath) {
+    return { applied: false, reason: 'no_reference_curve' }
+  }
+
+  const maxCutDb    = precutConfig?.maxCutDb    ?? DEFAULT_PRECUT_MAX_CUT_DB
+  const minExcessDb = precutConfig?.minExcessDb ?? DEFAULT_PRECUT_MIN_EXCESS_DB
+
+  const resultPath = tempPath('.json')
+
+  const args = [
+    '--input',         inputPath,
+    '--result-json',   resultPath,
+    '--curve',         curvePath,
+    '--air-boost-db',  String(gainDb),
+    '--max-cut-db',    String(maxCutDb),
+    '--min-excess-db', String(minExcessDb),
+  ]
+  if (noiseFloorDbfs != null) args.push('--noise-floor', String(noiseFloorDbfs))
+
+  try {
+    await spawnPython(PRECUT_SCRIPT, args, 'AirBoostPrecut')
+    const text = await readFile(resultPath, 'utf8')
+    return JSON.parse(text)
+  } finally {
+    await removeTmp(resultPath)
+  }
+}
+
+/**
  * Apply the Air Boost filter chain to inputPath, writing the result to outputPath.
+ *
+ * When a reference curve exists for the preset, a predictive pre-cut is
+ * computed and prepended to the FFmpeg filter chain (no extra file hop). The
+ * pre-cut can also instruct a reduction to the airBoost gain itself when the
+ * raw predicted excess would exceed the configured clamp ceiling.
  *
  * @param {string} inputPath        Source WAV (float32, 44.1 kHz)
  * @param {string} outputPath       Destination path (pre-allocated by caller via ctx.tmp)
  * @param {number} gainDb           Requested boost from preset.airBoost.gainDb
  * @param {string} outputProfileId  'acx' | 'podcast' | 'broadcast'
  * @param {object} metrics          ctx.results.metrics — must contain frames[] for remeasure
+ * @param {object} [options]
+ * @param {string} [options.presetId]      Preset id (looked up for reference curve)
+ * @param {object} [options.precutConfig]  { enabled, maxCutDb, minExcessDb }
  * @returns {object}                Result object written to ctx.results.airBoost
  */
-export async function applyAirBoost(inputPath, outputPath, gainDb, outputProfileId, metrics) {
+export async function applyAirBoost(inputPath, outputPath, gainDb, outputProfileId, metrics, options = {}) {
   const requestedGainDb = gainDb
 
   if (gainDb <= 0) {
@@ -138,11 +236,43 @@ export async function applyAirBoost(inputPath, outputPath, gainDb, outputProfile
     }
   }
 
+  // Predictive pre-cut. Computed once on the input; the cut filter and the
+  // gain reduction are held constant inside the ACX post-check loop below.
+  let precut    = null
+  let precutErr = null
+  if (options.presetId) {
+    try {
+      precut = await runPrecutAnalysis(
+        inputPath,
+        gainDb,
+        options.presetId,
+        options.precutConfig,
+        metrics?.noiseFloorDbfs ?? null,
+      )
+    } catch (err) {
+      precutErr = err.message
+      precut    = { applied: false, reason: 'precut_script_error' }
+    }
+  }
+  const precutAppliedFilter = precut?.applied
+    ? `equalizer=f=${precut.center_hz}:width_type=q:w=${precut.q}:g=${precut.gain_db.toFixed(5)}`
+    : null
+  const gainReductionDb = precut?.applied ? (precut.gain_db_reduction ?? 0) : 0
+
   // Apply filter chain, with an ACX noise-floor compliance loop.
-  let currentGain = gainDb
+  let currentGain = gainDb - gainReductionDb
+  if (currentGain <= 0) {
+    return {
+      applied:           false,
+      requested_gain_db: requestedGainDb,
+      skip_reason:       'precut_consumed_all_gain',
+      ...buildPrecutReport(precut, precutErr),
+    }
+  }
 
   while (true) {
     const filters = buildFilters(currentGain)
+    if (precutAppliedFilter) filters.unshift(precutAppliedFilter)
     await applyParametricEQ(inputPath, outputPath, filters)
 
     if (!isAcx) break  // non-ACX profiles skip the post-check entirely
@@ -159,17 +289,20 @@ export async function applyAirBoost(inputPath, outputPath, gainDb, outputProfile
         applied:           false,
         requested_gain_db: requestedGainDb,
         skip_reason:       'noise_floor_unresolvable',
+        ...buildPrecutReport(precut, precutErr),
       }
     }
   }
 
   return {
-    applied:           true,
-    requested_gain_db: requestedGainDb,
-    applied_gain_db:   round4(currentGain),
-    acx_constrained:   isAcx && currentGain < requestedGainDb,
-    model:             'maag_eq4_approximation_v1_unverified',
-    bands:             bandsReport(currentGain),
+    applied:                   true,
+    requested_gain_db:         requestedGainDb,
+    applied_gain_db:           round4(currentGain),
+    gain_db_reduced_by_precut: round4(gainReductionDb),
+    acx_constrained:           isAcx && currentGain < (requestedGainDb - gainReductionDb),
+    model:                     'maag_eq4_approximation_v1_unverified',
+    bands:                     bandsReport(currentGain),
+    ...buildPrecutReport(precut, precutErr),
   }
 }
 

--- a/server/pipeline/index.js
+++ b/server/pipeline/index.js
@@ -334,7 +334,7 @@ function formatAirBoostResult(r) {
     applied_gain_db:           r.applied_gain_db,
     acx_constrained:           r.acx_constrained ?? false,
     model:                     r.model,
-    shelves:                   r.shelves,
+    bands:                     r.bands,
     ...(r.gain_db_reduced_by_precut > 0
       && { gain_db_reduced_by_precut: r.gain_db_reduced_by_precut }),
     ...(r.pre_attenuation && { pre_attenuation: r.pre_attenuation }),

--- a/server/pipeline/index.js
+++ b/server/pipeline/index.js
@@ -325,15 +325,19 @@ function formatAirBoostResult(r) {
       applied:           false,
       requested_gain_db: r.requested_gain_db,
       skip_reason:       r.skip_reason,
+      ...(r.pre_attenuation && { pre_attenuation: r.pre_attenuation }),
     }
   }
   return {
-    applied:           true,
-    requested_gain_db: r.requested_gain_db,
-    applied_gain_db:   r.applied_gain_db,
-    acx_constrained:   r.acx_constrained ?? false,
-    model:             r.model,
-    shelves:           r.shelves,
+    applied:                   true,
+    requested_gain_db:         r.requested_gain_db,
+    applied_gain_db:           r.applied_gain_db,
+    acx_constrained:           r.acx_constrained ?? false,
+    model:                     r.model,
+    shelves:                   r.shelves,
+    ...(r.gain_db_reduced_by_precut > 0
+      && { gain_db_reduced_by_precut: r.gain_db_reduced_by_precut }),
+    ...(r.pre_attenuation && { pre_attenuation: r.pre_attenuation }),
   }
 }
 

--- a/server/pipeline/stages.js
+++ b/server/pipeline/stages.js
@@ -832,6 +832,7 @@ export async function airBoost(ctx) {
     gainDb,
     ctx.outputProfileId,
     ctx.results.metrics,
+    { presetId: ctx.presetId, precutConfig: airBoostConfig.precut },
   )
 
   if (result.applied) {
@@ -870,6 +871,12 @@ export async function airBoost(ctx) {
     gainDb:   result.applied_gain_db ?? 'skipped',
     ...(result.skip_reason  && { reason:       result.skip_reason }),
     ...(result.sibilantMask && { sibilantMask: `floor=${sibilantGainFloor}` }),
+    ...(result.pre_attenuation && {
+      preCut: `${result.pre_attenuation.gain_db.toFixed(2)} dB @ ${result.pre_attenuation.f_hz} Hz Q=${result.pre_attenuation.q}`,
+    }),
+    ...(result.gain_db_reduced_by_precut > 0 && {
+      precutGainReduction: `${result.gain_db_reduced_by_precut.toFixed(2)} dB`,
+    }),
   })
 }
 

--- a/server/scripts/air_boost_precut.py
+++ b/server/scripts/air_boost_precut.py
@@ -1,0 +1,365 @@
+"""
+air_boost_precut.py
+Predictive pre-attenuation sizing for the airBoost stage.
+
+Reads the current audio, measures its 1/3-octave speech spectrum, predicts the
+post-airBoost magnitude spectrum analytically (using the same Maag-model
+BANDS table that airBoost.js applies), and — when the prediction exceeds the
+preset's referenceEQ target curve in the 6-16 kHz region — sizes a single
+parametric bell cut that brings the predicted excess down to target.
+
+The cut is returned as { center_hz, q, gain_db }. When the raw excess would
+exceed the configured maxCutDb, the script additionally returns a
+gain_db_reduction value: the amount by which the Node side should reduce the
+airBoost gain so the residual excess fits inside the clamp.
+
+The BANDS table and REFERENCE_PLATEAU_DB constant are duplicated from
+server/pipeline/airBoost.js — both are version-tagged
+(maag_eq4_approximation_v1_unverified) and stable. A sanity check at module
+load asserts the analytic transfer function reproduces the verification values
+in the airBoost.js header.
+
+Dependencies: numpy, scipy
+"""
+
+import argparse
+import json
+import logging
+import sys
+
+import numpy as np
+
+# Reuse the speech-gated 1/3-octave spectrum measurement from referenceEQ so
+# both stages compare against the reference curve on identical bins with
+# identical normalisation.
+from reference_eq import (
+    THIRD_OCTAVE_CENTERS,
+    speech_spectrum,
+    _load_audio,
+)
+
+logger = logging.getLogger(__name__)
+
+# ── airBoost model — must match server/pipeline/airBoost.js ───────────────────
+
+REFERENCE_PLATEAU_DB = 12.5932
+
+# (freqHz, type, q_or_width_oct, gRef_db)
+BANDS = [
+    (  600.0, 'bell',  0.5,    +0.19570),
+    ( 1200.0, 'bell',  0.5,    -0.32018),
+    ( 2400.0, 'bell',  0.5,    +1.20294),
+    ( 4800.0, 'bell',  0.5,    +2.05333),
+    ( 9600.0, 'bell',  0.5,    +3.46946),
+    (14000.0, 'shelf', 3.023, +15.08686),
+]
+
+MODEL_NAME = 'maag_eq4_approximation_v1_unverified'
+SR_FOR_TF  = 44100.0      # pipeline runs at 44.1 kHz throughout
+
+# Region of interest for the pre-cut: the 1/3-octave bins from 6.3 kHz upward.
+# Below 6 kHz the airBoost lift is mild and rarely causes harshness even on
+# bright recordings. Above 16 kHz we have no measurement.
+PRECUT_BAND_LO_HZ = 6000.0
+PRECUT_BAND_HI_HZ = 16000.0
+
+DEFAULT_MAX_CUT_DB    = 6.0
+DEFAULT_MIN_EXCESS_DB = 1.0
+Q_CLAMP_MIN = 0.5
+Q_CLAMP_MAX = 4.0
+DEFAULT_Q   = 1.0
+
+
+# ── Biquad transfer function (RBJ cookbook, FFmpeg-compatible) ────────────────
+#
+# Reproduces FFmpeg's `equalizer` (peaking) and `highshelf` filters when called
+# with the same width_type/value pair the airBoost stage uses.
+#   peaking, width_type='q': alpha = sin(w0) / (2*Q)
+#   shelf,   width_type='o': alpha = sin(w0) * sinh(ln(2)/2 * width * w0/sin(w0))
+#
+# The shelving coefficients are the RBJ form FFmpeg implements internally.
+
+def _peaking_response_db(freq_hz, f0_hz, q, gain_db, sr):
+    if gain_db == 0.0:
+        return np.zeros_like(freq_hz)
+    w0    = 2.0 * np.pi * f0_hz / sr
+    cw0   = np.cos(w0)
+    sw0   = np.sin(w0)
+    A     = 10.0 ** (gain_db / 40.0)
+    alpha = sw0 / (2.0 * q)
+
+    b0 = 1.0 + alpha * A
+    b1 = -2.0 * cw0
+    b2 = 1.0 - alpha * A
+    a0 = 1.0 + alpha / A
+    a1 = -2.0 * cw0
+    a2 = 1.0 - alpha / A
+
+    return _biquad_magnitude_db(b0, b1, b2, a0, a1, a2, freq_hz, sr)
+
+
+def _highshelf_response_db(freq_hz, f0_hz, width_oct, gain_db, sr):
+    if gain_db == 0.0:
+        return np.zeros_like(freq_hz)
+    w0   = 2.0 * np.pi * f0_hz / sr
+    cw0  = np.cos(w0)
+    sw0  = np.sin(w0)
+    A    = 10.0 ** (gain_db / 40.0)
+    sA   = np.sqrt(A)
+    # FFmpeg's octave-width conversion for biquad shelves.
+    alpha = sw0 * np.sinh(np.log(2.0) / 2.0 * width_oct * w0 / sw0)
+
+    b0 =      A * ((A + 1) + (A - 1) * cw0 + 2 * sA * alpha)
+    b1 = -2 * A * ((A - 1) + (A + 1) * cw0)
+    b2 =      A * ((A + 1) + (A - 1) * cw0 - 2 * sA * alpha)
+    a0 =          (A + 1) - (A - 1) * cw0 + 2 * sA * alpha
+    a1 =      2 * ((A - 1) - (A + 1) * cw0)
+    a2 =          (A + 1) - (A - 1) * cw0 - 2 * sA * alpha
+
+    return _biquad_magnitude_db(b0, b1, b2, a0, a1, a2, freq_hz, sr)
+
+
+def _biquad_magnitude_db(b0, b1, b2, a0, a1, a2, freq_hz, sr):
+    w   = 2.0 * np.pi * freq_hz / sr
+    ejw  = np.exp(-1j * w)
+    ej2w = np.exp(-2j * w)
+    num  = b0 + b1 * ejw + b2 * ej2w
+    den  = a0 + a1 * ejw + a2 * ej2w
+    return 20.0 * np.log10(np.abs(num / den) + 1e-20)
+
+
+def air_boost_response_db(freq_hz, air_boost_db):
+    """Sum the Maag-model band responses at `air_boost_db` request gain."""
+    freq_hz = np.asarray(freq_hz, dtype=float)
+    if air_boost_db <= 0:
+        return np.zeros_like(freq_hz)
+    scale = air_boost_db / REFERENCE_PLATEAU_DB
+    total = np.zeros_like(freq_hz)
+    for f0, kind, width, gref in BANDS:
+        g = gref * scale
+        if kind == 'bell':
+            total += _peaking_response_db(freq_hz, f0, width, g, SR_FOR_TF)
+        else:
+            total += _highshelf_response_db(freq_hz, f0, width, g, SR_FOR_TF)
+    return total
+
+
+def _sanity_check_transfer_function():
+    """
+    The airBoost.js header records the model's response at three frequencies
+    when air_boost_db=18 (extrapolated from a measured 17 dB setting):
+      1870 Hz  → +4.33 dB
+      5556 Hz  → +12.22 dB
+      13610 Hz → +16.32 dB
+    Catch silent drift between Node and Python copies of BANDS.
+    """
+    check = air_boost_response_db([1870.0, 5556.0, 13610.0], 18.0)
+    expected = np.array([4.33, 12.22, 16.32])
+    err = np.abs(check - expected)
+    if np.any(err > 0.15):
+        raise RuntimeError(
+            f"airBoost transfer function disagrees with airBoost.js verification "
+            f"values at 18 dB: got {check.tolist()}, expected {expected.tolist()} "
+            f"(max error {float(err.max()):.3f} dB). "
+            f"BANDS constants in air_boost_precut.py and airBoost.js are out of sync."
+        )
+
+
+_sanity_check_transfer_function()
+
+
+# ── Cut sizing ────────────────────────────────────────────────────────────────
+
+def _interp_log_freq_crossing(f_lo, f_hi, v_lo, v_hi, target):
+    """Linear interp in log-frequency to find the f where v crosses target."""
+    if v_hi == v_lo:
+        return f_lo
+    t = (target - v_lo) / (v_hi - v_lo)
+    return float(np.exp(np.log(f_lo) + t * (np.log(f_hi) - np.log(f_lo))))
+
+
+def _fwhm_q(bins_hz, excess_db, peak_idx):
+    """
+    Derive a parametric-EQ Q from the full-width-half-maximum of the excess
+    curve in log-frequency. Returns DEFAULT_Q if the FWHM can't be measured
+    (excess monotonic to an edge of the measurement region).
+    """
+    peak_val = excess_db[peak_idx]
+    half = peak_val / 2.0
+
+    lo_freq = None
+    for i in range(peak_idx, 0, -1):
+        if excess_db[i - 1] < half <= excess_db[i]:
+            lo_freq = _interp_log_freq_crossing(
+                bins_hz[i - 1], bins_hz[i], excess_db[i - 1], excess_db[i], half,
+            )
+            break
+
+    hi_freq = None
+    for i in range(peak_idx, len(bins_hz) - 1):
+        if excess_db[i] >= half > excess_db[i + 1]:
+            hi_freq = _interp_log_freq_crossing(
+                bins_hz[i], bins_hz[i + 1], excess_db[i], excess_db[i + 1], half,
+            )
+            break
+
+    if lo_freq is None or hi_freq is None:
+        return DEFAULT_Q
+
+    bw_oct = float(np.log2(hi_freq / lo_freq))
+    if bw_oct <= 0:
+        return DEFAULT_Q
+    q = 1.0 / (2.0 * np.sinh(np.log(2.0) / 2.0 * bw_oct))
+    return float(np.clip(q, Q_CLAMP_MIN, Q_CLAMP_MAX))
+
+
+def size_precut(measured_db, reference_db, air_boost_db, max_cut_db, min_excess_db):
+    """
+    Decide whether a pre-cut is warranted and, if so, return its parameters.
+
+    Returns one of:
+      { 'applied': True, center_hz, q, gain_db, gain_db_reduction,
+        excess_curve_db, excess_curve_freqs_hz, ... }
+      { 'applied': False, 'reason': str, ... }
+    """
+    # Restrict to the 6-16 kHz region of interest.
+    region_mask = (
+        (THIRD_OCTAVE_CENTERS >= PRECUT_BAND_LO_HZ)
+        & (THIRD_OCTAVE_CENTERS <= PRECUT_BAND_HI_HZ)
+    )
+    region_freqs    = THIRD_OCTAVE_CENTERS[region_mask]
+    region_measured = measured_db[region_mask]
+    region_ref      = reference_db[region_mask]
+
+    # Drop bins where either side is non-finite.
+    valid = np.isfinite(region_measured) & np.isfinite(region_ref)
+    if not np.any(valid):
+        return {'applied': False, 'reason': 'no_valid_region_bins'}
+    region_freqs    = region_freqs[valid]
+    region_measured = region_measured[valid]
+    region_ref      = region_ref[valid]
+
+    boost_response = air_boost_response_db(region_freqs, air_boost_db)
+    predicted_db   = region_measured + boost_response
+    raw_excess     = predicted_db - region_ref
+    excess_db      = np.maximum(raw_excess, 0.0)
+
+    peak_idx = int(np.argmax(excess_db))
+    peak_val = float(excess_db[peak_idx])
+
+    excess_payload = {
+        'excess_curve_db':       [round(float(v), 3) for v in excess_db],
+        'excess_curve_freqs_hz': [int(f) for f in region_freqs],
+        'predicted_db':          [round(float(v), 3) for v in predicted_db],
+        'reference_db':          [round(float(v), 3) for v in region_ref],
+        'measured_db':           [round(float(v), 3) for v in region_measured],
+        'air_boost_response_db': [round(float(v), 3) for v in boost_response],
+    }
+
+    if peak_val < min_excess_db:
+        return {
+            'applied': False,
+            'reason':  'below_dead_zone',
+            'peak_excess_db': peak_val,
+            **excess_payload,
+        }
+
+    # Decide whether to reduce airBoost gain so residual excess fits in the
+    # clamp. excess(f, g) = baseline(f) + g * weight(f), linear in g.
+    baseline   = region_measured - region_ref
+    weight     = boost_response / max(air_boost_db, 1e-9)   # per-dB gain weight
+    pos_weight = weight > 0
+    if peak_val > max_cut_db and np.any(pos_weight):
+        # Smallest g for which every bin's excess <= max_cut_db.
+        max_g_candidates = (max_cut_db - baseline[pos_weight]) / weight[pos_weight]
+        max_g_candidates = max_g_candidates[max_g_candidates > 0]
+        if len(max_g_candidates):
+            g_new = float(min(air_boost_db, np.min(max_g_candidates)))
+        else:
+            g_new = 0.0
+        gain_db_reduction = max(0.0, air_boost_db - g_new)
+        # Recompute excess curve at the reduced gain for downstream sizing.
+        boost_response_new = air_boost_response_db(region_freqs, g_new)
+        predicted_new      = region_measured + boost_response_new
+        excess_new         = np.maximum(predicted_new - region_ref, 0.0)
+        peak_idx           = int(np.argmax(excess_new))
+        peak_val_new       = float(excess_new[peak_idx])
+        cut_gain_db        = -min(peak_val_new, max_cut_db)
+        q                  = _fwhm_q(region_freqs, excess_new, peak_idx)
+    else:
+        gain_db_reduction = 0.0
+        cut_gain_db       = -peak_val
+        q                 = _fwhm_q(region_freqs, excess_db, peak_idx)
+
+    return {
+        'applied':           True,
+        'center_hz':         int(region_freqs[peak_idx]),
+        'q':                 round(q, 3),
+        'gain_db':           round(cut_gain_db, 3),
+        'gain_db_reduction': round(gain_db_reduction, 4),
+        'peak_excess_db':    round(peak_val, 3),
+        **excess_payload,
+    }
+
+
+# ── Entry point ───────────────────────────────────────────────────────────────
+
+def run(audio, sr, reference_levels, noise_floor_db, air_boost_db,
+        max_cut_db, min_excess_db):
+    measured_db, n_speech = speech_spectrum(audio, sr, noise_floor_db)
+    if measured_db is None:
+        return {
+            'applied':         False,
+            'reason':          'insufficient_speech',
+            'n_speech_frames': n_speech,
+        }
+    out = size_precut(
+        measured_db, reference_levels, air_boost_db, max_cut_db, min_excess_db,
+    )
+    out['n_speech_frames'] = n_speech
+    return out
+
+
+if __name__ == '__main__':
+    logging.basicConfig(level=logging.INFO, stream=sys.stderr, format='%(message)s')
+    parser = argparse.ArgumentParser(description='airBoost predictive pre-attenuation')
+    parser.add_argument('--input',         required=True, help='Input WAV (float32, 44.1 kHz, mono)')
+    parser.add_argument('--result-json',   required=True, help='Result JSON path')
+    parser.add_argument('--curve',         required=True, help='Reference curve JSON path')
+    parser.add_argument('--air-boost-db',  required=True, type=float)
+    parser.add_argument('--max-cut-db',    type=float, default=DEFAULT_MAX_CUT_DB)
+    parser.add_argument('--min-excess-db', type=float, default=DEFAULT_MIN_EXCESS_DB)
+    parser.add_argument('--noise-floor',   type=float, default=None,
+                        help='Canonical pipeline noise floor (dBFS) for the speech gate')
+    args = parser.parse_args()
+
+    with open(args.curve) as fh:
+        curve = json.load(fh)
+    curve_freqs  = np.asarray(curve['frequencies_hz'], dtype=float)
+    curve_levels = np.asarray(curve['levels_db'], dtype=float)
+    if not np.array_equal(curve_freqs, THIRD_OCTAVE_CENTERS):
+        curve_levels = np.interp(
+            np.log2(THIRD_OCTAVE_CENTERS), np.log2(curve_freqs), curve_levels,
+        )
+
+    sr, audio = _load_audio(args.input)
+    result = run(
+        audio, sr, curve_levels, args.noise_floor,
+        args.air_boost_db, args.max_cut_db, args.min_excess_db,
+    )
+    result['reference_corpus_version'] = curve.get('corpus_version')
+    result['reference_spec_version']   = curve.get('spec_version')
+    result['requested_air_boost_db']   = args.air_boost_db
+    result['model']                    = MODEL_NAME
+
+    with open(args.result_json, 'w') as fh:
+        json.dump(result, fh)
+
+    if result.get('applied'):
+        print(
+            f"airBoostPrecut: cut={result['gain_db']:+.2f} dB @ {result['center_hz']} Hz "
+            f"Q={result['q']:.2f} reduction={result['gain_db_reduction']:.3f} dB",
+            flush=True,
+        )
+    else:
+        print(f"airBoostPrecut: skipped — {result.get('reason')}", flush=True)

--- a/src/audio/presets.js
+++ b/src/audio/presets.js
@@ -245,6 +245,9 @@ export const PRESETS = {
             min_flatness: 0.1,
             broadband_trigger_db: 10.0,
           },
+          // Predictive pre-attenuation — conservative for ACX human review.
+          // Gated on data/reference_curves/acx_audiobook.json existing.
+          precut: { enabled: true, maxCutDb: 4.0, minExcessDb: 1.5 },
         },
       },
       /*
@@ -450,7 +453,12 @@ export const PRESETS = {
           detectionBand: { lowHz: 80, highHz: 800 },
         },
       },
-      { airBoost: { gainDb: 2.5, sibilantGainFloor: 0.25 } },
+      { airBoost: {
+          gainDb: 2.5,
+          sibilantGainFloor: 0.25,
+          precut: { enabled: true, maxCutDb: 6.0, minExcessDb: 1.0 },
+        },
+      },
       {
         resonanceSuppressor: {
           depth: 0.65,
@@ -613,6 +621,7 @@ export const PRESETS = {
           gainDb: 16,
           sibilantGainFloor: 0.0,
           sibilanceDetection: { broadband_trigger_db: 9.0 },
+          precut: { enabled: true, maxCutDb: 6.0, minExcessDb: 1.0 },
         },
       },
       {


### PR DESCRIPTION
Before applying the Maag-modeled HF lift, the airBoost stage now predicts
the post-airBoost magnitude spectrum analytically and — when the prediction
exceeds the preset's referenceEQ target curve in the 6-16 kHz region —
applies a single parametric bell cut sized to bring the predicted excess
back to the target curve. When the raw excess would exceed the configured
clamp ceiling, the airBoost gain itself is reduced so residual excess
fits inside the clamp.

The pre-cut is gated on a reference curve existing for the active preset
(mirroring referenceEQ's gate), so this is a clean no-op until the corpus
is built.