### PR TITLE
Refactor pipeline to config-driven architecture; remove voice_ready preset

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,5 @@
 # Instant Polish — CLAUDE.md
-> Project intelligence for Claude Code | Last updated: April 2026 | Codebase status: ~57 source files, ~7,973 lines
+> Project intelligence for Claude Code | Last updated: May 2026 | Codebase status: ~60 source files, ~10,000+ lines
 
 ---
 
@@ -60,27 +60,6 @@ Processing is split between client and server based on operation type. This is n
 
 **Why noise reduction must be server-side:** RNNoise (the client-side alternative) produces meaningfully worse results than DeepFilterNet3. For a product positioning on audio quality, shipping an inferior NR path for spot edits is not acceptable. The processing modal pattern normalizes the wait — every major audio tool works this way for NR.
 
-### Spot Noise Reduction — Naked DeepFilterNet3 Pass
-
-When a user applies noise reduction manually to a selection, the server receives **only that clip** and runs **only DeepFilterNet3** — no preset chain, no EQ, no limiting, no compliance processing, no room tone padding. The model is applied to the clip with user-controlled parameters and the result is returned.
-
-**Server request shape for spot NR:**
-```json
-{
-  "file": "<selection clip>",
-  "operation": "noise_reduction",
-  "context": "spot_edit",
-  "params": {
-    "strength": 0.7
-  }
-}
-```
-
-The `context: "spot_edit"` flag suppresses all preset post-processing. The server applies DeepFilterNet3 and returns the processed clip only.
-
-**⚠ Open question — DeepFilterNet3 exposed parameters:**
-The appropriate user-facing controls for spot NR have not been finalized. Candidate parameters are **strength** (aggressiveness of reduction) and **sensitivity** (how conservatively the model classifies speech vs. noise). However, it is unclear how much the `deepfilternet` / `libdf` API actually exposes — if the model has only one meaningful control (attenuation ceiling), presenting two sliders that don't do meaningfully different things would be misleading. **This requires a research spike before the spot-edit NR UI is designed.** Findings should update this document.
-
 ### Full Preset Chain — Server Request Shape
 
 ```json
@@ -120,17 +99,16 @@ Key data structures: `Segment`, `SilenceSegment`, `Timeline` (ordered segment ar
 
 ## Preset + Output Profile Architecture
 
-These are **independent** selections. A preset governs the character of processing (Stages 1–4a). An output profile governs the loudness target, peak ceiling, and measurement method (Stages 5–6), and determines whether ACX certification runs (Stage 7).
+These are **independent** selections. A preset governs the character of processing. An output profile governs the loudness target, peak ceiling, and measurement method, and determines whether ACX certification runs.
 
-### Presets (five at launch)
+### Presets (four at launch)
 
 | Preset ID | Display Name | Audience | Channel Output |
 |---|---|---|---|
 | `acx_audiobook` | ACX Audiobook | Audiobook narrators | Mono |
 | `podcast_ready` | Podcast Ready | Podcast hosts | Preserve original |
-| `voice_ready` | Voice Ready | Voice actors | Mono |
 | `general_clean` | General Clean | Everyone else (default) | Preserve original |
-| `noise_eraser` | Noise Eraser | Severely noisy recordings where standard processing has failed | Mono (default) |
+| `noise_eraser` | Noise Eraser | Severely noisy recordings where standard processing has failed | Mono |
 
 **Default preset:** `general_clean` — or `acx_audiobook` if the user has previously selected it.
 
@@ -148,9 +126,8 @@ Output profiles are loudness targets, not compliance standards. They govern what
 
 | Preset | Default Output Profile |
 |---|---|
-| `acx_audiobook` | `acx` |
+| `acx_audiobook` | `acx` (locked) |
 | `podcast_ready` | `podcast` |
-| `voice_ready` | `acx` |
 | `general_clean` | `podcast` |
 | `noise_eraser` | `podcast` |
 
@@ -162,93 +139,78 @@ Output profiles are loudness targets, not compliance standards. They govern what
 
 ---
 
-## Processing Chain (Standard Presets)
+## Processing Pipeline Architecture
 
-```
-Pre-0:    Decode (FFmpeg → 32-bit float, 44.1 kHz)
-Pre-1:    Mono mixdown (preset-dependent)
-Pre-2:    Measure before (RMS, LUFS, noise floor, peaks)
-Pre-3:    Peak normalize (±1 dBFS ceiling, linear)
-Pre-4:    Silence analysis — frame-based noise floor measurement (Silero VAD v5)
-Stage 1:  High-Pass Filter (80 Hz Butterworth, 4th order; + conditional 60 Hz notch)
-Stage 2:  Adaptive Noise Reduction (DeepFilterNet3)
-Stage 2a: Silence analysis post-NR (refine noise floor estimate)
-Stage 2b: Dereverberation (NARA-WPE, conditional — light/medium/heavy paths)
-Stage 2c: Room tone padding (ACX only — auto-detect quietest silence segment, pad head 0.75 s + tail 2 s)
-Stage 3:  Enhancement EQ (Meyda.js spectral analysis → FFmpeg parametric EQ)
-Stage 4:  De-esser (conditional — only if P95 sibilant energy exceeds threshold)
-Stage 4a:    Compression (conditional for ACX; always-on for other presets)
-Stage 4a-PC: Parallel Compression (wet/dry blend with parallel de-esser + VAD gate)
-Stage 4a-E:  Vocal Expander (frequency-selective dynamic attenuation of silence-floor residual)
-Stage 4b:    Auto Leveler (VAD-gated gain riding, conditional — normalizes level variance across voiced segments)
-Stage 4d:    Harmonic Exciter (conditional brightness boost)
-Stage 5:  Loudness Normalization (libebur128-wasm + FFmpeg loudnorm) ← output profile governs target
-Stage 6:  True Peak Limiting (FFmpeg loudnorm two-pass, 192 kHz upsample) ← output profile governs ceiling
-Stage 7:  Measurement + Processing Report (ACX certification + quality advisory flags)
-Post:     Encode (WAV or MP3 per tier/preset) + extract waveform peak data (~1000 points)
-```
+The pipeline is **fully config-driven**. There is no hardcoded stage ordering. Each preset declares its own `stages` array in `src/audio/presets.js`, and the pipeline runner in `server/pipeline/index.js` executes those stages sequentially via a stage registry. This means:
 
+- Adding or reordering stages for a preset is a data change in `presets.js` only — no changes to the runner
+- Stages can carry inline config: `{ noiseReduce: { model: "rnnoise" } }` overrides that stage's defaults for that one call
+- The same stage function can appear multiple times in a preset's chain (e.g. `noiseReduce` called twice with different models, `compression` called in multiple passes)
+- Stage results accumulate in `ctx.results`; absent stages produce no orphaned keys in the report JSON
+- There is no separate "Noise Eraser pipeline" — `noise_eraser` is a preset with its own `stages` array, executed by the same runner as every other preset
 
+**Source of truth:** `src/audio/presets.js` — all preset and output profile definitions live here. The server re-exports from `server/presets.js`.
 
-### Key Stage Notes
+### Available Stages (stage registry in `server/pipeline/stages.js`)
 
-**Pre-4 — Silence Analysis (frame-based, Silero VAD v5):**
-- Runs before Stage 1 to establish the authoritative noise floor measurement.
-- Runs again after Stage 2 (post-NR) to refine the estimate.
-- This frame-based measurement is the canonical noise floor for all downstream decisions (silence exclusion thresholds, NR tier selection, compliance checks).
-- For Noise Eraser: use the post-NE-5 noise floor, not the pre-processing measurement.
+**Pre-processing & measurement:** `decode`, `monoMixdown`, `measureBefore`, `measureAfter`, `peakNormalize`, `analyzeFramesRaw`, `remeasureFramesPostNr`
 
-**Stage 2b — Dereverberation (NARA-WPE, conditional):**
-- Python `nara-wpe` + `librosa`. Three paths: light, medium, heavy (selected based on measured reverb characteristics).
-- Applied after NR so the dereverberation model works on a cleaner signal.
-- Conditional — skipped if reverb measurement does not meet threshold.
-- Present in both standard and Noise Eraser pipelines.
+**Noise & tonal:** `humDetect`, `hpf`, `noiseReduce` (DF3 / RNNoise / DTLN switchable per call), `spectralSubtraction`, `clickRemove`, `dereverb`
 
-**Stage 2 — Noise Reduction (standard presets only):**
-- DeepFilterNet3 (neural network). Python `deepfilternet` / `libdf`.
-- Adaptive tiers 1–5 based on measured noise floor. `acx_audiobook` and `voice_ready` cap at Tier 4 (12 dB max). `podcast_ready` caps at Tier 3.
+**Voice enhancement:** `correctiveEQ`, `referenceEQ`, `airBoost`, `clipGainDeEss`, `deEss`, `resonanceSuppressor`, `breathReduce`, `vocalExpander`
+
+**Dynamics:** `compress` (multi-pass, crest-factor driven), `parallelCompress`, `autoLevel`, `vadGate`
+
+**Separation & extension (Noise Eraser):** `tonalPretreatment`, `separateVocals` (Demucs or ConvTasNet), `separationValidation`, `bandwidthExtension` (AP-BWE or LavaSR)
+
+**ClearerVoice path:** `clearerVoiceEnhance` (mossformer2_48k or frcrn_16k)
+
+**Special effects:** `harmonicExciter`, `vocalSaturation`, `roomPresence`
+
+**Output & reporting:** `normalize`, `truePeakLimit`, `acxCertification`, `qualityAdvisory`, `encode`, `extractPeaks`, `roomTonePad`
+
+### Key Processing Notes
+
+**Frame analysis (`analyzeFramesRaw` / `remeasureFramesPostNr`):**
+- Establishes the canonical noise floor measurement used by all downstream stages
+- Runs multiple times per preset to refresh metrics after heavy processing passes
+- Noise floor from this analysis drives silence exclusion thresholds, NR skip conditions, and ACX compliance checks
+
+**Noise Reduction (`noiseReduce`):**
+- Model is switchable per call: `df3` (DeepFilterNet3), `rnnoise`, or `dtln`
+- `acx_audiobook` runs DF3 then RNNoise in sequence; `noise_eraser` runs DF3 before separation
+- `skipBelowDb` option skips the call entirely if the measured noise floor is already below the given threshold
 - **Never force a pass.** If noise floor can't reach -60 dBFS without artifact risk, report failure. Do not over-process.
-- Conservative defaults for ACX — overprocessing artifacts cause human review rejection.
 - Noise floor enforcement only applies when `output_profile = acx`. For other profiles, reduction is applied for quality only.
 
-**Stage 4a-E — Vocal Expander (frequency-selective silence-floor attenuator):**
-- Runs after Stage 4a-PC and before Stage 4b. Not a gate and not a replacement for Stage 2 NR.
-- Threshold is calibrated from the file's measured silence P90 energy (re-measured on the post-compression signal) plus a preset headroom offset; clamped to -70 dBFS.
-- Two-path architecture: detection is 80–800 Hz bandpass → 10 ms frame RMS → soft-ratio gain reduction with 10 ms lookahead, 10 ms attack, 20 ms hold, 150–200 ms release. Attenuation is applied full-depth below 800 Hz and softened above 800 Hz via `highFreqDepth` to preserve consonant clarity.
-- **Skipped** when silence P90 on the post-compression signal is already below -72 dBFS.
-- Present in all three pipelines (`STANDARD_PIPELINE`, `noise_eraser`, `clearervoice_eraser`). On ClearerVoice the calibration still works correctly — it measures the current signal regardless of what produced it.
-- Emits a `vocal_expander` object in `processing_applied` and can raise an `over_expansion` advisory flag when it reaches into quiet speech.
+**Compression (`compress`):**
+- Crest-factor driven, not fixed-ratio. `targetCrestFactorDb` sets the target; the compressor adjusts ratio dynamically up to `maxRatio`.
+- Most presets run 2–3 serial compression passes with decreasing target crest factors
+- Followed by `parallelCompress` (wet/dry blend with VAD gate and integrated clip-gain de-esser)
 
-**Stage 4b — Auto Leveler (VAD-gated gain riding):**
-- Added in PR #26 as the most recent pipeline addition.
-- Uses Silero VAD v5 to classify voiced vs. silence frames, then applies gain riding only to voiced segments.
-- Reduces level variance between loud and quiet passages before the final loudness normalization.
-- Conditional per preset — present in all standard presets but with different aggressiveness settings.
-- **Do not apply after Stage 5** — gain riding post-normalization breaks compliance targets.
+**Vocal Expander (`vocalExpander`):**
+- Frequency-selective silence-floor attenuator. Not a gate — soft-ratio, band-weighted, calibrated per file.
+- Detection band: 80–800 Hz. Attenuation softened above 800 Hz via `highFreqDepth` to preserve consonants.
+- Threshold set from post-compression silence P90 + headroom offset; skipped if already below -72 dBFS.
+- Emits a `vocal_expander` key in the report; raises `over_expansion` advisory flag when it reaches into quiet speech.
 
-**Stage 5 — Normalization:**
-- `acx` output profile → unweighted RMS measurement (ACX measures RMS, not LUFS).
-- `podcast` / `broadcast` output profiles → K-weighted integrated LUFS (EBU R128).
-- Exclude silence frames from RMS measurement using dynamic threshold: `noise_floor + 6 dB`.
-- For Noise Eraser: use post-NE-5 noise floor for silence exclusion threshold, not the original pre-processing noise floor.
+**Auto Leveler (`autoLevel`):**
+- VAD-gated gain riding — reduces level variance across voiced segments before final normalization.
+- Must not run after `normalize` — gain riding post-normalization breaks compliance targets.
 
-**Stage 7 — Report (two independent systems):**
-
-*System 1 — ACX Technical Certification:* Runs only when `output_profile = acx`. Six-point deterministic pass/fail: RMS, true peak, noise floor, sample rate, bit depth, channel format. Issues a binary certificate. The `acx_certification` key is **absent** (not null) from the JSON when `output_profile` is not `acx`.
-
-*System 2 — Quality Advisory Flags:* Runs for all presets and all output profiles. Probabilistic observations the user should review before submitting. Flags have severity `info` or `review`. No aggregate risk score. Each flag includes a "Mark as reviewed" checkbox in the UI.
-
-These two systems are independent. A file can be ACX certified and still have advisory flags. Advisory flags are never gates — the user can download at any point.
+**Normalization & reporting:**
+- `normalize`: `acx` output profile → unweighted RMS; `podcast`/`broadcast` → K-weighted LUFS (EBU R128). Silence exclusion threshold: `noise_floor + 6 dB`.
+- `acxCertification`: runs for all presets when `output_profile = acx`. Six-point deterministic pass/fail. The `acx_certification` key is **absent** (not null) from the JSON for other output profiles.
+- `qualityAdvisory`: runs for all presets and output profiles. Probabilistic flags (`info` / `review`), no aggregate score, each with a "Mark as reviewed" checkbox.
 
 See `docs/instant_polish_compliance_model_v2.md` for full flag definitions, JSON structure, and UI model.
 
 ### Preset Character Distinctions (do not converge)
 
-- **ACX Audiobook:** Clean, transparent, controlled dynamics. Highest priority in term of noise reduction and artifact free output. 
-- **Podcast Ready:** Punchy, intimate, compressed.  More aggressive EQ mud cut. LUFS target (not RMS). Stereo preserved for dual-host. 
-- **Voice Ready:** Broadcast-neutral. Versatile — sits under music beds. Mono output. 
-- **General Clean:** Pragmatic. More aggressive noise reduction acceptable (Tier 4, relaxed artifact warnings).
-- **Noise Eraser:** Voice extraction, not noise reduction. Prioritizes noise removal over voice transparency. Output may have a "dry booth" quality. 
+- **ACX Audiobook:** Clean, transparent, controlled dynamics. Highest priority on noise reduction quality and artifact-free output. Conservative compression. Dual NR pass (DF3 → RNNoise).
+- **Podcast Ready:** Punchy, intimate, compressed. More aggressive EQ. LUFS target (not RMS). Stereo preserved for dual-host. Vocal saturation + room presence added for character.
+- **General Clean:** Pragmatic. Uses ClearerVoice enhancement for broad-band cleanup. More aggressive de-esser. No strong tonal character.
+- **Noise Eraser:** Voice extraction, not noise reduction. Prioritizes noise removal over voice transparency. Uses Demucs source separation. Output may have a "dry booth" quality.
 
 ---
 
@@ -268,8 +230,8 @@ Full specification: `docs/instant_polish_compliance_model_v2.md`.
 
 These apply only to the `acx_audiobook` preset:
 
-- **Room tone padding:** ✓ Implemented — Auto-detect and pad head (0.75 s) and tail (2 s) using actual room tone from the file's quietest silence segment. Not digital silence. Runs as Stage 2c.
-- **ACX compliance report:** ✓ Implemented — Per-file six-point technical certification + quality advisory flags.
+- **Room tone padding:** Stage `roomTonePad` is implemented and available in the stage registry — auto-detect and pad head (0.75 s) and tail (2 s) using actual room tone from the file's quietest silence segment. Not digital silence. Currently not included in the `acx_audiobook` stages array.
+- **ACX compliance report:** ✓ Implemented — Per-file six-point technical certification + quality advisory flags. `acxCertification` runs for all presets when `output_profile = acx`.
 - **Plosive and breath detection:** ✓ Implemented — Surfaces as quality advisory flags for manual review before ACX submission.
 - **Batch processing (Creator tier gate):** ✗ Not yet implemented — Multi-phase: batch analysis → per-file processing → cross-chapter consistency pass. Consistency pass aligns RMS (< 1 dB deviation from batch median) and spectral centroid (< 15% deviation) across chapters. This is the **primary value prop for narrators**. Planned for Sprint 5.
 
@@ -279,7 +241,7 @@ These apply only to the `acx_audiobook` preset:
 
 ## Implementation Status
 
-### Complete (as of April 2026)
+### Complete (as of May 2026)
 
 **Frontend:**
 - Vue 3 (Composition API) production app — not a PoC
@@ -287,16 +249,16 @@ These apply only to the `acx_audiobook` preset:
 - Undo/redo stack (50-item cap)
 - Waveform visualization (Canvas 2D, peak caching, device pixel ratio support)
 - Playback with A/B before/after comparison
-- Preset panel (5 presets) + output profile panel (3 profiles) with dynamic UI rules
-- Effects panel (manual NR, compression, normalize — client-side spot operations)
+- Preset panel (4 presets) + output profile panel (3 profiles) with dynamic UI rules
 - Processing report panel (measurements, ACX certification, advisory flags)
 
 **Backend:**
-- Full 21-stage standard processing pipeline (all 4 non-NE presets)
-- Full Noise Eraser pipeline (NE-1 through NE-7 + shared Stage 5–7)
+- Config-driven pipeline architecture — all 4 presets share a single orchestrator; stage sequences declared per-preset in `src/audio/presets.js`
+- Stage registry (`server/pipeline/stages.js`): 29 stage functions including correctiveEQ, referenceEQ, airBoost, clipGainDeEss, spectralSubtraction, resonanceSuppressor, vocalSaturation, roomPresence, autoLevel, parallelCompress, vocalExpander, clickRemove, humDetect, tonalPretreatment, separateVocals, separationValidation, clearerVoiceEnhance, bandwidthExtension, vadGate
+- Noise Eraser as a preset (same runner, different stages array): spectral subtraction → DF3 → tonal pretreatment → Demucs separation → separation validation → bandwidth extension
 - Async job architecture (POST → 202 + jobId → polling → download)
 - Rate limiting, CORS, temp file cleanup, job TTL
-- All Python integrations: DeepFilterNet3, RNNoise, Demucs, ConvTasNet, NARA-WPE, Silero VAD v5, AudioSR
+- Python integrations: DeepFilterNet3, RNNoise, Demucs, ConvTasNet, AP-BWE / LavaSR, ClearerVoice
 
 ### Not Yet Implemented
 
@@ -308,10 +270,13 @@ These apply only to the `acx_audiobook` preset:
 - **Persistent job storage** — Jobs are in-memory; server restart loses them
 - **`docs/acx_production_workflow.md`** and **`docs/instant_polish_gtm.md`** — Referenced but not created
 
-### Partially Integrated (code present, not fully wired)
+### Available but Not Active in Current Presets
 
-- **VoiceFixer** — Python script present; not yet connected to a preset or UI path
-- **ClearerVoice** — Python script present; UI integration incomplete
+- **Room tone padding** (`roomTonePad`) — Stage implemented; not currently in any preset's stages array
+- **Dereverberation** (`dereverb`) — Stage implemented; commented out in presets
+- **VAD gate** (`vadGate`) — Stage implemented; disabled in current presets
+- **Bandwidth extension** (`bandwidthExtension`) — Stage implemented; `enabled: false` in noise_eraser preset
+- **Harmonic exciter**, **breath reducer**, **throat click attenuator** — Stages implemented; not in any active preset
 
 ---
 
@@ -346,7 +311,6 @@ Narrators primarily upload WAV (16-bit, 44.1 kHz, mono). MP3 input supported for
 |---|---|---|---|
 | ACX Audiobook | MP3 128 kbps | MP3 192 kbps CBR (LAME, strict CBR — ACX requirement) | WAV 16-bit 44.1 kHz mono |
 | Podcast Ready | MP3 128 kbps | MP3 320 kbps CBR | WAV 16-bit 44.1 kHz |
-| Voice Ready | MP3 128 kbps | WAV only (clients expect WAV) | WAV 16-bit 44.1 kHz mono |
 | General Clean | MP3 128 kbps | MP3 256 kbps CBR | WAV 16-bit 44.1 kHz |
 | Noise Eraser | MP3 128 kbps | MP3 256 kbps CBR | WAV 16-bit 44.1 kHz mono |
 
@@ -361,16 +325,14 @@ ACX MP3 must be strict CBR. Use LAME via FFmpeg with `-b:a 192k -abr 0`.
 | Concern | Technology |
 |---|---|
 | Decode / encode / resample | FFmpeg |
-| Noise reduction (preset chain + spot NR) | DeepFilterNet3 (`deepfilternet` / `libdf`) |
-| Pre-separation noise reduction (Noise Eraser) | RNNoise (`pyrnnoise`) |
+| Noise reduction | DeepFilterNet3 (`deepfilternet` / `libdf`), RNNoise (`pyrnnoise`), DTLN |
 | Source separation (Noise Eraser) | Demucs `htdemucs_ft` (primary); ConvTasNet via `asteroid` (fallback) |
-| Bandwidth extension (Noise Eraser) | AudioSR (`audiosr` Python package, conditional) |
-| Dereverberation | NARA-WPE (`nara-wpe` + `librosa` Python packages) |
-| Voice activity detection | Silero VAD v5 (`silero-vad`, via `torch.hub`) |
+| Bandwidth extension | AP-BWE (`ap_bwe`), LavaSR — available but currently disabled in presets |
+| Speech enhancement (General Clean) | ClearerVoice (`mossformer2_48k` or `frcrn_16k`) |
 | Spectral analysis | Meyda.js (in-process, Node.js) |
 | Enhancement EQ | FFmpeg `equalizer` filter (parametric biquad IIR) |
-| Compression (preset chain) | Custom DSP (JavaScript) |
-| RMS / LUFS measurement | libebur128-wasm (WASM bindings) |
+| Compression / dynamics | Custom DSP (JavaScript) — compression, parallel compression, vocal expander, auto leveler |
+| RMS / LUFS measurement | libebur128 (node-ebur128 bindings) |
 | True peak limiting | FFmpeg `loudnorm` (two-pass, 192 kHz upsample) |
 | MP3 encoding | LAME via FFmpeg |
 | Server framework | Express 5.1.0 (ES modules) |
@@ -383,8 +345,6 @@ ACX MP3 must be strict CBR. Use LAME via FFmpeg with `-b:a 192k -abr 0`.
 | Framework | Vue 3 (Composition API) |
 | Build | Vite 8.0.1 |
 | Styling | Tailwind CSS 4.2.2 |
-| Normalize (spot) | Pure JS — peak scan + linear gain multiply |
-| Compression (spot) | OfflineAudioContext + native DynamicsCompressorNode |
 | Waveform rendering | Canvas 2D API, peak data from server |
 | Playback | Web Audio API (`AudioBufferSourceNode`) |
 | Segment editing | Pure JS — no audio data touched |
@@ -401,14 +361,13 @@ ACX MP3 must be strict CBR. Use LAME via FFmpeg with `-b:a 192k -abr 0`.
 1. ✓ **Sprint 1** — Core pipeline (ACX Audiobook): FFmpeg decode + HPF + mono → DeepFilterNet3 → normalization + limiting → libebur128 → ACX certification → WAV/MP3 output
 2. ✓ **Sprint 2** — Enhancement quality (ACX): Meyda.js EQ → silence exclusion → room tone padding → quality advisory flags (overprocessing, breath, plosive detection)
 3. ✓ **Sprint 3** — De-esser + compression (ACX): F0 estimation → sibilance analysis → conditional de-esser → conditional compression
-4. ✓ **Sprint 4** — Preset and output profile architecture: separate preset/output profile configs → Podcast Ready, Voice Ready, General Clean → LUFS normalization path → output profile selector in UI → output measurements reporting for non-ACX profiles
-5. ✓ **Sprint Dereverb** *(post-Sprint 4, unnumbered)* — Dereverberation: NARA-WPE integration → light/medium/heavy paths → added to standard and Noise Eraser pipelines → noise floor recalculation post-dereverb
-6. ✓ **Sprint NE-1** — Noise Eraser core path: RNNoise pre-pass → Demucs separation → residual DF3 cleanup → Stage 5–7 → validate on high-noise test corpus
-7. ✓ **Sprint NE-2** — Noise Eraser full pipeline: tonal pre-treatment → sibilance/breath assessment → AudioSR bandwidth extension → post-separation EQ → separation quality rating in report; ConvTasNet (asteroid) added as separation fallback
-8. ✓ **Sprint Auto-Leveler** *(post-NE-2, PR #26)* — Auto Leveler Stage 4b: Silero VAD v5 integration → VAD-gated gain riding → applied to all standard presets → silence analysis framework unified on frame-based measurement
-9. ✗ **Sprint 5** — Batch processing (ACX): batch analysis → per-file processing → consistency pass → batch report *(Creator tier gate — primary differentiator for narrators)*
-10. ✗ **Sprint 6** — Commercial library evaluation: Krisp vs. DeepFilterNet3 on real narrator recordings
-11. ✗ **Sprint NE-3** — Noise Eraser benchmarking: test corpus across noise floor severity levels → calibrate NE-4 thresholds → validate AudioSR guidance scale → Demucs vs. ConvTasNet comparison
+4. ✓ **Sprint 4** — Preset and output profile architecture: separate preset/output profile configs → Podcast Ready, General Clean → LUFS normalization path → output profile selector in UI → output measurements reporting for non-ACX profiles
+5. ✓ **Sprint NE-1** — Noise Eraser core path: spectral subtraction → DF3 → tonal pretreatment → Demucs separation → separation validation → Stage 5–7; ConvTasNet (asteroid) added as fallback
+6. ✓ **Sprint Auto-Leveler** — Auto Leveler + pipeline refactor: VAD-gated gain riding → silence analysis framework unified on frame-based measurement → pipeline becomes fully config-driven via preset `stages` array
+7. ✓ **Sprint Pipeline Expansion** — Extended stage registry: clip-gain de-esser → corrective EQ → reference EQ → air boost → resonance suppressor → vocal saturation → room presence → spectral subtraction → click remover → hum detector → vocal expander → parallel compression → ClearerVoice integration (General Clean) → multi-pass crest-factor compression for all presets
+8. ✗ **Sprint 5** — Batch processing (ACX): batch analysis → per-file processing → consistency pass → batch report *(Creator tier gate — primary differentiator for narrators)*
+9. ✗ **Sprint 6** — Commercial library evaluation: Krisp vs. DeepFilterNet3 on real narrator recordings
+10. ✗ **Sprint NE-3** — Noise Eraser benchmarking: test corpus across noise floor severity levels → validate bandwidth extension → Demucs vs. ConvTasNet comparison
 
 ---
 
@@ -461,7 +420,7 @@ ACX MP3 must be strict CBR. Use LAME via FFmpeg with `-b:a 192k -abr 0`.
 |---|---|---|
 | `docs/instant_polish_processing_spec_v3.md` | ✓ Present | Full processing chain technical specification. Authoritative source for all processing parameters, stage definitions, preset profiles, and output profile behavior. |
 | `docs/instant_polish_compliance_model_v2.md` | ✓ Present | ACX certification system, quality advisory flag definitions, report JSON structure, and UI model. Authoritative source for all compliance and reporting behavior. |
-| `docs/instant_polish_processing_spec_noise_eraser.md` | ✓ Present | Noise Eraser preset specification. Parallel processing path (NE-1 through NE-7). Read alongside v3 spec, not as a standalone. |
+| `docs/instant_polish_processing_spec_noise_eraser.md` | ✓ Present | Noise Eraser preset specification. Documents the separation-based processing stages and their parameters. Read alongside v3 spec. Note: the NE-1 through NE-7 stage numbering used in this doc is deprecated — NE is now a standard preset in the unified pipeline. |
 | `docs/acx_production_workflow.md` | ✗ Not present | ACX narrator workflow reference. Context for why features exist and where Instant Polish fits in the production chain. |
 | `docs/instant_polish_gtm.md` | ✗ Not present | Go-to-market strategy. Positioning, pricing, launch plan, SEO content map. |
 

--- a/docs/instant_polish_compliance_model_v2.md
+++ b/docs/instant_polish_compliance_model_v2.md
@@ -102,7 +102,7 @@ Quality advisory flags run for all presets and all output profiles. The specific
 | `plosives` | Sharp low-frequency transients consistent with unedited plosives | Review | "Possible plosive sounds detected. These may require manual editing." |
 | `noise_floor_marginal` | Noise floor -60 to -62 dBFS (passes certification but close to limit) | Info | "Noise floor is within spec but close to the limit. Re-recording in a quieter environment would add headroom." |
 | `high_nr_tier` | Noise reduction Tier 4 was applied | Info | "Heavy noise reduction was applied. Some processing character may be audible on close listening." |
-| `separation_used` | `noise_eraser` preset was used | Review | "Voice separation was used. The output may have a processed quality. Review carefully before submitting to ACX." |
+| `separation_used` | `noise_eraser` preset was used (contains `separateVocals` stage) | Review | "Voice separation was used. The output may have a processed quality. Review carefully before submitting to ACX." |
 | `over_expansion` | `pct_frames_expanded` > 35% OR any VAD-voiced frame received > 3 dB attenuation from the Stage 4a-E vocal expander | Review | "The expander may have affected quiet speech. Listen for unnatural silences between words or clipped consonants." |
 | `chapter_outlier` | Batch mode: this file deviates > 2 dB from batch median after consistency pass | Review | "This chapter sounds noticeably different from the rest of the batch. Review for consistency." |
 
@@ -110,9 +110,9 @@ Quality advisory flags run for all presets and all output profiles. The specific
 
 **`noise_floor_marginal`** applies when `output_profile = acx` only — the marginal threshold is defined relative to ACX's -60 dBFS requirement.
 
-**`separation_used`** applies when `preset = noise_eraser` regardless of output profile.
+**`separation_used`** applies when the `separateVocals` stage ran (i.e. `preset = noise_eraser`) regardless of output profile.
 
-**`over_expansion`** applies only when the Stage 4a-E vocal expander actually ran (`vocal_expander.applied = true`).
+**`over_expansion`** applies only when the vocal expander stage actually ran (`vocal_expander.applied = true`).
 
 All other flags apply to all presets and output profiles.
 
@@ -273,4 +273,4 @@ When `output_profile = acx` and certification passes, surface an "Export Certifi
 
 ---
 
-*This document is a companion to `instant_polish_processing_spec_v3.md` and `instant_polish_processing_spec_noise_eraser.md`.*
+*This document is a companion to `instant_polish_processing_spec_v3.md` (v3.2) and `instant_polish_processing_spec_noise_eraser.md`.*

--- a/docs/instant_polish_processing_spec_noise_eraser.md
+++ b/docs/instant_polish_processing_spec_noise_eraser.md
@@ -1,5 +1,13 @@
 # Instant Polish — Noise Eraser Preset Specification
-> Addendum to Processing Chain Technical Specification v3.1 | April 2026
+> Addendum to Processing Chain Technical Specification v3.2 | May 2026
+
+---
+
+## Architecture Note
+
+**The `noise_eraser` preset is a standard preset in the unified config-driven pipeline.** It uses the same pipeline runner and stage registry as `acx_audiobook`, `podcast_ready`, and `general_clean`. There is no separate "Noise Eraser pipeline" in the codebase. The preset declares its own `stages` array in `src/audio/presets.js`, and the orchestrator executes those stages like any other preset.
+
+The stage numbering in this document (NE-1 through NE-7) is a **documentation convention only** — it does not exist in the code. The authoritative stage sequence is the `noise_eraser` preset's `stages` array. Use this document for understanding the purpose and parameters of each separation-related stage; use `src/audio/presets.js` for the actual ordering, inline config, and currently active stages.
 
 ---
 
@@ -7,7 +15,7 @@
 
 This document specifies the `noise_eraser` preset as an addendum to the v3 processing chain specification. It follows the same preset + output profile architecture established in v3.1. Where this document is silent, v3.1 defaults apply.
 
-Noise Eraser is a **parallel processing path**, not an extension of the standard noise reduction chain. It does not use the Stage 1–6 chain defined in v3. It replaces Stages 1–4a with a source separation pipeline, then rejoins the standard chain at Stage 5 (Loudness Normalization) and Stage 6 (True Peak Limiting). Stage 7 (Measurement and Processing Report) runs as normal with noise-eraser-specific additions.
+Noise Eraser's distinguishing characteristic is its use of **source separation** (Demucs) rather than noise reduction filters as its primary voice extraction method. The pre-separation and post-separation stages are otherwise drawn from the same stage registry used by all other presets.
 
 ---
 
@@ -23,67 +31,63 @@ The tradeoff is explicit: Noise Eraser prioritizes noise removal over voice tran
 
 ## Preset Registration
 
-Add to the preset table in v3 § "Presets":
+The `noise_eraser` preset is defined in `src/audio/presets.js` alongside the other presets.
 
 | Preset ID | Display name | Primary audience |
 |---|---|---|
 | `noise_eraser` | Noise Eraser | Severely noisy recordings where standard processing has failed |
 
-**Default output profile:** `standard`
+**Default output profile:** `podcast`
 
 The output profile is user-overridable. However: noise floor enforcement (`acx`) should not be the default for this preset. Source separation does not guarantee a -60 dBFS noise floor, and presenting ACX compliance as the default target would produce misleading pass/fail results. If a user selects `acx` output profile with `noise_eraser`, surface a warning: *"ACX compliance is not recommended for Noise Eraser output. Separation artifacts may cause ACX human review rejection even if measurements pass."*
 
 ---
 
-## Processing Chain: Noise Eraser Path
+## Processing Chain: Noise Eraser Stage Sequence
+
+The active stage sequence is defined in `src/audio/presets.js`. As of May 2026, the `noise_eraser` stages array runs approximately:
 
 ```
-Input
-  │
-  ├── Pre-processing (decode, resample, channel handling) — same as v3
-  │
-  ├── Stage NE-1:  Pre-separation RNNoise pass
-  ├── Stage NE-2:  Tonal noise pre-treatment (conditional)
-  ├── Stage NE-3:  Demucs source separation (htdemucs_ft, vocals model)
-  ├── Stage NE-4:  Post-separation validation and artifact assessment
-  ├── Stage NE-5:  Residual cleanup (conditional light DF3 pass)
-  ├── Stage NE-6:  Bandwidth extension (AudioSR)
-  ├── Stage NE-7:  Post-separation enhancement EQ
-  │
-  ├── Stage 4a:    Serial compression (standard DSP)
-  ├── Stage 4a-PC: Parallel compression (wet/dry blend)
-  ├── Stage 4a-E:  Vocal Expander (frequency-selective silence-floor attenuator)
-  ├── Stage 4b:    Auto Leveler (VAD-gated gain riding, conditional)
-  │
-  ├── Stage 5:     Loudness Normalization (v3, standard path)
-  ├── Stage 6:     True Peak Limiting (v3, standard path)
-  └── Stage 7:     Measurement + Processing Report (v3, with NE additions)
+decode → measureBefore → peakNormalize → analyzeFramesRaw
+→ humDetect → hpf
+→ spectralSubtraction → noiseReduce (df3)
+→ tonalPretreatment
+→ separateVocals (demucs)
+→ separationValidation
+→ bandwidthExtension (currently disabled — enabled: false)
+→ remeasureFramesPostNr
+→ vocalExpander (pass 1, conservative)
+→ vocalSaturation
+→ compress (3 passes)
+→ vocalExpander (pass 2, more aggressive)
+→ vadGate (currently disabled)
+→ autoLevel
+→ airBoost → roomPresence (currently disabled)
+→ normalize → truePeakLimit → measureAfter
+→ acxCertification → qualityAdvisory → encode → extractPeaks
 ```
 
-**Stages skipped vs. v3 standard chain:**
-- Stage 1 (High-Pass Filter) — subsumed by NE-2 tonal pre-treatment and Demucs separation
-- Stage 2 (Adaptive Noise Reduction / DF3) — replaced by NE-1 through NE-5
-- Stage 3 (Enhancement EQ) — replaced by NE-7 (post-separation EQ, different reference profile)
-- Stage 4 (De-esser) — not applied; separation-induced sibilance changes are addressed in NE-7
-
-**Note on compression:** The Noise Eraser path now includes Stage 4a / 4a-PC compression (aligned with the standard chain) followed by Stage 4a-E (vocal expander) and Stage 4b (auto leveler). The expander is calibrated from the measured silence P90 on the *current* signal regardless of what produced it, so the absence of upstream compression (for `clearervoice_eraser`) does not break calibration. Output crest factor is still logged; if below 8 dB after normalization, a warning appears in the report.
+**How this differs from standard presets:**
+- Uses `tonalPretreatment` → `separateVocals` → `separationValidation` as the core voice extraction path
+- No `correctiveEQ` or `referenceEQ` — post-separation tonal correction relies on `airBoost` + `vocalSaturation`
+- No `clipGainDeEss` — de-essing on separated audio can further damage already-altered sibilance
+- `vocalExpander` runs twice: once before compression (conservative) and once after (more aggressive)
+- RNNoise pre-pass described in earlier specs is replaced by spectral subtraction + DF3 before separation
+- `bandwidthExtension` is present in the stages array but currently disabled
 
 ---
 
-## Stage NE-1 — Pre-separation RNNoise Pass
+## Stage NE-1 — Pre-separation Noise Reduction
 
-**Purpose:** Reduce the stationary component of the noise floor before handing off to Demucs. Source separation models perform better when the SNR is improved going in, even modestly. RNNoise is cheap to run and provides a meaningful pre-reduction with minimal artifact risk at this stage.
+**Current implementation:** The preset runs `spectralSubtraction` followed by `noiseReduce` (DF3) before handing off to Demucs. This replaces the earlier design of a standalone RNNoise pre-pass.
 
-**Implementation:** RNNoise (Mozilla). Python `pyrnnoise` bindings or equivalent server-side wrapper.
+**Purpose:** Reduce the stationary component of the noise floor before source separation. Separation models perform better when the SNR is improved going in, even modestly.
 
-**Parameters:**
-- Apply unconditionally to all `noise_eraser` files — no tier gating
-- No attenuation ceiling — allow RNNoise to operate at its natural output level
-- Do not apply post-pass artifact check at this stage; artifact assessment runs after full separation in NE-4
+**Stage sequence in current preset:** `spectralSubtraction` (MMSE Wiener with transient shaping) → `noiseReduce { model: "df3" }` → then separation.
 
-**Expected contribution:** Approximately 5–10 dB reduction of stationary broadband noise. Non-stationary components (wind, crowd, variable ambient) will be reduced less. The goal is not to clean the file — it is to reduce the job Demucs has to do, improving separation quality on the residual.
+**Expected contribution:** Reduces stationary broadband noise before separation. Non-stationary components will be reduced less. The goal is not to fully clean the file — it is to reduce the job Demucs has to do.
 
-**Logging:** Record pre-RNNoise and post-RNNoise noise floor in processing report.
+**Logging:** Frame analysis (`analyzeFramesRaw`) before this block establishes the pre-processing noise floor.
 
 ---
 
@@ -101,7 +105,7 @@ Input
 
 ---
 
-## Stage NE-3 — Demucs Source Separation
+## Stage NE-3 — Source Separation (Demucs)
 
 **Purpose:** Extract the voice signal from the mixture, discarding all non-voice content.
 
@@ -146,21 +150,19 @@ If no voiced frames are detected in the post-separation output (separation has p
 
 ---
 
-## Stage NE-5 — Residual Cleanup (Conditional)
+## Stage NE-5 — Residual Cleanup
 
-**Purpose:** Mop up residual noise bleed that Demucs did not fully suppress. Separation is not perfect — low-level background content bleeds through, particularly in the high-frequency range.
+**Note:** A separate explicit residual cleanup stage is not currently in the `noise_eraser` stages array. The `noiseReduce` call before separation (NE-1) handles pre-separation noise reduction. Post-separation cleanup is handled by the `remeasureFramesPostNr` + `vocalExpander` combination which attenuates the remaining noise floor in silence gaps.
 
-**Trigger condition:** Post-separation noise floor (measured in NE-4) > -55 dBFS. If the noise floor is already below -55 dBFS, skip this stage.
+The design rationale below describes the intended behavior if a post-separation DF3 pass is added:
 
-**Implementation:** DeepFilterNet3, light pass. Tier 2 ceiling (8 dB max attenuation). This is a cleanup pass, not a primary reduction pass — DF3 is being asked to handle a much smaller residual problem than in the standard chain. Apply conservatively.
-
-**Artifact check:** Run post-pass spectral flatness check as in v3 Stage 2c. If artifacts are detected, reduce DF3 attenuation by 50% and re-run once. If artifacts persist, skip NE-5 and log "Residual cleanup skipped — artifact risk. Residual noise floor: [X] dBFS."
-
-**If noise floor is still above -55 dBFS after NE-5:** Do not apply further reduction. Log the measured value. Report will surface this as a warning, not a failure — the separation has already done the primary work, and the residual is likely low-amplitude non-stationary content that further processing cannot cleanly address.
+**Trigger condition:** Post-separation noise floor > -55 dBFS. Light DF3 pass (8 dB max attenuation) to mop up residual bleed. If artifacts are detected, reduce attenuation and re-run once. If the noise floor remains above -55 dBFS after cleanup, report the value as a warning — do not over-process.
 
 ---
 
 ## Stage NE-6 — Bandwidth Extension
+
+**Current status:** The `bandwidthExtension` stage is present in the `noise_eraser` stages array with `enabled: false`. It can be enabled per-request via `presetOverrides` or by updating the preset config.
 
 **Purpose:** Restore high-frequency voice content attenuated during source separation. Demucs, like all separation models, tends to suppress high-frequency content in noisy conditions because broadband noise and voice air/presence occupy the same spectral region. The output voice can sound dull or "close" compared to the original.
 
@@ -189,9 +191,11 @@ If no voiced frames are detected in the post-separation output (separation has p
 
 ## Stage NE-7 — Post-separation Enhancement EQ
 
-**Purpose:** Correct tonal imbalances introduced by the separation and bandwidth extension process. The post-separation voice has a different spectral character than a cleanly recorded voice — the EQ reference used in v3 Stage 3 is calibrated for recorded voices, not separated voices. A separation-specific reference is needed.
+**Current status:** The `noise_eraser` preset does not currently run `correctiveEQ` or `referenceEQ`. Post-separation tonal correction is handled by `airBoost` and `vocalSaturation`. A full post-separation EQ pass with a separation-specific reference profile is the intended future state.
 
-**Implementation:** FFmpeg `equalizer` filter, parametric biquad IIR. Same implementation as v3 Stage 3, different reference profile.
+**Purpose:** Correct tonal imbalances introduced by the separation and bandwidth extension process. The post-separation voice has a different spectral character than a cleanly recorded voice — a separation-specific EQ reference is needed.
+
+**Implementation:** FFmpeg `equalizer` filter, parametric biquad IIR.
 
 **Noise Eraser EQ reference profile:**
 
@@ -300,30 +304,30 @@ Aggregate the NE-4 assessments into a single separation quality indicator with t
 
 | Parameter | Value | Rationale |
 |---|---|---|
-| Processing path | Parallel (NE-1 through NE-7) | Replaces v3 Stages 1–4a |
-| Pre-separation pass | RNNoise (unconditional) | Improves Demucs input SNR |
-| Tonal pre-treatment | Notch filtering (conditional) | Removes periodic noise Demucs handles poorly |
-| Primary separation | Demucs `htdemucs_ft` | Voice extraction rather than noise reduction |
-| Residual cleanup | DF3 Tier 2 (conditional, > -55 dBFS) | Mops up separation bleed |
-| Bandwidth extension | AudioSR | Restores high-frequency content lost in separation |
-| Post-separation EQ | Separation-specific reference profile | Corrects tonal imbalances from separation process |
-| De-esser | Not applied | Separation already alters sibilance; calibration not validated |
-| Compression | Not applied | Separation output has compressed character; avoid stacking |
-| Channel output | Mono (default) | Most Noise Eraser use cases are mono deliverables |
-| Default output profile | `standard` | ACX output profile not recommended for separation output |
+| Pipeline | Unified (same runner as all presets) | `noise_eraser` is a preset, not a separate pipeline |
+| Pre-separation NR | spectralSubtraction → DF3 | Improves Demucs input SNR |
+| Tonal pre-treatment | `tonalPretreatment` (conditional notch filtering) | Removes periodic noise Demucs handles poorly |
+| Primary separation | `separateVocals` — Demucs `htdemucs_ft` (default) or ConvTasNet | Voice extraction rather than noise reduction |
+| Post-separation validation | `separationValidation` | Artifact assessment, sibilance/breath ratios |
+| Residual cleanup | Not currently an explicit stage — handled by vocalExpander | Future: conditional DF3 light pass |
+| Bandwidth extension | AP-BWE (present but disabled) | Can be enabled; restores HF lost in separation |
+| Post-separation EQ | `airBoost` + `vocalSaturation` | Full corrective/reference EQ not applied to separated audio |
+| De-esser | Not applied | Separation already alters sibilance; clip-gain de-esser would need re-calibration |
+| Compression | 3 passes (crest-factor driven) | Runs on separated signal |
+| Vocal expander | 2 passes (before and after compression) | Addresses noise floor bleed in silence gaps |
+| Channel output | Mono | Most Noise Eraser use cases are mono deliverables |
+| Default output profile | `podcast` | ACX output profile not recommended for separation output |
 | Noise floor enforcement | Not enforced by default | Separation does not guarantee -60 dBFS |
 
 ---
 
-## Library Additions
-
-Add to the Library Reference table in v3:
+## Library Reference (Noise Eraser specific)
 
 | Stage | Library / Tool | License | Cost |
 |---|---|---|---|
-| Pre-separation noise reduction | RNNoise (`pyrnnoise`) | BSD | Free |
 | Source separation | Demucs `htdemucs_ft` (`demucs` Python package) | MIT | Free |
-| Bandwidth extension | AudioSR (`audiosr` Python package) | MIT | Free |
+| Source separation (fallback) | ConvTasNet via `asteroid` | MIT | Free |
+| Bandwidth extension | AP-BWE (`ap_bwe`) / LavaSR | MIT | Free |
 
 ---
 

--- a/docs/instant_polish_processing_spec_v3.md
+++ b/docs/instant_polish_processing_spec_v3.md
@@ -1,6 +1,6 @@
 # Instant Polish — Audio Processing Chain: Technical Specification
-> Version 3.1 | April 2026
-> Supersedes v3.0
+> Version 3.2 | May 2026
+> Supersedes v3.1
 
 ---
 
@@ -8,7 +8,9 @@
 
 This document specifies the complete audio processing chain for Instant Polish. All processing runs server-side. The browser handles file upload, waveform visualization, playback of both the original and processed audio, and the processing report.
 
-The processing chain is designed to serve multiple use cases through a **preset + output profile** architecture. A preset defines the character of the processing — the EQ curve, compression behavior, noise reduction aggressiveness, and target loudness. An output profile defines the loudness target, peak ceiling, and measurement method the chain tries to achieve. These are independent selections.
+The processing chain is designed to serve multiple use cases through a **preset + output profile** architecture. A preset defines the character of the processing. An output profile defines the loudness target, peak ceiling, and measurement method the chain tries to achieve. These are independent selections.
+
+**Architecture note (v3.2 — config-driven pipeline):** The pipeline is fully config-driven. There is no hardcoded stage ordering. Each preset declares its own `stages` array in `src/audio/presets.js`, and the pipeline runner (`server/pipeline/index.js`) executes those stages sequentially via a stage registry in `server/pipeline/stages.js`. The stage numbering used in this document (Stage 1, Stage 2, Stage 4a, etc.) is a documentation convention only — it does not exist in the code. The actual stage sequence for any preset is authoritative in its `stages` array. Stages can appear multiple times, carry inline config overrides, and be omitted entirely for a given preset. There is no separate "Noise Eraser pipeline" — `noise_eraser` is a preset that uses the same runner and stage registry as every other preset.
 
 **Architecture note (v3.1):** Previous versions of this spec used the term "compliance target" for what is now called "output profile." The rename reflects a cleaner separation of concerns: an output profile drives processing decisions (normalization target, peak ceiling, measurement method). Compliance certification — checking the output against a formal external standard — is a separate post-processing step documented in the Compliance and Quality Review Model addendum. Output profiles and compliance certification are independent; not all output profiles have a corresponding formal certification standard.
 
@@ -63,8 +65,8 @@ Four presets ship at launch:
 |---|---|---|
 | `acx_audiobook` | ACX Audiobook | Audiobook narrators submitting to ACX/Audible |
 | `podcast_ready` | Podcast Ready | Podcast hosts and interview recordings |
-| `voice_ready` | Voice Ready | Voice actors, general voice-over |
 | `general_clean` | General Clean | Everyone else; default for unspecified use |
+| `noise_eraser` | Noise Eraser | Severely noisy recordings where standard processing has failed |
 
 Preset parameters are defined in full in the **Preset Profiles** section below.
 
@@ -88,12 +90,12 @@ Each preset has a natural default output profile, applied automatically unless o
 
 | Preset | Default output profile |
 |---|---|
-| `acx_audiobook` | `acx` |
+| `acx_audiobook` | `acx` (locked — output profile selector hidden in UI) |
 | `podcast_ready` | `podcast` |
-| `voice_ready` | `acx` |
 | `general_clean` | `podcast` |
+| `noise_eraser` | `podcast` |
 
-The user can override the output profile for any preset. The most common override: a narrator who prefers the processing character of `voice_ready` but needs their files to target ACX loudness levels.
+The user can override the output profile for any unlocked preset. Example: processing with `podcast_ready` character but targeting ACX loudness levels by selecting the `acx` output profile.
 
 ### How Preset and Output Profile Interact
 
@@ -178,42 +180,11 @@ Each preset is defined by the parameter values it passes to each processing stag
 
 ---
 
-### Preset: Voice Ready (`voice_ready`)
-
-**Use case:** Voice actors recording commercial copy, explainer videos, corporate narration, e-learning, and general voice-over work. Unlike ACX Audiobook, there is no single platform standard — the output needs to sound professional and versatile across different downstream contexts.
-
-**Character:** Clean, broadcast-quality, neutral. Sits between ACX Audiobook (very transparent, minimal processing) and Podcast Ready (punchy, compressed). Enough presence to cut through a mix but not so bright it clashes with music beds.
-
-| Parameter | Value | Rationale |
-|---|---|---|
-| Target loudness | -20 dBFS RMS | Broadcast-neutral; compatible with ACX and most video/multimedia workflows |
-| True peak ceiling | -3 dBFS | Leaves headroom for downstream mixing |
-| Noise floor target | Not enforced by default | No platform-specific noise floor requirement |
-| Noise reduction ceiling | Tier 3 (8 dB max) | |
-| Compression | Always applied | Commercial voice-over requires consistent level |
-| Compression ratio | 2.5:1 | More than ACX Audiobook, less than Podcast Ready |
-| Compression threshold | -22 dBFS | |
-| Compression attack | 8 ms | |
-| Compression release | 90 ms | |
-| EQ reference profile | Voice-over reference | Presence-forward, mild warmth cut, conservative air boost for studio character |
-| De-esser sensitivity | Standard (P95 > mean + 8 dB trigger) | |
-| De-esser max reduction | 5 dB | |
-| Channel output | Mono | Most voice-over deliverables are mono |
-| Default output profile | `acx` | ACX targets are conservative and appropriate for most voice-over deliverables |
-
-**Voice Ready notes:**
-- No room tone padding
-- No chapter batch processing
-- The -3 dBFS peak ceiling and -20 dBFS loudness target make this preset naturally ACX-certifiable when `acx` output profile is selected, without additional processing
-- ACX certification runs when output profile is `acx`
-
----
-
 ### Preset: General Clean (`general_clean`)
 
 **Use case:** Everything else — meeting recordings, lecture captures, field recordings, dictation, demo submissions, informal audio. The user has a file that sounds bad and wants it to sound better. No platform-specific requirements.
 
-**Character:** Pragmatic. More aggressive noise reduction than other presets. Balanced EQ with no strong character. Moderate compression for consistency.
+**Character:** Pragmatic. Uses ClearerVoice speech enhancement as the primary enhancement stage rather than standard EQ. Balanced, no strong tonal character. Moderate compression for consistency.
 
 | Parameter | Value | Rationale |
 |---|---|---|
@@ -286,15 +257,42 @@ These are the "before" values in the processing report.
 
 ## Processing Chain
 
+The stage sequence below reflects the general processing order shared by most presets, using documentation stage numbers for reference. The authoritative stage sequence for each preset is its `stages` array in `src/audio/presets.js` — refer there for the exact order, inline config, and any multi-pass calls.
+
+**Typical order (varies by preset):**
 ```
-Stage 1:  High-Pass Filter
-Stage 2:  Adaptive Noise Reduction
-Stage 3:  Enhancement EQ
-Stage 4:  De-esser (conditional)
-Stage 4a: Compression (conditional or always-on, per preset)
-Stage 5:  Loudness Normalization        ← output profile governs target and method
-Stage 6:  True Peak Limiting            ← output profile governs ceiling
-Stage 7:  Measurement + Processing Report
+Pre:      Decode → mono mixdown (if applicable) → measure before → peak normalize
+          → frame analysis (noise floor, VAD)
+          → hum detect → HPF → click removal
+
+NR:       Noise reduce (one or more passes, model switchable)
+          → spectral subtraction
+          → remeasure frames
+
+Voice:    Auto leveler → clip-gain de-esser → corrective EQ
+          → remeasure frames
+
+Dynamics: Compression (multi-pass, crest-factor driven)
+          → remeasure frames → parallel compression
+          → vocal expander (optional)
+
+Tonal:    Air boost → reference EQ → resonance suppressor
+          → vocal saturation → room presence (preset-dependent)
+
+Output:   Normalize ← output profile governs target and method
+          → true peak limit ← output profile governs ceiling
+          → measure after → ACX certification (if acx profile) → quality advisory
+          → encode → extract peaks
+```
+
+**Noise Eraser variant** replaces the NR block with source separation:
+```
+Pre:      ... same pre-processing ...
+          → spectral subtraction → DF3 noise reduce
+          → tonal pretreatment → separate vocals (Demucs / ConvTasNet)
+          → separation validation → bandwidth extension (optional)
+          → remeasure frames → vocal expander → ...
+          → (continues to dynamics/output as above)
 ```
 
 ---
@@ -361,7 +359,9 @@ After DF3 processing:
 
 **Purpose:** Improve tonal quality for the target use case. Runs after noise reduction, before normalization.
 
-**Implementation:** FFmpeg `equalizer` filter, parametric biquad IIR.
+**Implementation:** The current pipeline splits EQ into three separate stages in the stage registry: `correctiveEQ` (cepstral anomaly detection + adaptive parametric EQ), `referenceEQ` (corpus-reference broad tonal correction), and `airBoost` (high-frequency shelf with sibilance masking). Each is configured and ordered independently per preset. The description below reflects the combined intent.
+
+**EQ implementation:** FFmpeg `equalizer` filter, parametric biquad IIR.
 
 #### 3a — Spectral Analysis
 
@@ -407,7 +407,7 @@ No single band adjustment exceeds ±5 dB.
 
 **Purpose:** Reduce harsh sibilant energy.
 
-**Implementation:** Custom DSP — Meyda.js spectral analysis driving a frequency-selective compressor.
+**Implementation:** The current pipeline uses the `clipGainDeEss` stage (clip-gain de-esser): per-event sibilant reduction applied as a gain envelope over detected fricative and affricate events, rather than a traditional frequency-selective compressor. Parameters below reflect the general approach; see `src/audio/presets.js` for current per-preset values.
 
 **Trigger:** Standard (ACX Audiobook, Voice Ready): P95 > mean + 8 dB. Higher sensitivity (Podcast Ready, General Clean): P95 > mean + 6 dB. Skip if trigger not met.
 
@@ -431,23 +431,14 @@ F0 estimation → sibilant band identification → fricative event detection →
 
 **Purpose:** Reduce dynamic range to achieve the consistency appropriate to the target use case.
 
-| Preset | Applied | When |
+**Implementation:** The current compression model is crest-factor driven and multi-pass. Each compression call specifies a `targetCrestFactorDb` and `maxRatio`; the compressor adjusts dynamically to reach the target. Most presets run 2–3 serial compression passes with progressively lower target crest factors. Followed by `parallelCompress` (wet/dry parallel compression with VAD gate and integrated clip-gain de-esser). The fixed-ratio, fixed-threshold parameters described here are the historical specification; the authoritative current config is in `src/audio/presets.js`.
+
+| Preset | Compression passes | Notes |
 |---|---|---|
-| ACX Audiobook | Conditionally | Only when crest factor > 20 dB |
-| Podcast Ready | Always | |
-| Voice Ready | Always | |
-| General Clean | Always | |
-
-**Parameters by preset:**
-
-| Parameter | ACX Audiobook | Podcast Ready | Voice Ready | General Clean |
-|---|---|---|---|---|
-| Threshold | -24 dBFS | -20 dBFS | -22 dBFS | -20 dBFS |
-| Ratio | 2:1 | 3:1 | 2.5:1 | 3:1 |
-| Attack | 10 ms | 5 ms | 8 ms | 8 ms |
-| Release | 100 ms | 80 ms | 90 ms | 80 ms |
-| Knee | Soft, 4 dB | Soft, 4 dB | Soft, 4 dB | Soft, 4 dB |
-| Makeup gain | 0 dB | 0 dB | 0 dB | 0 dB |
+| ACX Audiobook | 2 passes | Target crest factor 15 dB each pass |
+| Podcast Ready | 2 passes | More aggressive — targets 14 dB then 10 dB |
+| General Clean | 1 pass (conditional) | ClearerVoice stage runs first |
+| Noise Eraser | 3 passes | Runs on separated signal |
 
 ---
 
@@ -455,7 +446,7 @@ F0 estimation → sibilant band identification → fricative event detection →
 
 **Purpose:** Dynamically attenuate residual low-level noise (room tone, HVAC, mic handling, floor rumble) that compression elevates in the silence gaps between words. Runs after Stage 4a-PC (parallel compression). Not a gate and not a replacement for Stage 2 noise reduction — a soft-ratio, band-weighted expander calibrated from the file's measured silence-energy distribution.
 
-**Applied:** All three pipelines (`STANDARD_PIPELINE`, `noise_eraser`, `clearervoice_eraser`), enabled by default. Skipped when the post-compression silence P90 RMS is already below -72 dBFS.
+**Applied:** Available in all presets; enabled per preset config. Skipped when the post-compression silence P90 RMS is already below -72 dBFS.
 
 **Architecture (two-path):**
 
@@ -491,20 +482,18 @@ y[i] = low[i] × gainLowLin[i] + (x[i] - low[i]) × gainHighLin[i]
 
 This is equivalent to the spec form `softened_ratio = 1 + (ratio - 1) × high_freq_depth`; the gain-dB-scaling form above is numerically identical and computationally simpler.
 
-**Parameters by preset:**
+**Parameters by preset (see `src/audio/presets.js` for authoritative values):**
 
-| Parameter | ACX Audiobook | Podcast Ready | Voice Ready | General Clean | Noise Eraser | ClearerVoice Eraser |
-|---|---|---|---|---|---|---|
-| Enabled | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
-| Ratio | 1.5:1 | 2.0:1 | 1.5:1 | 2.0:1 | 2.0:1 | 2.0:1 |
-| Headroom offset | +4 dB | +6 dB | +4 dB | +6 dB | +6 dB | +6 dB |
-| High-freq depth | 0.25 | 0.5 | 0.25 | 0.5 | 0.5 | 0.5 |
-| Release | 200 ms | 150 ms | 200 ms | 150 ms | 150 ms | 150 ms |
-| Attack | 10 ms | 10 ms | 10 ms | 10 ms | 10 ms | 10 ms |
-| Hold | 20 ms | 20 ms | 20 ms | 20 ms | 20 ms | 20 ms |
-| Lookahead | 10 ms | 10 ms | 10 ms | 10 ms | 10 ms | 10 ms |
-| Max attenuation | 12 dB | 18 dB | 12 dB | 18 dB | 18 dB | 18 dB |
-| Detection band | 80–800 Hz | 80–800 Hz | 80–800 Hz | 80–800 Hz | 80–800 Hz | 80–800 Hz |
+| Parameter | ACX Audiobook | Podcast Ready | Noise Eraser |
+|---|---|---|---|
+| Ratio | 2.5:1 | 2.0:1 | 1.5:1 then 2.0:1 (two calls) |
+| Headroom offset | +4 dB | +6 dB | +4 dB / +6 dB |
+| High-freq depth | 1.0 | 0.5 | 0.25 / 0.5 |
+| Release | 150 ms | 120 ms | 50 ms |
+| Max attenuation | — | — | 12 dB / 18 dB |
+| Detection band | 80–800 Hz | 80–800 Hz | 80–800 Hz |
+
+Note: `acx_audiobook` and `podcast_ready` currently have `vocalExpander` commented out in their stages arrays. `noise_eraser` uses it actively with two sequential calls (before and after compression). `general_clean` does not currently use the vocal expander.
 
 **Implementation note:** The spec originally suggested FFmpeg `volume` + `equalizer` filters, but time-varying per-sample gain with lookahead/hold/release cannot be expressed in FFmpeg filter graphs. Implementation uses the custom-JS DSP pattern already established by `compression.js`, `autoLeveler.js`, and `parallelCompression.js` — read WAV via `readWavAllChannels()`, build sample-level gain curve, write WAV via `writeWavChannels()`.
 
@@ -707,12 +696,12 @@ Quality advisory flags run regardless of output profile. Full flag definitions i
 |---|---|---|
 | ACX Audiobook | MP3 192 kbps CBR | LAME via FFmpeg, `-b:a 192k -abr 0`. ACX requires strict CBR. |
 | Podcast Ready | MP3 320 kbps CBR | |
-| Voice Ready | WAV only | Voice-over deliverables are typically WAV |
 | General Clean | MP3 256 kbps CBR | |
+| Noise Eraser | MP3 256 kbps CBR | |
 
 ---
 
-## Room Tone Padding (ACX Audiobook only)
+## Room Tone Padding (ACX Audiobook)
 
 ACX requires 0.5–1 second of room tone at the head and 1–5 seconds at the tail of each file.
 
@@ -721,9 +710,11 @@ ACX requires 0.5–1 second of room tone at the head and 1–5 seconds at the ta
 **Correction:**
 - Head room tone < 0.5 s → prepend to reach 0.75 s
 - Tail room tone < 1 s → append to reach 2 s
-- Source: 500 ms sample from the lowest-energy silence segment identified in Stage 2a
+- Source: 500 ms sample from the lowest-energy silence segment in the file
 
-Room tone padding is skipped for all other presets.
+The `roomTonePad` stage is implemented in the stage registry but is not currently included in any preset's `stages` array. It is available to add to `acx_audiobook` when needed.
+
+Room tone padding is not applicable for other presets.
 
 ---
 
@@ -778,18 +769,20 @@ For `podcast` and `broadcast` output profiles, the report section is titled **"O
 |---|---|---|---|
 | Decode / encode / resample / convert | FFmpeg (system binary) | LGPL | Free |
 | High-pass filter | FFmpeg `highpass` filter | LGPL | Free |
-| 60 Hz notch filter | FFmpeg `equalizer` filter | LGPL | Free |
-| Noise reduction | DeepFilterNet3 (`deepfilternet` or `libdf`) | MIT | Free |
-| Noise reduction (future upgrade) | Krisp AI Voice SDK | Commercial | Custom |
+| Notch / parametric EQ | FFmpeg `equalizer` filter | LGPL | Free |
+| Noise reduction (DF3) | DeepFilterNet3 (`deepfilternet` or `libdf`) | MIT | Free |
+| Noise reduction (RNNoise) | RNNoise (`pyrnnoise`) | BSD | Free |
+| Source separation | Demucs `htdemucs_ft` (`demucs` Python package) | MIT | Free |
+| Bandwidth extension | AP-BWE (`ap_bwe`) / LavaSR | MIT | Free |
+| Speech enhancement | ClearerVoice (`mossformer2_48k` / `frcrn_16k`) | MIT | Free |
 | Spectral analysis (EQ + de-esser) | Meyda.js (server-side) | MIT | Free |
-| Enhancement EQ | FFmpeg `equalizer` filter | LGPL | Free |
-| De-esser | Custom DSP (Meyda.js + frequency-selective compressor) | — | Free |
-| Compression | Custom DSP | — | Free |
+| Compression / dynamics | Custom DSP (JavaScript) | — | Free |
 | RMS / LUFS measurement | libebur128 via node-ebur128 | MIT | Free |
 | True peak limiting | FFmpeg `loudnorm` (two-pass, 192 kHz upsample) | LGPL | Free |
 | Noise floor measurement | Custom energy-thresholding | — | Free |
 | Waveform data generation | Custom peak extraction | — | Free |
 | MP3 encoding | LAME via FFmpeg | LGPL + LAME | Free |
+| Noise reduction (future upgrade) | Krisp AI Voice SDK | Commercial | Custom |
 
 ---
 
@@ -815,12 +808,12 @@ Meyda.js spectral analysis → adaptive enhancement EQ → dynamic silence exclu
 F0 estimation → sibilance analysis → conditional de-esser → conditional compression → report logging
 
 **Sprint 4 — Preset and output profile architecture:**
-Separate preset config from output profile config → implement Podcast Ready, Voice Ready, General Clean presets → LUFS normalization path → output profile selector in UI → preset-specific EQ reference profiles → output profile override indicator → output measurements reporting for non-ACX profiles
+Separate preset config from output profile config → implement Podcast Ready, General Clean presets → LUFS normalization path → output profile selector in UI → preset-specific EQ reference profiles → output profile override indicator → output measurements reporting for non-ACX profiles
 
-**Sprint 5 — Batch processing (ACX Audiobook):**
+**Sprint 5 (planned) — Batch processing (ACX Audiobook):**
 Batch analysis phase → per-file processing → consistency pass → batch report
 
-**Sprint 6 — Commercial library evaluation:**
+**Sprint 6 (planned) — Commercial library evaluation:**
 Krisp SDK evaluation on real narrator recordings vs. DeepFilterNet3 → commercial licensing decision
 
 ---
@@ -837,4 +830,4 @@ Both improvements are post-launch. The heuristic system ships first.
 
 ---
 
-*This specification supersedes v3.0. Companion documents: `acx_production_workflow.md`, `instant_polish_gtm.md`, `instant_polish_compliance_model_v2.md`, `instant_polish_processing_spec_noise_eraser.md`.*
+*This specification supersedes v3.1. Companion documents: `acx_production_workflow.md`, `instant_polish_gtm.md`, `instant_polish_compliance_model_v2.md`, `instant_polish_processing_spec_noise_eraser.md`. The Noise Eraser spec documents the separation stages; the NE-X stage numbering used there is a documentation convention — in the codebase, Noise Eraser is a standard preset in the unified pipeline.*


### PR DESCRIPTION
## Summary

This PR refactors the audio processing pipeline from a hardcoded stage-ordering model to a fully config-driven architecture, where each preset declares its own stage sequence in `src/audio/presets.js`. It also removes the `voice_ready` preset and consolidates its use cases into the remaining four presets.

## Key Changes

**Pipeline Architecture:**
- Moved from implicit stage ordering (Stage 1, Stage 2, etc.) to explicit `stages` arrays per preset
- Created a unified stage registry in `server/pipeline/stages.js` with 29 stage functions (up from implicit hardcoded chains)
- Stages can now appear multiple times per preset, carry inline config overrides, and be omitted entirely
- Eliminated separate "Noise Eraser pipeline" — `noise_eraser` is now a standard preset using the same orchestrator as all others
- Updated pipeline runner (`server/pipeline/index.js`) to execute stages sequentially from preset config

**Preset Changes:**
- Removed `voice_ready` preset (was targeting voice actors with broadcast-neutral character)
- Reduced from 5 to 4 presets at launch: `acx_audiobook`, `podcast_ready`, `general_clean`, `noise_eraser`
- Updated `general_clean` to use ClearerVoice speech enhancement as primary enhancement stage
- Updated `podcast_ready` to include vocal saturation and room presence for character
- Locked `acx_audiobook` output profile to `acx` (no longer user-overridable)

**Documentation Updates:**
- Updated CLAUDE.md to reflect config-driven architecture and removed spot NR section (deferred feature)
- Rewrote processing spec (v3.2) to document stage registry and per-preset stage sequences
- Updated Noise Eraser addendum to clarify it uses the unified pipeline, not a separate code path
- Removed `voice_ready` from all preset tables and parameter specifications
- Updated compliance model to reflect current preset count and stage availability

**Stage Registry Additions:**
- New stages: `correctiveEQ`, `referenceEQ`, `airBoost`, `clipGainDeEss`, `spectralSubtraction`, `clickRemove`, `dereverb`, `resonanceSuppressor`, `breathReduce`, `vocalExpander`, `compress`, `parallelCompress`, `autoLevel`, `vadGate`, `tonalPretreatment`, `separateVocals`, `separationValidation`, `bandwidthExtension`, `clearerVoiceEnhance`, `harmonicExciter`, `vocalSaturation`, `roomPresence`, `roomTonePad`
- Stages can be disabled per-preset via `enabled: false` flag
- Inline config overrides allow per-call parameter customization (e.g., `noiseReduce { model: "rnnoise" }`)

**Implementation Details:**
- No hardcoded stage ordering in runner — all sequences are data-driven from `presets.js`
- Stage results accumulate in `ctx.results`; absent stages produce no orphaned keys in report JSON
- Compression model is now crest-factor driven with dynamic ratio adjustment (not fixed-ratio)
- Vocal expander can run multiple times per preset with different parameters
- Room tone padding stage is implemented but not currently included in any preset's stages array
- Noise Eraser uses spectral subtraction + DF3 pre-separation, then Demucs separation, then bandwidth extension (currently disabled)

**Codebase Status:**
- Updated from ~57 source files, ~7,973 lines to ~60 source files, ~10,000+ lines
- Last updated: May 2026

https://claude.ai/code/session_01Lyc8v91cPJ9iw9KY8xaeY9