### PR TITLE
Add BassEnhance stage for psychoacoustic bass synthesis

### DIFF
--- a/docs/instant_polish_compliance_model_v2.md
+++ b/docs/instant_polish_compliance_model_v2.md
@@ -104,6 +104,7 @@ Quality advisory flags run for all presets and all output profiles. The specific
 | `high_nr_tier` | Noise reduction Tier 4 was applied | Info | "Heavy noise reduction was applied. Some processing character may be audible on close listening." |
 | `separation_used` | `noise_eraser` preset was used (contains `separateVocals` stage) | Review | "Voice separation was used. The output may have a processed quality. Review carefully before submitting to ACX." |
 | `over_expansion` | `pct_frames_expanded` > 35% OR any VAD-voiced frame received > 3 dB attenuation from the Stage 4a-E vocal expander | Review | "The expander may have affected quiet speech. Listen for unnatural silences between words or clipped consonants." |
+| `excessive_bass_enhancement` | BassEnhance ran with `mix > 0.5` AND post-blend low-band energy exceeds dry low-band energy by more than 6 dB | Review | "Synthesized bass may be exaggerated. Listen on small speakers — the effect can sound natural on headphones but boomy on phones and laptops." |
 | `chapter_outlier` | Batch mode: this file deviates > 2 dB from batch median after consistency pass | Review | "This chapter sounds noticeably different from the rest of the batch. Review for consistency." |
 
 **`loud_breaths` and `plosives`** apply when `preset = acx_audiobook` only. These are specifically ACX human review concerns and are not meaningful outside that context.
@@ -113,6 +114,8 @@ Quality advisory flags run for all presets and all output profiles. The specific
 **`separation_used`** applies when the `separateVocals` stage ran (i.e. `preset = noise_eraser`) regardless of output profile.
 
 **`over_expansion`** applies only when the vocal expander stage actually ran (`vocal_expander.applied = true`).
+
+**`excessive_bass_enhancement`** applies only when the BassEnhance stage actually ran (`bass_enhance.applied = true`). The low-band energy comparison is post-blend RMS in the band below `crossover_hz` vs. the same band in the dry input, captured by the stage as `low_band_gain_db`.
 
 All other flags apply to all presets and output profiles.
 

--- a/docs/instant_polish_processing_spec_v3.md
+++ b/docs/instant_polish_processing_spec_v3.md
@@ -276,8 +276,9 @@ Dynamics: Compression (multi-pass, crest-factor driven)
           → remeasure frames → parallel compression
           → vocal expander (optional)
 
-Tonal:    Air boost → reference EQ → resonance suppressor
-          → vocal saturation → room presence (preset-dependent)
+Tonal:    Bass enhance (psychoacoustic, optional) → air boost
+          → reference EQ → resonance suppressor → vocal saturation
+          → room presence (preset-dependent)
 
 Output:   Normalize ← output profile governs target and method
           → true peak limit ← output profile governs ceiling
@@ -527,6 +528,148 @@ Note: `acx_audiobook` and `podcast_ready` currently have `vocalExpander` comment
 When skipped: `{ "applied": false, "skipped_reason": "silence_floor_already_below_-72_dbfs" }` or similar reason string.
 
 **Advisory flag:** Emits `over_expansion` (severity `review`) when `pct_frames_expanded > 35` OR any VAD-voiced frame received more than 3 dB of attenuation.
+
+---
+
+### Stage 4b — Bass Enhance (Psychoacoustic, Optional)
+
+**Purpose:** Add perceived low-end weight to thin-sounding recordings without
+adding sub-bass energy that would overload downstream limiters or disappear on
+small speakers. MaxxBass-style: synthesise harmonic overtones of the
+fundamental and blend them additively into the dry signal — the ear infers
+the missing fundamental from its overtones.
+
+**Implementation:** `server/scripts/bass_enhance.py` (Python), invoked from
+`server/pipeline/bassEnhance.js`. Reuses `tube_saturate` from
+`vocal_saturation.py` for the waveshaper (2× oversampled tanh/arctan blend
+with asymmetric bias).
+
+**Upstream inputs consumed:**
+- VAD frames from `ctx.results.metrics.frames` (Silero, 25 ms hop)
+- F0 contour from `getF0Contour(ctx, { useCache: true })` in
+  `f0Analysis.js` (autocorrelation, 512-sample hop, [70, 400] Hz range)
+
+Neither is required; without them the stage falls back to a fixed crossover
+and treats the whole file as voiced. Quality is best with both present, and
+the canonical preset wiring always provides both.
+
+**Signal flow:**
+
+1. **Per-utterance F0 segmentation.** Contiguous voiced regions separated by
+   silence gaps ≥ `f0ClusterMinGapMs` are treated as utterances. Per-utterance
+   median F0 (clamped to `[f0MinHz, f0MaxHz]`) sets the LPF crossover at
+   `1.5 × medianF0`. Utterances with fewer than 10 valid F0 frames fall back
+   to the file median F0 (clamped) rather than the global
+   `crossoverFallbackHz`. This is **not speaker segmentation** — per-utterance
+   median F0 tracks real pitch shifts between utterances without claiming
+   speaker identification that F0 clustering cannot deliver reliably.
+
+2. **Band isolation.** 4th-order Butterworth LPF, crossfaded at utterance
+   boundaries over `segmentTransitionMs` (default 75 ms) in log-Hz space.
+   Implemented as a small bank of fixed LPFs at geometric cutoffs;
+   per-sample weighted interpolation across the bank yields the time-varying
+   cutoff without coefficient redesign.
+
+3. **Waveshaping.** Bass band → `tube_saturate(drive, softness, bias)`.
+   `softness` blends tanh (odd harmonics) → arctan (even harmonics, warmer).
+   `bias` adds asymmetry for even-harmonic weight. 2× oversampling inside
+   `tube_saturate` suppresses aliasing.
+
+4. **Fundamental removal (balanced HPF).** Time-varying HPF with cutoff
+   `f0_contour × fundamentalCutRatio`, smoothed causally over
+   `fundamentalCutSmoothMs` (default 50 ms). The default
+   `fundamentalCutRatio = 1.25` is a deliberate compromise:
+
+   | Cutoff (× F0) | F0 attenuation | 2·F0 attenuation | 3·F0 attenuation |
+   |---|---|---|---|
+   | 0.9             | ~-1 dB  | ~0 dB | ~0 dB |
+   | **1.25 (default)** | **~-8 dB** | **~-1 dB** | **~0 dB** |
+   | 1.7             | ~-24 dB | ~-3 dB | ~-1 dB |
+   | 2.0             | ~-30 dB | ~-6 dB | ~-1 dB |
+
+   `1.25 × F0` preserves ~80–90% of the 2nd harmonic and almost all of h3+
+   while attenuating the fundamental by ~7–10 dB. Some residual fundamental
+   survives, producing a small genuine sub-bass lift on top of the
+   psychoacoustic effect — intentional, and documented in the script's
+   docstring so future readers do not "fix" it back to `0.9`.
+
+   Implemented as a precomputed bank of 12 fixed HPFs at geometric cutoffs
+   covering `[f0MinHz, f0MaxHz] × fundamentalCutRatio`. Per-sample weighted
+   interpolation across the bank tracks the smoothed F0 contour without
+   per-frame biquad redesign.
+
+5. **VAD gate.** Per-sample mask derived from VAD frames, smoothed by an
+   asymmetric IIR envelope (`vadAttackMs` / `vadReleaseMs`). The 25 ms VAD
+   frame quantisation is the floor on attack sharpness; sub-frame attack
+   times act as envelope shaping on the step transitions. Music beds, sound
+   effects, and silence pass through completely untouched (bit-identical to
+   dry in the silence span).
+
+6. **Stereo handling.** Stereo input is summed to mono for the harmonics
+   chain; the harmonics-only signal is then added equally to both channels.
+   Bass is center — per-channel processing would create stereo
+   de-correlation in the bass band, which is generally undesirable.
+
+7. **Additive blend.** `output = audio + mix × gated_harmonics`. Dry signal
+   passes through unchanged.
+
+8. **Output normalization (optional).** When `normalizeOutput = true`,
+   RMS-match output to dry level so perceived loudness is independent of
+   `mix`. Defaults to on.
+
+**Skip conditions:**
+- `enabled: false` in the preset block → no-op, reported as
+  `{ applied: false, skipped_reason: "disabled by preset" }`.
+- VAD coverage below `skipIfVoicedRatioBelow` (default 0.05) → no-op,
+  reported as `{ applied: false, skip_reason: "voiced_ratio_below_threshold" }`.
+  Operating the saturator on a near-silent file would manufacture artifacts.
+
+**Pipeline position:** after `parallelCompression` (so compression dynamics
+don't gate the harmonics) and before `airBoost`, `referenceEQ`, `normalize`,
+`truePeakLimit` (so the loudness pass absorbs any residual energy shift from
+the blend, and the limiter targets the final mix).
+
+**Preset defaults:**
+
+| Preset | `enabled` | `crossoverFallbackHz` | `drive` | `softness` | `bias` | `mix` |
+|---|---|---|---|---|---|---|
+| `acx_audiobook` | `false` (opt-in) | 280 | 2.5 | 0.6 | 0.2 | 0.2 |
+| `podcast_ready` | `true` | 300 | 3.0 | 0.4 | 0.4 | 0.35 |
+| `general_clean` | `true` | 300 | 3.0 | 0.5 | 0.3 | 0.3 |
+| `noise_eraser`  | not configured (separation artifacts should not be masked by synthesized bass) |
+
+ACX Audiobook is off by default because the preset's character is "clean,
+present, natural" and ACX human reviewers listen for unnatural tonality. The
+stage is wired in disabled so it can be enabled per-file without preset
+surgery.
+
+**Report payload (`bass_enhance` key):**
+```json
+{
+  "applied": true,
+  "n_segments": 4,
+  "segment_crossovers_hz": [180.0, 195.0, 187.5, 210.0],
+  "f0_range_hz": [120.0, 140.0],
+  "vad_coverage_pct": 87.5,
+  "mix_effective": 0.35,
+  "low_band_gain_db": 3.2,
+  "fundamental_cut_ratio": 1.25,
+  "drive": 3.0,
+  "softness": 0.4,
+  "bias": 0.4,
+  "channels": 1
+}
+```
+
+`low_band_gain_db` is the measured post-blend RMS in the bass band relative
+to the dry signal in the same band — drives the `excessive_bass_enhancement`
+advisory.
+
+**Advisory flag:** Emits `excessive_bass_enhancement` (severity `review`)
+when the stage applied with `mix > 0.5` AND `low_band_gain_db > 6`. Both
+conditions matter: a high mix on a source that already had healthy bass
+produces only a small `low_band_gain_db` (synthesized harmonics compete with
+existing energy), so neither alone is enough to flag.
 
 ---
 

--- a/docs/instant_polish_processing_spec_v3.md
+++ b/docs/instant_polish_processing_spec_v3.md
@@ -564,21 +564,22 @@ the canonical preset wiring always provides both.
    median F0 tracks real pitch shifts between utterances without claiming
    speaker identification that F0 clustering cannot deliver reliably.
 
-2. **Band isolation.** 4th-order Butterworth LPF, crossfaded at utterance
-   boundaries over `segmentTransitionMs` (default 75 ms) in log-Hz space.
-   Implemented as a small bank of fixed LPFs at geometric cutoffs;
-   per-sample weighted interpolation across the bank yields the time-varying
-   cutoff without coefficient redesign.
+2. **Band isolation.** 4th-order Butterworth LPF at `1.5 × medianF0`, fixed
+   per utterance. At utterance boundaries the outgoing and incoming filter
+   outputs are linearly crossfaded over `segmentTransitionMs` (default
+   75 ms) centred on the midpoint between the two utterances. One filter
+   pass per utterance — no bank, no per-sample interpolation across a
+   parallel bank.
 
 3. **Waveshaping.** Bass band → `tube_saturate(drive, softness, bias)`.
    `softness` blends tanh (odd harmonics) → arctan (even harmonics, warmer).
    `bias` adds asymmetry for even-harmonic weight. 2× oversampling inside
    `tube_saturate` suppresses aliasing.
 
-4. **Fundamental removal (balanced HPF).** Time-varying HPF with cutoff
-   `f0_contour × fundamentalCutRatio`, smoothed causally over
-   `fundamentalCutSmoothMs` (default 50 ms). The default
-   `fundamentalCutRatio = 1.25` is a deliberate compromise:
+4. **Fundamental removal (balanced HPF).** Per-utterance fixed-cutoff HPF
+   at `medianF0 × fundamentalCutRatio`, with the same boundary-crossfade
+   mechanic as the LPF. The default `fundamentalCutRatio = 1.25` is a
+   deliberate compromise:
 
    | Cutoff (× F0) | F0 attenuation | 2·F0 attenuation | 3·F0 attenuation |
    |---|---|---|---|
@@ -593,17 +594,25 @@ the canonical preset wiring always provides both.
    psychoacoustic effect — intentional, and documented in the script's
    docstring so future readers do not "fix" it back to `0.9`.
 
-   Implemented as a precomputed bank of 12 fixed HPFs at geometric cutoffs
-   covering `[f0MinHz, f0MaxHz] × fundamentalCutRatio`. Per-sample weighted
-   interpolation across the bank tracks the smoothed F0 contour without
-   per-frame biquad redesign.
+   The cutoff is fixed within an utterance, not tracked per-frame. Typical
+   speech pitch varies ~±20 % within an utterance, which maps to a bounded
+   ~±6 dB swing in fundamental attenuation around the target — acceptable
+   for a psychoacoustic effect, and a major simplification over a per-frame
+   tracked filter (a single IIR pass per utterance instead of a parallel
+   filter bank).
 
-5. **VAD gate.** Per-sample mask derived from VAD frames, smoothed by an
-   asymmetric IIR envelope (`vadAttackMs` / `vadReleaseMs`). The 25 ms VAD
+5. **VAD gate.** Frame-rate asymmetric IIR (`vadAttackMs` / `vadReleaseMs`)
+   over VAD frame targets (1.0 voiced, 0.0 silent), upsampled to sample
+   rate via linear interpolation between frame centres. The 25 ms VAD
    frame quantisation is the floor on attack sharpness; sub-frame attack
-   times act as envelope shaping on the step transitions. Music beds, sound
-   effects, and silence pass through completely untouched (bit-identical to
-   dry in the silence span).
+   times act as envelope shaping on the step transitions. The
+   harmonics-only signal is multiplied by this mask, so **no synthesized
+   harmonics are added inside the silence span** — music beds, sound
+   effects, and silence pass through unchanged at the harmonics-blend step.
+   The post-blend RMS-match (`normalizeOutput`, default on) applies a
+   global gain scalar to the whole file, so the silence span is not
+   bit-identical to dry input when normalization runs. Set
+   `normalizeOutput: false` for bit-identical silence regions.
 
 6. **Stereo handling.** Stereo input is summed to mono for the harmonics
    chain; the harmonics-only signal is then added equally to both channels.

--- a/server/pipeline/bassEnhance.js
+++ b/server/pipeline/bassEnhance.js
@@ -51,8 +51,6 @@ export async function applyBassEnhance(inputPath, outputPath, params = {}, frame
   if (params.bias                != null) args.push('--bias',                  String(params.bias))
   // Fundamental removal
   if (params.fundamentalCutRatio     != null) args.push('--fundamental-cut-ratio',     String(params.fundamentalCutRatio))
-  if (params.fundamentalCutSmoothMs  != null) args.push('--fundamental-cut-smooth-ms', String(params.fundamentalCutSmoothMs))
-  if (params.fundamentalCutNFilters  != null) args.push('--fundamental-cut-n-filters', String(params.fundamentalCutNFilters))
   // VAD gate
   if (params.vadAttackMs         != null) args.push('--vad-attack-ms',         String(params.vadAttackMs))
   if (params.vadReleaseMs        != null) args.push('--vad-release-ms',        String(params.vadReleaseMs))

--- a/server/pipeline/bassEnhance.js
+++ b/server/pipeline/bassEnhance.js
@@ -1,0 +1,88 @@
+/**
+ * BassEnhance — psychoacoustic bass synthesis wrapper.
+ *
+ * Adds harmonic overtones of the fundamental and blends them into the dry
+ * signal. The auditory system infers the missing fundamental from its
+ * overtones, producing perceived sub-bass without the energy cost (or
+ * limiter-overloading risk) of a real bass boost.
+ *
+ * Consumes upstream VAD frames (ctx.results.metrics.frames) and the cached
+ * F0 contour (getF0Contour in f0Analysis.js); both are written to temp JSON
+ * files referenced by --vad-frames-json / --f0-contour-json on the Python
+ * side. The script handles missing inputs gracefully — VAD absent means the
+ * whole file is treated as voiced; F0 absent means the fallback crossover
+ * drives both the LPF and the fundamental-removal HPF.
+ */
+
+import { writeFile, rm } from 'fs/promises'
+import { fileURLToPath } from 'url'
+import path from 'path'
+import { tempPath }       from '../lib/ffmpeg.js'
+import { spawnPythonCapture } from './spawnPython.js'
+
+const SCRIPTS_DIR        = path.join(path.dirname(fileURLToPath(import.meta.url)), '..', 'scripts')
+const BASS_ENHANCE_SCRIPT = path.join(SCRIPTS_DIR, 'bass_enhance.py')
+
+/**
+ * Apply BassEnhance to `inputPath`, writing the result to `outputPath`.
+ *
+ * @param {string} inputPath          32-bit float WAV (mono or stereo)
+ * @param {string} outputPath         Pre-allocated output path (ctx.tmp('.wav'))
+ * @param {object} [params]           Sparse parameter overrides; see bass_enhance.py
+ * @param {object[]|null} [frames]    ctx.results.metrics.frames — written to a temp
+ *   JSON file. Pass null/empty to disable VAD gating (whole file treated as voiced).
+ * @param {{ median:number, perFrame:number[], nFft:number, hopLength:number }|null} [f0Contour]
+ *   Per-frame F0 contour from getF0Contour() in f0Analysis.js. Pass null to fall
+ *   back to crossoverFallbackHz for both the LPF crossover and the HPF cutoff.
+ * @returns {Promise<object>}  Parsed JSON info dict from bass_enhance.py
+ */
+export async function applyBassEnhance(inputPath, outputPath, params = {}, frames = null, f0Contour = null) {
+  const args = ['--input', inputPath, '--output', outputPath]
+
+  // Segmentation
+  if (params.crossoverFallbackHz != null) args.push('--crossover-fallback-hz', String(params.crossoverFallbackHz))
+  if (params.segmentTransitionMs != null) args.push('--segment-transition-ms', String(params.segmentTransitionMs))
+  if (params.f0ClusterMinGapMs   != null) args.push('--f0-cluster-min-gap-ms', String(params.f0ClusterMinGapMs))
+  if (params.f0MinHz             != null) args.push('--f0-min-hz',             String(params.f0MinHz))
+  if (params.f0MaxHz             != null) args.push('--f0-max-hz',             String(params.f0MaxHz))
+  // Waveshaper
+  if (params.drive               != null) args.push('--drive',                 String(params.drive))
+  if (params.softness            != null) args.push('--softness',              String(params.softness))
+  if (params.bias                != null) args.push('--bias',                  String(params.bias))
+  // Fundamental removal
+  if (params.fundamentalCutRatio     != null) args.push('--fundamental-cut-ratio',     String(params.fundamentalCutRatio))
+  if (params.fundamentalCutSmoothMs  != null) args.push('--fundamental-cut-smooth-ms', String(params.fundamentalCutSmoothMs))
+  if (params.fundamentalCutNFilters  != null) args.push('--fundamental-cut-n-filters', String(params.fundamentalCutNFilters))
+  // VAD gate
+  if (params.vadAttackMs         != null) args.push('--vad-attack-ms',         String(params.vadAttackMs))
+  if (params.vadReleaseMs        != null) args.push('--vad-release-ms',        String(params.vadReleaseMs))
+  // Skip & mix
+  if (params.skipIfVoicedRatioBelow != null) args.push('--skip-if-voiced-ratio-below', String(params.skipIfVoicedRatioBelow))
+  if (params.mix                 != null) args.push('--mix',                   String(params.mix))
+  if (params.normalizeOutput === false)   args.push('--no-normalize-output')
+
+  // VAD frames as a temp JSON — Python script handles missing file by
+  // treating the whole input as voiced.
+  let vadPath = null
+  if (frames && frames.length > 0) {
+    vadPath = tempPath('.json')
+    await writeFile(vadPath, JSON.stringify(frames))
+    args.push('--vad-frames-json', vadPath)
+  }
+
+  // F0 contour — write the whole getF0Contour() shape; the Python side
+  // extracts perFrame / hopLength / median itself.
+  let f0Path = null
+  if (f0Contour?.perFrame?.length > 0) {
+    f0Path = tempPath('.json')
+    await writeFile(f0Path, JSON.stringify(f0Contour))
+    args.push('--f0-contour-json', f0Path)
+  }
+
+  try {
+    return await spawnPythonCapture(BASS_ENHANCE_SCRIPT, args, 'BassEnhance')
+  } finally {
+    if (vadPath) await rm(vadPath, { force: true }).catch(() => {})
+    if (f0Path)  await rm(f0Path,  { force: true }).catch(() => {})
+  }
+}

--- a/server/pipeline/index.js
+++ b/server/pipeline/index.js
@@ -199,6 +199,7 @@ function buildReport(ctx) {
       ...(results.vocalExpander         && { vocal_expander:          formatVocalExpanderResult(results.vocalExpander) }),
       ...(results.vadGate               && { vad_gate:                formatVadGateResult(results.vadGate) }),
       ...(results.resonanceSuppressor   && { resonance_suppressor:    formatResonanceSuppressorResult(results.resonanceSuppressor) }),
+      ...(results.bassEnhance           && { bass_enhance:             formatBassEnhanceResult(results.bassEnhance) }),
       normalization_gain_db:
         results.afterMeasurements?.rmsDbfs == null || results.beforeMeasurements?.rmsDbfs == null
           ? null
@@ -540,6 +541,31 @@ function formatVadGateResult(r) {
       open_segments:        r.openSegments,
       pct_samples_at_floor: r.pctSamplesAtFloor,
     },
+  }
+}
+
+function formatBassEnhanceResult(r) {
+  if (!r) return null
+  if (r.applied === false) {
+    return {
+      applied:        false,
+      skipped_reason: r.skip_reason ?? r.reason ?? null,
+      vad_coverage_pct: r.vad_coverage_pct ?? null,
+    }
+  }
+  return {
+    applied:                true,
+    n_segments:             r.n_segments,
+    segment_crossovers_hz:  r.segment_crossovers_hz,
+    f0_range_hz:            r.f0_range_hz,
+    vad_coverage_pct:       r.vad_coverage_pct,
+    mix_effective:          r.mix_effective,
+    low_band_gain_db:       r.low_band_gain_db,
+    fundamental_cut_ratio:  r.fundamental_cut_ratio,
+    drive:                  r.drive,
+    softness:               r.softness,
+    bias:                   r.bias,
+    channels:               r.channels,
   }
 }
 

--- a/server/pipeline/riskAssessment.js
+++ b/server/pipeline/riskAssessment.js
@@ -183,6 +183,25 @@ export async function generateQualityAdvisory(
     }
   }
 
+  // --- BassEnhance advisory flag ---
+  // Emit `excessive_bass_enhancement` when the stage ran with mix > 0.5 and the
+  // post-blend low-band gain (low_band_gain_db) exceeds 6 dB. The combination
+  // matters: a high mix on a source that already had healthy bass produces only
+  // a small low_band_gain (the synthesized harmonics compete with existing
+  // energy), so neither condition alone is enough.
+  const beResult = pipelineContext.bassEnhance
+  if (beResult && beResult.applied) {
+    const mix     = beResult.mix_effective    ?? 0
+    const gainDb  = beResult.low_band_gain_db ?? 0
+    if (mix > 0.5 && gainDb > 6) {
+      flags.push({
+        id:       'excessive_bass_enhancement',
+        severity: 'review',
+        message:  'Synthesized bass may be exaggerated. Listen on small speakers — the effect can sound natural on headphones but boomy on phones and laptops.',
+      })
+    }
+  }
+
   // --- Resonance Suppressor advisory flag ---
   // Emitted when the suppressor ran and artifact_risk is true.
   // artifact_risk is set when mean gain reduction across bins with > 0.01 dB

--- a/server/pipeline/stages.js
+++ b/server/pipeline/stages.js
@@ -54,6 +54,7 @@ import { applyAirBoost, applyAirBoostMask } from './airBoost.js'
 import { getReferenceCurvePath, runReferenceEQPass } from './referenceEQ.js'
 import { getF0Contour } from './f0Analysis.js'
 import { analyzeSibilanceEvents } from './sibilanceEvents.js'
+import { applyBassEnhance } from './bassEnhance.js'
 
 // ── Stage: Decode ─────────────────────────────────────────────────────────────
 
@@ -1219,6 +1220,51 @@ export async function vocalSaturation(ctx) {
   await logLevel(ctx, 'after vocal saturation', ctx.currentPath, {})
 }
 
+// ── Stage: Bass Enhance ───────────────────────────────────────────────────────
+// Psychoacoustic bass synthesis (MaxxBass-style). Generates harmonic overtones
+// of the fundamental and blends them additively into the dry signal — the ear
+// infers the missing fundamental from its overtones, producing perceived
+// sub-bass without adding sub-bass energy that would overload the limiter.
+//
+// Consumes upstream VAD frames (ctx.results.metrics.frames) and the cached F0
+// contour (getF0Contour). With neither available the stage still runs but
+// uses a fixed fallback crossover; quality is best when both are present.
+//
+// Skipped (no audio change) when preset.bassEnhance.enabled === false.
+// Skipped at the script level when VAD coverage falls below
+// preset.bassEnhance.skipIfVoicedRatioBelow.
+
+export async function bassEnhance(ctx) {
+  const cfg = ctx.preset?.bassEnhance ?? {}
+  if (cfg.enabled === false) {
+    ctx.results.bassEnhance = { applied: false, reason: 'disabled by preset' }
+    ctx.log('[bass-enhance] disabled — skipped')
+    return
+  }
+
+  const frames     = ctx.results.metrics?.frames ?? null
+  const f0Contour  = await getF0Contour(ctx, { useCache: true })
+  const outPath    = ctx.tmp('.wav')
+
+  const info = await applyBassEnhance(ctx.currentPath, outPath, cfg, frames, f0Contour)
+
+  if (info?.applied === false) {
+    ctx.results.bassEnhance = info
+    ctx.log(`[bass-enhance] skipped — ${info.skip_reason ?? 'unknown'}`)
+    return
+  }
+
+  ctx.currentPath = outPath
+  ctx.results.bassEnhance = info
+  ctx.log(
+    `[bass-enhance] applied segments=${info.n_segments} ` +
+    `f0=${info.f0_range_hz?.join('–')}Hz ` +
+    `mix=${info.mix_effective} low_band_gain=${info.low_band_gain_db}dB ` +
+    `vad_coverage=${info.vad_coverage_pct}%`,
+  )
+  await logLevel(ctx, 'after bass enhance', ctx.currentPath, {})
+}
+
 // ── Stage: Room Presence (Stage 4c) ──────────────────────────────────────────
 // Convolution reverb with a synthetic IR. Placed after all corrective and
 // tonal processing so the reverb tail doesn't amplify residual noise, and
@@ -1395,6 +1441,7 @@ export async function qualityAdvisory(ctx) {
     autoLeveler:         ctx.results.autoLeveler ?? null,
     vocalExpander:       ctx.results.vocalExpander ?? null,
     resonanceSuppressor: ctx.results.resonanceSuppressor ?? null,
+    bassEnhance:         ctx.results.bassEnhance ?? null,
   }
   ctx.results.qualityAdvisory = await generateQualityAdvisory(
     ctx.currentPath,

--- a/server/scripts/bass_enhance.py
+++ b/server/scripts/bass_enhance.py
@@ -142,134 +142,8 @@ def _utterance_median_f0(
 
 
 # ---------------------------------------------------------------------------
-# Time-varying HPF — pre-computed bank with sample-level interpolation
+# VAD mask — frame-rate asymmetric IIR with vectorised upsampling
 # ---------------------------------------------------------------------------
-
-def _build_hpf_bank(
-    sr: int,
-    f0_min_hz: float,
-    f0_max_hz: float,
-    cut_ratio: float,
-    n_filters: int,
-    order: int,
-) -> tuple[np.ndarray, list[np.ndarray]]:
-    """
-    Build a bank of HPFs at semitone-spaced cutoff frequencies from
-    f0_min*cut_ratio to f0_max*cut_ratio. Returns (cutoff_array, [sos, ...]).
-
-    Per the spec the bank is precomputed once; the chunk loop selects the two
-    nearest filters per sample and interpolates their outputs.
-    """
-    fc_lo = f0_min_hz * cut_ratio
-    fc_hi = f0_max_hz * cut_ratio
-    # Geometric (semitone-ish) spacing so the perceptual resolution is
-    # constant across the bank — high cutoffs would otherwise be too sparsely
-    # covered.
-    cutoffs = np.geomspace(fc_lo, fc_hi, n_filters)
-    bank = [_butter_hp_sos(float(fc), sr, order=order) for fc in cutoffs]
-    return cutoffs, bank
-
-
-def _apply_tracking_hpf(
-    x: np.ndarray,
-    sr: int,
-    sample_cutoff_hz: np.ndarray,
-    bank_cutoffs: np.ndarray,
-    bank_sos: list[np.ndarray],
-) -> np.ndarray:
-    """
-    Apply a time-varying HPF whose cutoff follows `sample_cutoff_hz` (one
-    cutoff per sample, smooth from upstream F0 smoothing).
-
-    Implementation: run x through every filter in the bank in parallel, then
-    per-sample linear-interpolate between the two adjacent filter outputs that
-    bracket the requested cutoff. With a 12-filter bank this is 12 IIR passes
-    per call — bounded and easy to verify, no per-frame coefficient design.
-    """
-    # All bank outputs at once. State-initialised to first-sample value to
-    # suppress the IIR boot transient.
-    outputs = np.stack([_sosfilt_with_zi(sos, x) for sos in bank_sos], axis=0)
-
-    # Clamp cutoff to the bank's covered range, then locate the right bracket.
-    clamped = np.clip(sample_cutoff_hz, bank_cutoffs[0], bank_cutoffs[-1])
-    # searchsorted returns insertion index; we want the bracket [i-1, i].
-    idx_hi = np.searchsorted(bank_cutoffs, clamped, side="left")
-    idx_hi = np.clip(idx_hi, 1, len(bank_cutoffs) - 1)
-    idx_lo = idx_hi - 1
-
-    # Interpolation weight in log-cutoff space (matches the geometric bank
-    # spacing — a half-step between two bank cutoffs is one half-octave, not
-    # one half of the linear Hz gap).
-    log_lo = np.log(bank_cutoffs[idx_lo])
-    log_hi = np.log(bank_cutoffs[idx_hi])
-    log_target = np.log(clamped)
-    denom = log_hi - log_lo
-    # Where lo == hi (clamped past the bank edges) denom is 0 — pick the edge
-    # filter outright by sending weight to the bracket-low output.
-    weight = np.where(denom > 1e-12, (log_target - log_lo) / denom, 0.0)
-
-    samples = np.arange(len(x))
-    y_lo = outputs[idx_lo, samples]
-    y_hi = outputs[idx_hi, samples]
-    return (1.0 - weight) * y_lo + weight * y_hi
-
-
-# ---------------------------------------------------------------------------
-# Smoothing & per-sample maps
-# ---------------------------------------------------------------------------
-
-def _causal_smooth(x: np.ndarray, window: int) -> np.ndarray:
-    """Causal moving average; window in samples (>=1)."""
-    if window <= 1 or x.size == 0:
-        return x
-    # Use cumulative sum for an O(n) causal mean.
-    pad = np.concatenate([np.full(window - 1, x[0]), x])
-    csum = np.cumsum(pad)
-    return (csum[window - 1:] - np.concatenate([[0.0], csum[:-window]])) / window
-
-
-def _f0_contour_to_sample_cutoff(
-    f0_per_frame: list[float],
-    f0_hop: int,
-    n_samples: int,
-    sr: int,
-    cut_ratio: float,
-    smooth_ms: float,
-    fallback_hz: float,
-    f0_min_hz: float,
-    f0_max_hz: float,
-) -> np.ndarray:
-    """
-    Expand the F0 contour to a per-sample HPF cutoff signal.
-
-    Smoothing is causal so the cutoff lags the F0 contour slightly rather
-    than leading it — matters across phoneme boundaries where leading the
-    pitch can sweep the cutoff past a sustained vowel before the harmonics
-    appear in the saturator output.
-    """
-    if f0_per_frame and f0_hop > 0:
-        f0_arr = np.asarray(f0_per_frame, dtype=np.float64)
-        # Replace zero/NaN entries (gaps the upstream estimator couldn't fill)
-        # with the fallback so the cutoff curve stays continuous.
-        bad = ~np.isfinite(f0_arr) | (f0_arr <= 0)
-        if bad.any():
-            f0_arr = np.where(bad, fallback_hz / max(cut_ratio, 1e-6), f0_arr)
-        # Clamp to the estimator's operating range — anything outside is an
-        # octave error or a regression to silence.
-        f0_arr = np.clip(f0_arr, f0_min_hz, f0_max_hz)
-
-        # Upsample frame-rate values to sample-rate via nearest-neighbour;
-        # smoothing turns the staircase into a smooth ramp.
-        sample_idx = np.arange(n_samples) // f0_hop
-        sample_idx = np.clip(sample_idx, 0, f0_arr.size - 1)
-        per_sample_f0 = f0_arr[sample_idx]
-    else:
-        per_sample_f0 = np.full(n_samples, fallback_hz / max(cut_ratio, 1e-6))
-
-    cutoff = per_sample_f0 * cut_ratio
-    smooth_samples = max(1, int(smooth_ms * sr / 1000.0))
-    return _causal_smooth(cutoff, smooth_samples).astype(np.float64)
-
 
 def _build_vad_sample_mask(
     vad_frames: list,
@@ -280,116 +154,174 @@ def _build_vad_sample_mask(
 ) -> tuple[np.ndarray, float]:
     """
     Convert VAD frame labels to a per-sample float gate with asymmetric
-    attack/release envelopes. Returns (mask, voiced_coverage_fraction).
+    attack/release envelopes. Returns ``(mask, voiced_coverage_fraction)``.
 
-    With no VAD frames available the whole file is treated as voiced. The
-    25 ms VAD frame quantisation is the effective floor on attack sharpness;
-    sub-frame attack times act as envelope shaping on the step transitions.
+    Implementation runs the IIR at frame rate (~40 Hz for 25 ms VAD frames),
+    not sample rate (44.1 kHz). The frame quantisation is already the
+    effective floor on attack sharpness — sub-frame attack times act as
+    envelope shaping on the step transitions — so processing at frame rate
+    is algorithmically equivalent within the VAD's own time resolution while
+    being ~1000× cheaper than a per-sample Python loop. The frame envelope
+    is upsampled to sample rate via vectorised linear interpolation.
+
+    With no VAD frames available the whole file is treated as voiced.
     """
     if not vad_frames:
         return np.ones(n_samples, dtype=np.float32), 1.0
 
-    step = np.zeros(n_samples, dtype=np.float32)
-    voiced_samples = 0
-    for f in vad_frames:
-        s = int(f["offsetSamples"])
-        e = min(s + int(f["lengthSamples"]), n_samples)
-        if s >= n_samples:
-            break
-        if not f.get("isSilence", False):
-            step[s:e] = 1.0
-            voiced_samples += (e - s)
+    n_frames        = len(vad_frames)
+    targets         = np.empty(n_frames, dtype=np.float32)
+    centers_samples = np.empty(n_frames, dtype=np.float64)
+    voiced_samples  = 0
 
-    a_coef = np.exp(-1.0 / max(1.0, attack_ms  * sr / 1000.0))
-    r_coef = np.exp(-1.0 / max(1.0, release_ms * sr / 1000.0))
-    mask = np.empty(n_samples, dtype=np.float32)
+    for i, f in enumerate(vad_frames):
+        s = int(f["offsetSamples"])
+        ln = int(f["lengthSamples"])
+        e = min(s + ln, n_samples)
+        if s >= n_samples:
+            # Frames past the end of the audio — clamp the array and break.
+            targets         = targets[:i]
+            centers_samples = centers_samples[:i]
+            n_frames        = i
+            break
+        silent = bool(f.get("isSilence", False))
+        targets[i]         = 0.0 if silent else 1.0
+        centers_samples[i] = (s + e) / 2.0
+        if not silent:
+            voiced_samples += max(0, e - s)
+
+    if n_frames == 0:
+        return np.ones(n_samples, dtype=np.float32), 1.0
+
+    # Frame period for the IIR coefficients. Most callers pass uniform 25 ms
+    # frames so the median is a good representative; degenerate single-frame
+    # inputs fall back to the frame's own length.
+    if n_frames > 1:
+        frame_period_ms = float(np.median(np.diff(centers_samples)) * 1000.0 / sr)
+    else:
+        frame_period_ms = float(int(vad_frames[0]["lengthSamples"]) * 1000.0 / sr)
+    frame_period_ms = max(frame_period_ms, 1.0)
+
+    a_coef = np.exp(-frame_period_ms / max(1.0, attack_ms))
+    r_coef = np.exp(-frame_period_ms / max(1.0, release_ms))
+
+    # Asymmetric IIR at frame rate — ~40 iterations per second of audio.
+    env  = np.empty(n_frames, dtype=np.float32)
     prev = 0.0
-    # State-dependent coefficient — attack when rising, release when falling.
-    # Tight loop in Python is the bottleneck for very long files; acceptable
-    # for the current synchronous pipeline (10–60 s clips) but worth a numba
-    # JIT pass if BassEnhance graduates to batch mode.
-    for i in range(n_samples):
-        t = step[i]
+    for i in range(n_frames):
+        t = targets[i]
         c = a_coef if t >= prev else r_coef
         prev = c * prev + (1.0 - c) * t
-        mask[i] = prev
+        env[i] = prev
+
+    # Upsample to sample rate via vectorised linear interpolation between
+    # frame centres. Edges are held at the first/last frame value.
+    sample_indices = np.arange(n_samples, dtype=np.float64)
+    mask = np.interp(
+        sample_indices, centers_samples, env,
+        left=float(env[0]), right=float(env[-1]),
+    ).astype(np.float32)
 
     coverage = voiced_samples / float(n_samples) if n_samples > 0 else 0.0
     return mask, coverage
 
 
 # ---------------------------------------------------------------------------
-# Per-utterance LPF with boundary crossfade
+# Per-utterance fixed-cutoff filter with boundary crossfade
 # ---------------------------------------------------------------------------
 
-def _apply_utterance_lpf(
+def _apply_per_utterance_filter(
     audio: np.ndarray,
     sr: int,
     utterances: list[tuple[int, int]],
-    utterance_crossovers: list[float],
+    cutoffs: list[float],
     transition_ms: float,
+    btype: str,
+    order: int = 4,
 ) -> np.ndarray:
     """
-    Apply a per-utterance LPF whose cutoff follows the utterance median F0,
-    crossfaded at boundaries to avoid clicks on hard consonants.
+    Apply a per-utterance fixed-cutoff Butterworth filter to ``audio``.
 
-    Outside utterance spans the LPF still runs (using the nearest utterance's
-    cutoff) so the saturator sees a continuous bass band — the VAD gate later
-    zeros the harmonics-only signal in those regions anyway.
+    Within an utterance the filter is a single fixed-cutoff biquad chain. At
+    boundaries between adjacent utterances, the outgoing and incoming filter
+    outputs are linearly crossfaded over a window centred on the midpoint
+    between the two utterances.
+
+    Memory: ~4 × n_samples peak (input + one filter output + per-utterance
+    weight envelope + accumulator). The previous bank-based approach held
+    ``n_filters × n_samples`` in parallel — switching to one filter at a
+    time means peak memory is independent of utterance count.
+
+    CPU: ``n_utterances`` full-file IIR passes. For very long files with
+    many utterances this could still be a lot of work; the simpler design
+    is acceptable because per-utterance fixed cutoff is correct for a
+    psychoacoustic effect (typical within-utterance pitch variation maps
+    to bounded ~±6 dB of fundamental-attenuation swing).
+
+    ``btype`` is ``'low'`` or ``'high'``. With no utterances, falls back
+    to a single filter applied to the whole file at ``cutoffs[0]`` (or 300
+    Hz when cutoffs is empty).
     """
     n = len(audio)
+    if n == 0:
+        return audio.astype(np.float32, copy=False)
+
     if not utterances:
-        return _sosfilt_with_zi(_butter_lp_sos(300.0, sr), audio)
+        fc = cutoffs[0] if cutoffs else 300.0
+        sos = butter(order, max(fc, 20.0) / (sr / 2.0), btype=btype, output='sos')
+        return _sosfilt_with_zi(sos, audio).astype(np.float32)
 
     transition_samples = max(8, int(transition_ms * sr / 1000.0))
+    half_trans = transition_samples // 2
 
-    # Build a sample-aligned cutoff envelope: piecewise constant inside each
-    # utterance, linearly interpolated in log-Hz space across the boundary.
-    cutoff_env = np.empty(n, dtype=np.float64)
-    last_end = 0
-    last_fc = utterance_crossovers[0]
-    for (s, e), fc in zip(utterances, utterance_crossovers):
-        # Gap before this utterance — ramp from last cutoff to this one in the
-        # last `transition_samples` of the gap region.
-        if s > last_end:
-            ramp_start = max(last_end, s - transition_samples)
-            cutoff_env[last_end:ramp_start] = last_fc
-            ramp_n = s - ramp_start
-            if ramp_n > 0:
-                log_lo = np.log(last_fc)
-                log_hi = np.log(fc)
-                cutoff_env[ramp_start:s] = np.exp(
-                    np.linspace(log_lo, log_hi, ramp_n, endpoint=False)
+    out = np.zeros(n, dtype=np.float32)
+
+    for i, ((s, e), fc) in enumerate(zip(utterances, cutoffs)):
+        sos = butter(order, max(fc, 20.0) / (sr / 2.0), btype=btype, output='sos')
+        # One IIR pass over the whole file for this utterance's cutoff. The
+        # output is reused via weighted-sum below and then released to the
+        # garbage collector before the next iteration.
+        y = _sosfilt_with_zi(sos, audio).astype(np.float32, copy=False)
+
+        # Build this utterance's weight envelope: 1.0 in its active region,
+        # ramped at the midpoints between adjacent utterances.
+        weight = np.zeros(n, dtype=np.float32)
+
+        # Left edge: ramp 0 → 1 across the boundary with the previous utterance.
+        if i == 0:
+            active_start = 0
+        else:
+            prev_e  = utterances[i - 1][1]
+            mid     = (prev_e + s) // 2
+            xf_lo   = max(0, mid - half_trans)
+            xf_hi   = min(n, mid + half_trans)
+            if xf_hi > xf_lo:
+                weight[xf_lo:xf_hi] = np.linspace(
+                    0.0, 1.0, xf_hi - xf_lo, dtype=np.float32, endpoint=False,
                 )
-        cutoff_env[s:e] = fc
-        last_end = e
-        last_fc = fc
-    cutoff_env[last_end:n] = last_fc
+            active_start = xf_hi
 
-    # Reuse the tracking-HPF infrastructure for the LPF too — build an LPF
-    # bank, run audio through it, and pick the correct cutoff per sample.
-    # The bank's cutoff range covers the utterance crossovers ±20%.
-    fc_lo = max(60.0, min(utterance_crossovers) * 0.8)
-    fc_hi = max(fc_lo * 2.0, max(utterance_crossovers) * 1.2)
-    cutoffs = np.geomspace(fc_lo, fc_hi, 8)
-    bank = [_butter_lp_sos(float(fc), sr) for fc in cutoffs]
+        # Right edge: ramp 1 → 0 across the boundary with the next utterance.
+        if i == len(utterances) - 1:
+            active_end = n
+        else:
+            next_s  = utterances[i + 1][0]
+            mid     = (e + next_s) // 2
+            xf_lo   = max(0, mid - half_trans)
+            xf_hi   = min(n, mid + half_trans)
+            if xf_hi > xf_lo:
+                weight[xf_lo:xf_hi] = np.linspace(
+                    1.0, 0.0, xf_hi - xf_lo, dtype=np.float32, endpoint=False,
+                )
+            active_end = xf_lo
 
-    outputs = np.stack([_sosfilt_with_zi(sos, audio) for sos in bank], axis=0)
+        # Active region (full weight).
+        if active_end > active_start:
+            weight[active_start:active_end] = 1.0
 
-    clamped = np.clip(cutoff_env, cutoffs[0], cutoffs[-1])
-    idx_hi = np.searchsorted(cutoffs, clamped, side="left")
-    idx_hi = np.clip(idx_hi, 1, len(cutoffs) - 1)
-    idx_lo = idx_hi - 1
-    log_lo = np.log(cutoffs[idx_lo])
-    log_hi = np.log(cutoffs[idx_hi])
-    log_t  = np.log(clamped)
-    denom  = log_hi - log_lo
-    w = np.where(denom > 1e-12, (log_t - log_lo) / denom, 0.0)
+        out += weight * y
 
-    samples = np.arange(n)
-    y_lo = outputs[idx_lo, samples]
-    y_hi = outputs[idx_hi, samples]
-    return ((1.0 - w) * y_lo + w * y_hi).astype(np.float32)
+    return out
 
 
 # ---------------------------------------------------------------------------
@@ -414,8 +346,6 @@ def bass_enhance(
     bias: float = 0.3,
     # Fundamental removal
     fundamental_cut_ratio: float = 1.25,
-    fundamental_cut_smooth_ms: float = 50.0,
-    fundamental_cut_n_filters: int = 12,
     # VAD gate
     vad_attack_ms: float = 5.0,
     vad_release_ms: float = 20.0,
@@ -491,8 +421,9 @@ def bass_enhance(
     f0_range_hz = (min(f0_used), max(f0_used))
 
     # --- Step 1: LPF to isolate the bass band -------------------------------
-    bass_band = _apply_utterance_lpf(
-        mono, sr, utterances, utterance_crossovers, segment_transition_ms,
+    bass_band = _apply_per_utterance_filter(
+        mono, sr, utterances, utterance_crossovers,
+        segment_transition_ms, btype='low',
     )
 
     # Track dry low-band RMS for the report (low_band_gain_db advisory).
@@ -504,21 +435,15 @@ def bass_enhance(
         drive=drive, bias=bias, softness=softness,
     ).astype(np.float32)
 
-    # --- Step 3: Time-varying HPF — strip (most of) the fundamental --------
-    sample_cutoff = _f0_contour_to_sample_cutoff(
-        f0_per_frame, f0_hop, n_samples, sr,
-        cut_ratio=fundamental_cut_ratio,
-        smooth_ms=fundamental_cut_smooth_ms,
-        fallback_hz=crossover_fallback_hz,
-        f0_min_hz=f0_min_hz,
-        f0_max_hz=f0_max_hz,
-    )
-    bank_cutoffs, bank_sos = _build_hpf_bank(
-        sr, f0_min_hz, f0_max_hz, fundamental_cut_ratio,
-        n_filters=fundamental_cut_n_filters, order=4,
-    )
-    harmonics_only = _apply_tracking_hpf(
-        saturated, sr, sample_cutoff, bank_cutoffs, bank_sos,
+    # --- Step 3: Per-utterance HPF — strip (most of) the fundamental ------
+    # Per-utterance fixed cutoff at f0_median × fundamental_cut_ratio.
+    # Within an utterance the cutoff is fixed; speech pitch varies ~±20% so
+    # the resulting fundamental attenuation swings ~±6 dB around the target,
+    # which is acceptable for a psychoacoustic effect.
+    hpf_cutoffs = [c / 1.5 * fundamental_cut_ratio for c in utterance_crossovers]
+    harmonics_only = _apply_per_utterance_filter(
+        saturated, sr, utterances, hpf_cutoffs,
+        segment_transition_ms, btype='high',
     ).astype(np.float32)
 
     # --- Step 4: VAD gate — zero harmonics during silence ------------------
@@ -601,8 +526,6 @@ def main():
     parser.add_argument("--bias",                   type=float, default=0.3)
     # Fundamental removal
     parser.add_argument("--fundamental-cut-ratio",       type=float, default=1.25)
-    parser.add_argument("--fundamental-cut-smooth-ms",   type=float, default=50.0)
-    parser.add_argument("--fundamental-cut-n-filters",   type=int,   default=12)
     # VAD gate
     parser.add_argument("--vad-attack-ms",          type=float, default=5.0)
     parser.add_argument("--vad-release-ms",         type=float, default=20.0)
@@ -643,8 +566,6 @@ def main():
         softness=args.softness,
         bias=args.bias,
         fundamental_cut_ratio=args.fundamental_cut_ratio,
-        fundamental_cut_smooth_ms=args.fundamental_cut_smooth_ms,
-        fundamental_cut_n_filters=args.fundamental_cut_n_filters,
         vad_attack_ms=args.vad_attack_ms,
         vad_release_ms=args.vad_release_ms,
         skip_if_voiced_ratio_below=args.skip_if_voiced_ratio_below,

--- a/server/scripts/bass_enhance.py
+++ b/server/scripts/bass_enhance.py
@@ -42,12 +42,14 @@ logger = logging.getLogger("bass_enhance")
 # Filter helpers
 # ---------------------------------------------------------------------------
 
-def _butter_lp_sos(fc: float, sr: int, order: int = 4) -> np.ndarray:
-    return butter(order, fc / (sr / 2.0), btype="low", output="sos")
-
-
-def _butter_hp_sos(fc: float, sr: int, order: int = 4) -> np.ndarray:
-    return butter(order, fc / (sr / 2.0), btype="high", output="sos")
+def _safe_cutoff(fc: float, sr: int) -> float:
+    """Clamp a cutoff frequency to the open interval (0, Nyquist). ``butter``
+    rejects normalized frequencies at or beyond 1.0, so a user-supplied
+    ``crossoverFallbackHz`` or ``fundamentalCutRatio`` that pushes a cutoff
+    to/above Nyquist would crash the stage at runtime. Clamping at 99 % of
+    Nyquist keeps the filter design valid for any input."""
+    nyquist = sr / 2.0
+    return float(np.clip(fc, 20.0, 0.99 * nyquist))
 
 
 def _sosfilt_with_zi(sos: np.ndarray, x: np.ndarray) -> np.ndarray:
@@ -268,7 +270,7 @@ def _apply_per_utterance_filter(
 
     if not utterances:
         fc = cutoffs[0] if cutoffs else 300.0
-        sos = butter(order, max(fc, 20.0) / (sr / 2.0), btype=btype, output='sos')
+        sos = butter(order, _safe_cutoff(fc, sr) / (sr / 2.0), btype=btype, output='sos')
         return _sosfilt_with_zi(sos, audio).astype(np.float32)
 
     transition_samples = max(8, int(transition_ms * sr / 1000.0))
@@ -277,7 +279,7 @@ def _apply_per_utterance_filter(
     out = np.zeros(n, dtype=np.float32)
 
     for i, ((s, e), fc) in enumerate(zip(utterances, cutoffs)):
-        sos = butter(order, max(fc, 20.0) / (sr / 2.0), btype=btype, output='sos')
+        sos = butter(order, _safe_cutoff(fc, sr) / (sr / 2.0), btype=btype, output='sos')
         # One IIR pass over the whole file for this utterance's cutoff. The
         # output is reused via weighted-sum below and then released to the
         # garbage collector before the next iteration.
@@ -449,8 +451,19 @@ def bass_enhance(
     # --- Step 4: VAD gate — zero harmonics during silence ------------------
     gated = harmonics_only * vad_mask
 
-    # Post-blend low-band energy for the advisory check.
-    post_low_rms = float(np.sqrt(np.mean((bass_band + mix * gated) ** 2)) + 1e-12)
+    # Post-blend low-band energy for the advisory check. dry_low_rms is the
+    # LPF'd bass_band RMS, so the post measurement must also be band-limited
+    # to the same crossover — the gated harmonics signal carries significant
+    # energy at 2 × F0 / 3 × F0 / … which lies above the LPF cutoff and
+    # would inflate the metric if included raw. Run the gated signal through
+    # the same per-utterance LPF to isolate its in-band contribution, then
+    # add to bass_band before taking RMS so before/after are measured in the
+    # same band.
+    gated_low = _apply_per_utterance_filter(
+        gated, sr, utterances, utterance_crossovers,
+        segment_transition_ms, btype='low',
+    )
+    post_low_rms = float(np.sqrt(np.mean((bass_band + mix * gated_low) ** 2)) + 1e-12)
     low_band_gain_db = round(20.0 * np.log10(post_low_rms / dry_low_rms), 2)
 
     # --- Step 5: Additive blend onto the dry signal -------------------------

--- a/server/scripts/bass_enhance.py
+++ b/server/scripts/bass_enhance.py
@@ -1,0 +1,662 @@
+#!/usr/bin/env python3
+"""
+Bass Enhancement — psychoacoustic bass synthesis (MaxxBass-style).
+
+Instead of boosting sub-bass energy (which overloads downstream limiters and
+disappears on small speakers), this stage synthesises harmonic overtones of
+the fundamental and blends them additively into the dry signal. The auditory
+system infers the missing fundamental from its overtones, producing the
+sensation of deep bass without adding sub-bass energy.
+
+Per-utterance F0 segmentation drives the LPF crossover so the band fed into
+the saturator tracks the speaker's actual pitch. A balanced HPF above F0
+strips most of the fundamental from the saturator output before the additive
+blend; some residual fundamental survives — see fundamental_cut_ratio.
+
+Upstream inputs consumed (both optional but recommended):
+  --vad-frames-json   ctx.results.metrics.frames (Silero, 25 ms hop @ 44.1 kHz)
+  --f0-contour-json   estimate_f0_contour.py output (autocorr, 512-sample hop)
+
+Inputs/outputs: 32-bit float WAV; mono and stereo supported (stereo is summed
+to mono for the harmonics chain, then the harmonics-only signal is added to
+both channels equally — bass should be center).
+"""
+
+import argparse
+import json
+import logging
+import sys
+
+import numpy as np
+from scipy.io import wavfile
+from scipy.signal import butter, sosfilt, sosfilt_zi
+
+# tube_saturate already does 2× oversampling + tanh/arctan blend with bias —
+# exactly what BassEnhance needs. Reuse rather than duplicate.
+from vocal_saturation import tube_saturate
+
+logger = logging.getLogger("bass_enhance")
+
+
+# ---------------------------------------------------------------------------
+# Filter helpers
+# ---------------------------------------------------------------------------
+
+def _butter_lp_sos(fc: float, sr: int, order: int = 4) -> np.ndarray:
+    return butter(order, fc / (sr / 2.0), btype="low", output="sos")
+
+
+def _butter_hp_sos(fc: float, sr: int, order: int = 4) -> np.ndarray:
+    return butter(order, fc / (sr / 2.0), btype="high", output="sos")
+
+
+def _sosfilt_with_zi(sos: np.ndarray, x: np.ndarray) -> np.ndarray:
+    """sosfilt seeded to the input's leading sample — avoids the long boot
+    transient a zero-initial-state SOS chain produces on bass-rich signals."""
+    if x.size == 0:
+        return x
+    zi = sosfilt_zi(sos) * x[0]
+    y, _ = sosfilt(sos, x, zi=zi)
+    return y
+
+
+# ---------------------------------------------------------------------------
+# Per-utterance F0 segmentation
+# ---------------------------------------------------------------------------
+
+def _build_utterances(
+    vad_frames: list,
+    audio_len: int,
+    sr: int,
+    min_gap_ms: float,
+    min_utterance_ms: float = 300.0,
+) -> list[tuple[int, int]]:
+    """
+    Build (start_sample, end_sample) spans of contiguous voiced content.
+
+    A new utterance starts after a silence gap of at least `min_gap_ms`.
+    Utterances shorter than `min_utterance_ms` are dropped — pitch median over
+    very short voiced runs is noisy and not worth a coefficient crossfade.
+
+    With no VAD frames available, the whole file is treated as one utterance.
+    """
+    if not vad_frames:
+        return [(0, audio_len)]
+
+    gap_samples = int(min_gap_ms * sr / 1000.0)
+    min_samples = int(min_utterance_ms * sr / 1000.0)
+
+    utterances = []
+    cur_start = None
+    last_voiced_end = None
+    silence_run_samples = 0
+
+    for f in vad_frames:
+        s = int(f["offsetSamples"])
+        e = s + int(f["lengthSamples"])
+        if not f.get("isSilence", False):
+            if cur_start is None:
+                cur_start = s
+            last_voiced_end = e
+            silence_run_samples = 0
+        else:
+            silence_run_samples += (e - s)
+            if cur_start is not None and silence_run_samples >= gap_samples:
+                if last_voiced_end - cur_start >= min_samples:
+                    utterances.append((cur_start, last_voiced_end))
+                cur_start = None
+                last_voiced_end = None
+
+    if cur_start is not None and last_voiced_end is not None:
+        if last_voiced_end - cur_start >= min_samples:
+            utterances.append((cur_start, last_voiced_end))
+
+    return utterances
+
+
+def _utterance_median_f0(
+    start_sample: int,
+    end_sample: int,
+    f0_per_frame: list[float],
+    f0_hop: int,
+    f0_min_hz: float,
+    f0_max_hz: float,
+    min_estimates: int = 10,
+) -> float | None:
+    """Median F0 across the utterance's F0 frames, clamped to [f0_min, f0_max].
+
+    Returns None when fewer than `min_estimates` valid frames overlap the
+    utterance — caller falls back to the crossover_fallback_hz value."""
+    if not f0_per_frame or f0_hop <= 0:
+        return None
+
+    lo = max(0, start_sample // f0_hop)
+    hi = min(len(f0_per_frame), (end_sample + f0_hop - 1) // f0_hop)
+    if hi <= lo:
+        return None
+
+    vals = [v for v in f0_per_frame[lo:hi] if v and f0_min_hz <= v <= f0_max_hz]
+    if len(vals) < min_estimates:
+        return None
+    return float(np.median(vals))
+
+
+# ---------------------------------------------------------------------------
+# Time-varying HPF — pre-computed bank with sample-level interpolation
+# ---------------------------------------------------------------------------
+
+def _build_hpf_bank(
+    sr: int,
+    f0_min_hz: float,
+    f0_max_hz: float,
+    cut_ratio: float,
+    n_filters: int,
+    order: int,
+) -> tuple[np.ndarray, list[np.ndarray]]:
+    """
+    Build a bank of HPFs at semitone-spaced cutoff frequencies from
+    f0_min*cut_ratio to f0_max*cut_ratio. Returns (cutoff_array, [sos, ...]).
+
+    Per the spec the bank is precomputed once; the chunk loop selects the two
+    nearest filters per sample and interpolates their outputs.
+    """
+    fc_lo = f0_min_hz * cut_ratio
+    fc_hi = f0_max_hz * cut_ratio
+    # Geometric (semitone-ish) spacing so the perceptual resolution is
+    # constant across the bank — high cutoffs would otherwise be too sparsely
+    # covered.
+    cutoffs = np.geomspace(fc_lo, fc_hi, n_filters)
+    bank = [_butter_hp_sos(float(fc), sr, order=order) for fc in cutoffs]
+    return cutoffs, bank
+
+
+def _apply_tracking_hpf(
+    x: np.ndarray,
+    sr: int,
+    sample_cutoff_hz: np.ndarray,
+    bank_cutoffs: np.ndarray,
+    bank_sos: list[np.ndarray],
+) -> np.ndarray:
+    """
+    Apply a time-varying HPF whose cutoff follows `sample_cutoff_hz` (one
+    cutoff per sample, smooth from upstream F0 smoothing).
+
+    Implementation: run x through every filter in the bank in parallel, then
+    per-sample linear-interpolate between the two adjacent filter outputs that
+    bracket the requested cutoff. With a 12-filter bank this is 12 IIR passes
+    per call — bounded and easy to verify, no per-frame coefficient design.
+    """
+    # All bank outputs at once. State-initialised to first-sample value to
+    # suppress the IIR boot transient.
+    outputs = np.stack([_sosfilt_with_zi(sos, x) for sos in bank_sos], axis=0)
+
+    # Clamp cutoff to the bank's covered range, then locate the right bracket.
+    clamped = np.clip(sample_cutoff_hz, bank_cutoffs[0], bank_cutoffs[-1])
+    # searchsorted returns insertion index; we want the bracket [i-1, i].
+    idx_hi = np.searchsorted(bank_cutoffs, clamped, side="left")
+    idx_hi = np.clip(idx_hi, 1, len(bank_cutoffs) - 1)
+    idx_lo = idx_hi - 1
+
+    # Interpolation weight in log-cutoff space (matches the geometric bank
+    # spacing — a half-step between two bank cutoffs is one half-octave, not
+    # one half of the linear Hz gap).
+    log_lo = np.log(bank_cutoffs[idx_lo])
+    log_hi = np.log(bank_cutoffs[idx_hi])
+    log_target = np.log(clamped)
+    denom = log_hi - log_lo
+    # Where lo == hi (clamped past the bank edges) denom is 0 — pick the edge
+    # filter outright by sending weight to the bracket-low output.
+    weight = np.where(denom > 1e-12, (log_target - log_lo) / denom, 0.0)
+
+    samples = np.arange(len(x))
+    y_lo = outputs[idx_lo, samples]
+    y_hi = outputs[idx_hi, samples]
+    return (1.0 - weight) * y_lo + weight * y_hi
+
+
+# ---------------------------------------------------------------------------
+# Smoothing & per-sample maps
+# ---------------------------------------------------------------------------
+
+def _causal_smooth(x: np.ndarray, window: int) -> np.ndarray:
+    """Causal moving average; window in samples (>=1)."""
+    if window <= 1 or x.size == 0:
+        return x
+    # Use cumulative sum for an O(n) causal mean.
+    pad = np.concatenate([np.full(window - 1, x[0]), x])
+    csum = np.cumsum(pad)
+    return (csum[window - 1:] - np.concatenate([[0.0], csum[:-window]])) / window
+
+
+def _f0_contour_to_sample_cutoff(
+    f0_per_frame: list[float],
+    f0_hop: int,
+    n_samples: int,
+    sr: int,
+    cut_ratio: float,
+    smooth_ms: float,
+    fallback_hz: float,
+    f0_min_hz: float,
+    f0_max_hz: float,
+) -> np.ndarray:
+    """
+    Expand the F0 contour to a per-sample HPF cutoff signal.
+
+    Smoothing is causal so the cutoff lags the F0 contour slightly rather
+    than leading it — matters across phoneme boundaries where leading the
+    pitch can sweep the cutoff past a sustained vowel before the harmonics
+    appear in the saturator output.
+    """
+    if f0_per_frame and f0_hop > 0:
+        f0_arr = np.asarray(f0_per_frame, dtype=np.float64)
+        # Replace zero/NaN entries (gaps the upstream estimator couldn't fill)
+        # with the fallback so the cutoff curve stays continuous.
+        bad = ~np.isfinite(f0_arr) | (f0_arr <= 0)
+        if bad.any():
+            f0_arr = np.where(bad, fallback_hz / max(cut_ratio, 1e-6), f0_arr)
+        # Clamp to the estimator's operating range — anything outside is an
+        # octave error or a regression to silence.
+        f0_arr = np.clip(f0_arr, f0_min_hz, f0_max_hz)
+
+        # Upsample frame-rate values to sample-rate via nearest-neighbour;
+        # smoothing turns the staircase into a smooth ramp.
+        sample_idx = np.arange(n_samples) // f0_hop
+        sample_idx = np.clip(sample_idx, 0, f0_arr.size - 1)
+        per_sample_f0 = f0_arr[sample_idx]
+    else:
+        per_sample_f0 = np.full(n_samples, fallback_hz / max(cut_ratio, 1e-6))
+
+    cutoff = per_sample_f0 * cut_ratio
+    smooth_samples = max(1, int(smooth_ms * sr / 1000.0))
+    return _causal_smooth(cutoff, smooth_samples).astype(np.float64)
+
+
+def _build_vad_sample_mask(
+    vad_frames: list,
+    n_samples: int,
+    sr: int,
+    attack_ms: float,
+    release_ms: float,
+) -> tuple[np.ndarray, float]:
+    """
+    Convert VAD frame labels to a per-sample float gate with asymmetric
+    attack/release envelopes. Returns (mask, voiced_coverage_fraction).
+
+    With no VAD frames available the whole file is treated as voiced. The
+    25 ms VAD frame quantisation is the effective floor on attack sharpness;
+    sub-frame attack times act as envelope shaping on the step transitions.
+    """
+    if not vad_frames:
+        return np.ones(n_samples, dtype=np.float32), 1.0
+
+    step = np.zeros(n_samples, dtype=np.float32)
+    voiced_samples = 0
+    for f in vad_frames:
+        s = int(f["offsetSamples"])
+        e = min(s + int(f["lengthSamples"]), n_samples)
+        if s >= n_samples:
+            break
+        if not f.get("isSilence", False):
+            step[s:e] = 1.0
+            voiced_samples += (e - s)
+
+    a_coef = np.exp(-1.0 / max(1.0, attack_ms  * sr / 1000.0))
+    r_coef = np.exp(-1.0 / max(1.0, release_ms * sr / 1000.0))
+    mask = np.empty(n_samples, dtype=np.float32)
+    prev = 0.0
+    # State-dependent coefficient — attack when rising, release when falling.
+    # Tight loop in Python is the bottleneck for very long files; acceptable
+    # for the current synchronous pipeline (10–60 s clips) but worth a numba
+    # JIT pass if BassEnhance graduates to batch mode.
+    for i in range(n_samples):
+        t = step[i]
+        c = a_coef if t >= prev else r_coef
+        prev = c * prev + (1.0 - c) * t
+        mask[i] = prev
+
+    coverage = voiced_samples / float(n_samples) if n_samples > 0 else 0.0
+    return mask, coverage
+
+
+# ---------------------------------------------------------------------------
+# Per-utterance LPF with boundary crossfade
+# ---------------------------------------------------------------------------
+
+def _apply_utterance_lpf(
+    audio: np.ndarray,
+    sr: int,
+    utterances: list[tuple[int, int]],
+    utterance_crossovers: list[float],
+    transition_ms: float,
+) -> np.ndarray:
+    """
+    Apply a per-utterance LPF whose cutoff follows the utterance median F0,
+    crossfaded at boundaries to avoid clicks on hard consonants.
+
+    Outside utterance spans the LPF still runs (using the nearest utterance's
+    cutoff) so the saturator sees a continuous bass band — the VAD gate later
+    zeros the harmonics-only signal in those regions anyway.
+    """
+    n = len(audio)
+    if not utterances:
+        return _sosfilt_with_zi(_butter_lp_sos(300.0, sr), audio)
+
+    transition_samples = max(8, int(transition_ms * sr / 1000.0))
+
+    # Build a sample-aligned cutoff envelope: piecewise constant inside each
+    # utterance, linearly interpolated in log-Hz space across the boundary.
+    cutoff_env = np.empty(n, dtype=np.float64)
+    last_end = 0
+    last_fc = utterance_crossovers[0]
+    for (s, e), fc in zip(utterances, utterance_crossovers):
+        # Gap before this utterance — ramp from last cutoff to this one in the
+        # last `transition_samples` of the gap region.
+        if s > last_end:
+            ramp_start = max(last_end, s - transition_samples)
+            cutoff_env[last_end:ramp_start] = last_fc
+            ramp_n = s - ramp_start
+            if ramp_n > 0:
+                log_lo = np.log(last_fc)
+                log_hi = np.log(fc)
+                cutoff_env[ramp_start:s] = np.exp(
+                    np.linspace(log_lo, log_hi, ramp_n, endpoint=False)
+                )
+        cutoff_env[s:e] = fc
+        last_end = e
+        last_fc = fc
+    cutoff_env[last_end:n] = last_fc
+
+    # Reuse the tracking-HPF infrastructure for the LPF too — build an LPF
+    # bank, run audio through it, and pick the correct cutoff per sample.
+    # The bank's cutoff range covers the utterance crossovers ±20%.
+    fc_lo = max(60.0, min(utterance_crossovers) * 0.8)
+    fc_hi = max(fc_lo * 2.0, max(utterance_crossovers) * 1.2)
+    cutoffs = np.geomspace(fc_lo, fc_hi, 8)
+    bank = [_butter_lp_sos(float(fc), sr) for fc in cutoffs]
+
+    outputs = np.stack([_sosfilt_with_zi(sos, audio) for sos in bank], axis=0)
+
+    clamped = np.clip(cutoff_env, cutoffs[0], cutoffs[-1])
+    idx_hi = np.searchsorted(cutoffs, clamped, side="left")
+    idx_hi = np.clip(idx_hi, 1, len(cutoffs) - 1)
+    idx_lo = idx_hi - 1
+    log_lo = np.log(cutoffs[idx_lo])
+    log_hi = np.log(cutoffs[idx_hi])
+    log_t  = np.log(clamped)
+    denom  = log_hi - log_lo
+    w = np.where(denom > 1e-12, (log_t - log_lo) / denom, 0.0)
+
+    samples = np.arange(n)
+    y_lo = outputs[idx_lo, samples]
+    y_hi = outputs[idx_hi, samples]
+    return ((1.0 - w) * y_lo + w * y_hi).astype(np.float32)
+
+
+# ---------------------------------------------------------------------------
+# Main entry point
+# ---------------------------------------------------------------------------
+
+def bass_enhance(
+    audio: np.ndarray,
+    sr: int,
+    vad_frames: list | None,
+    f0_contour: dict | None,
+    *,
+    # Segmentation
+    crossover_fallback_hz: float = 300.0,
+    segment_transition_ms: float = 75.0,
+    f0_cluster_min_gap_ms: float = 500.0,
+    f0_min_hz: float = 80.0,
+    f0_max_hz: float = 400.0,
+    # Waveshaper
+    drive: float = 3.0,
+    softness: float = 0.5,
+    bias: float = 0.3,
+    # Fundamental removal
+    fundamental_cut_ratio: float = 1.25,
+    fundamental_cut_smooth_ms: float = 50.0,
+    fundamental_cut_n_filters: int = 12,
+    # VAD gate
+    vad_attack_ms: float = 5.0,
+    vad_release_ms: float = 20.0,
+    # Skip conditions
+    skip_if_voiced_ratio_below: float = 0.05,
+    # Mix & output
+    mix: float = 0.3,
+    normalize_output: bool = True,
+) -> tuple[np.ndarray, dict]:
+    """
+    Apply psychoacoustic bass enhancement to `audio`.
+
+    Stereo input is summed to mono for the harmonics chain, then the
+    harmonics-only signal is added equally to both channels (bass should be
+    center; per-channel processing would produce stereo de-correlation in the
+    bass band).
+
+    Returns (processed_audio, info_dict).
+    """
+    audio = np.asarray(audio, dtype=np.float32)
+
+    # --- Stereo handling: extract a mono sum for processing -----------------
+    if audio.ndim == 2:
+        n_channels = audio.shape[1]
+        mono = np.mean(audio, axis=1).astype(np.float32)
+    else:
+        n_channels = 1
+        mono = audio
+    n_samples = len(mono)
+
+    # --- VAD gate mask + voiced coverage guard ------------------------------
+    vad_mask, voiced_ratio = _build_vad_sample_mask(
+        vad_frames, n_samples, sr, vad_attack_ms, vad_release_ms,
+    )
+    if voiced_ratio < skip_if_voiced_ratio_below:
+        logger.info(
+            "BassEnhance: voiced coverage %.1f%% < %.1f%% — skipping stage",
+            voiced_ratio * 100, skip_if_voiced_ratio_below * 100,
+        )
+        return audio, {
+            "applied": False,
+            "skip_reason": "voiced_ratio_below_threshold",
+            "vad_coverage_pct": round(voiced_ratio * 100, 2),
+        }
+
+    # --- Per-utterance segmentation -----------------------------------------
+    utterances = _build_utterances(
+        vad_frames, n_samples, sr, f0_cluster_min_gap_ms,
+    )
+    if not utterances:
+        utterances = [(0, n_samples)]
+
+    f0_per_frame = (f0_contour or {}).get("perFrame") or []
+    f0_hop       = int((f0_contour or {}).get("hopLength") or 512)
+    file_median  = (f0_contour or {}).get("median") or crossover_fallback_hz / 1.5
+
+    utterance_crossovers = []
+    for (s, e) in utterances:
+        med = _utterance_median_f0(
+            s, e, f0_per_frame, f0_hop, f0_min_hz, f0_max_hz,
+        )
+        if med is None:
+            # Fall back to the file median (clamped) rather than the global
+            # crossover constant — file median is closer to the speaker than
+            # an arbitrary 300 Hz default.
+            med = float(np.clip(file_median, f0_min_hz, f0_max_hz))
+        utterance_crossovers.append(med * 1.5)
+
+    if not utterance_crossovers:
+        utterance_crossovers = [crossover_fallback_hz]
+
+    f0_used = [c / 1.5 for c in utterance_crossovers]
+    f0_range_hz = (min(f0_used), max(f0_used))
+
+    # --- Step 1: LPF to isolate the bass band -------------------------------
+    bass_band = _apply_utterance_lpf(
+        mono, sr, utterances, utterance_crossovers, segment_transition_ms,
+    )
+
+    # Track dry low-band RMS for the report (low_band_gain_db advisory).
+    dry_low_rms = float(np.sqrt(np.mean(bass_band ** 2)) + 1e-12)
+
+    # --- Step 2: Waveshaping — generates harmonics at 2F0, 3F0, … ----------
+    saturated = tube_saturate(
+        bass_band.astype(np.float32),
+        drive=drive, bias=bias, softness=softness,
+    ).astype(np.float32)
+
+    # --- Step 3: Time-varying HPF — strip (most of) the fundamental --------
+    sample_cutoff = _f0_contour_to_sample_cutoff(
+        f0_per_frame, f0_hop, n_samples, sr,
+        cut_ratio=fundamental_cut_ratio,
+        smooth_ms=fundamental_cut_smooth_ms,
+        fallback_hz=crossover_fallback_hz,
+        f0_min_hz=f0_min_hz,
+        f0_max_hz=f0_max_hz,
+    )
+    bank_cutoffs, bank_sos = _build_hpf_bank(
+        sr, f0_min_hz, f0_max_hz, fundamental_cut_ratio,
+        n_filters=fundamental_cut_n_filters, order=4,
+    )
+    harmonics_only = _apply_tracking_hpf(
+        saturated, sr, sample_cutoff, bank_cutoffs, bank_sos,
+    ).astype(np.float32)
+
+    # --- Step 4: VAD gate — zero harmonics during silence ------------------
+    gated = harmonics_only * vad_mask
+
+    # Post-blend low-band energy for the advisory check.
+    post_low_rms = float(np.sqrt(np.mean((bass_band + mix * gated) ** 2)) + 1e-12)
+    low_band_gain_db = round(20.0 * np.log10(post_low_rms / dry_low_rms), 2)
+
+    # --- Step 5: Additive blend onto the dry signal -------------------------
+    if audio.ndim == 2:
+        # Add the same harmonics signal to every channel (bass = center).
+        blend = audio.copy()
+        for ch in range(n_channels):
+            blend[:, ch] = audio[:, ch] + mix * gated
+    else:
+        blend = audio + mix * gated
+
+    # --- Step 6: Optional RMS-match back to dry level -----------------------
+    if normalize_output:
+        dry_rms = float(np.sqrt(np.mean(audio ** 2)) + 1e-12)
+        out_rms = float(np.sqrt(np.mean(blend ** 2)) + 1e-12)
+        if out_rms > 0:
+            blend = blend * (dry_rms / out_rms)
+
+    # Safety clip — the saturator + blend can push transient peaks past unity
+    # on inputs that were already close to full scale.
+    blend = np.clip(blend, -1.0, 1.0).astype(np.float32)
+
+    info = {
+        "applied":               True,
+        "n_segments":            len(utterances),
+        "segment_crossovers_hz": [round(c, 1) for c in utterance_crossovers],
+        "f0_range_hz":           [round(f0_range_hz[0], 1), round(f0_range_hz[1], 1)],
+        "vad_coverage_pct":      round(voiced_ratio * 100, 2),
+        "mix_effective":         round(mix, 3),
+        "low_band_gain_db":      low_band_gain_db,
+        "fundamental_cut_ratio": round(fundamental_cut_ratio, 3),
+        "drive":                 round(drive, 3),
+        "softness":              round(softness, 3),
+        "bias":                  round(bias, 3),
+        "channels":              n_channels,
+    }
+    return blend, info
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def main():
+    logging.basicConfig(level=logging.INFO, stream=sys.stderr, format="%(message)s")
+
+    parser = argparse.ArgumentParser(
+        description="BassEnhance — psychoacoustic bass synthesis stage",
+    )
+    parser.add_argument("--input",  required=True, help="Input WAV path (32-bit float)")
+    parser.add_argument("--output", required=True, help="Output WAV path (32-bit float)")
+
+    # Upstream inputs (passed via temp JSON files by the JS wrapper)
+    parser.add_argument("--vad-frames-json", default=None,
+                        help="Path to JSON list of FrameInfo objects "
+                             "(ctx.results.metrics.frames). Optional — if absent, "
+                             "the whole file is treated as voiced.")
+    parser.add_argument("--f0-contour-json", default=None,
+                        help="Path to JSON produced by estimate_f0_contour.py "
+                             "(getF0Contour in f0Analysis.js). Optional — if "
+                             "absent, the crossover fallback drives both the LPF "
+                             "and the fundamental-removal HPF.")
+
+    # Segmentation
+    parser.add_argument("--crossover-fallback-hz",  type=float, default=300.0)
+    parser.add_argument("--segment-transition-ms",  type=float, default=75.0)
+    parser.add_argument("--f0-cluster-min-gap-ms",  type=float, default=500.0)
+    parser.add_argument("--f0-min-hz",              type=float, default=80.0)
+    parser.add_argument("--f0-max-hz",              type=float, default=400.0)
+    # Waveshaper
+    parser.add_argument("--drive",                  type=float, default=3.0)
+    parser.add_argument("--softness",               type=float, default=0.5)
+    parser.add_argument("--bias",                   type=float, default=0.3)
+    # Fundamental removal
+    parser.add_argument("--fundamental-cut-ratio",       type=float, default=1.25)
+    parser.add_argument("--fundamental-cut-smooth-ms",   type=float, default=50.0)
+    parser.add_argument("--fundamental-cut-n-filters",   type=int,   default=12)
+    # VAD gate
+    parser.add_argument("--vad-attack-ms",          type=float, default=5.0)
+    parser.add_argument("--vad-release-ms",         type=float, default=20.0)
+    # Skip conditions & mix
+    parser.add_argument("--skip-if-voiced-ratio-below", type=float, default=0.05)
+    parser.add_argument("--mix",                    type=float, default=0.3)
+    parser.add_argument("--no-normalize-output",    action="store_true",
+                        help="Skip the post-blend RMS-match step")
+
+    args = parser.parse_args()
+
+    # --- Load audio ---------------------------------------------------------
+    sr, audio = wavfile.read(args.input)
+    # The pipeline always feeds 32-bit float PCM; defensive cast for safety.
+    if np.issubdtype(audio.dtype, np.integer):
+        audio = audio.astype(np.float32) / np.iinfo(audio.dtype).max
+    audio = audio.astype(np.float32, copy=False)
+
+    # --- Load upstream JSON inputs ------------------------------------------
+    vad_frames = None
+    if args.vad_frames_json:
+        with open(args.vad_frames_json) as fh:
+            vad_frames = json.load(fh)
+
+    f0_contour = None
+    if args.f0_contour_json:
+        with open(args.f0_contour_json) as fh:
+            f0_contour = json.load(fh)
+
+    processed, info = bass_enhance(
+        audio, sr, vad_frames, f0_contour,
+        crossover_fallback_hz=args.crossover_fallback_hz,
+        segment_transition_ms=args.segment_transition_ms,
+        f0_cluster_min_gap_ms=args.f0_cluster_min_gap_ms,
+        f0_min_hz=args.f0_min_hz,
+        f0_max_hz=args.f0_max_hz,
+        drive=args.drive,
+        softness=args.softness,
+        bias=args.bias,
+        fundamental_cut_ratio=args.fundamental_cut_ratio,
+        fundamental_cut_smooth_ms=args.fundamental_cut_smooth_ms,
+        fundamental_cut_n_filters=args.fundamental_cut_n_filters,
+        vad_attack_ms=args.vad_attack_ms,
+        vad_release_ms=args.vad_release_ms,
+        skip_if_voiced_ratio_below=args.skip_if_voiced_ratio_below,
+        mix=args.mix,
+        normalize_output=not args.no_normalize_output,
+    )
+
+    wavfile.write(args.output, sr, processed.astype(np.float32))
+
+    # Pure JSON on stdout — consumed by spawnPythonCapture in the JS wrapper.
+    print(json.dumps(info))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/audio/presets.js
+++ b/src/audio/presets.js
@@ -327,6 +327,10 @@ export const PRESETS = {
         },
       },
       */
+      // BassEnhance off by default for audiobook narration. The preset's
+      // character is "Clean, present, natural" and ACX human review listens
+      // for unnatural tonality / over-processing; opt in per file if needed.
+      { bassEnhance: { enabled: false, drive: 2.5, softness: 0.6, bias: 0.2, mix: 0.2, crossoverFallbackHz: 280 } },
       {
         vocalSaturation: {
           drive: 2.5,
@@ -349,7 +353,7 @@ export const PRESETS = {
             min_flatness: 0.1,
             broadband_trigger_db: 10.0,
           },
-          // Predictive pre-attenuation 
+          // Predictive pre-attenuation
           precut: { enabled: true, maxCutDb: 5.0, minExcessDb: 1.5 },
         },
       },
@@ -552,6 +556,11 @@ export const PRESETS = {
         },
       },
       */
+      // BassEnhance — adds perceived low-end weight via psychoacoustic
+      // harmonic synthesis. Runs after parallelCompression so the dynamics
+      // pass doesn't gate the harmonics, and before airBoost / EQ so the
+      // tonal stages shape the result.
+      { bassEnhance: { drive: 3.0, softness: 0.4, bias: 0.4, mix: 0.35, crossoverFallbackHz: 300 } },
       { airBoost: {
           gainDb: 5,
           sibilantGainFloor: 0.25,
@@ -693,6 +702,10 @@ export const PRESETS = {
           },
         },
       },
+      // BassEnhance — perceived low-end weight via psychoacoustic harmonics.
+      // Conservative mix because General Clean is the catch-all preset and
+      // we cannot assume the source has thin low end.
+      { bassEnhance: { drive: 3.0, softness: 0.5, bias: 0.3, mix: 0.3, crossoverFallbackHz: 300 } },
       {
         resonanceSuppressor: {
           depth: 0.7,


### PR DESCRIPTION
Adds perceived low-end weight to thin recordings by synthesizing harmonic
overtones of the fundamental (MaxxBass-style). The ear infers the missing
fundamental from its overtones, producing perceived sub-bass without the
energy cost or limiter-overloading risk of a real bass boost.

Wired in for podcast_ready and general_clean (active) and acx_audiobook
(disabled, opt-in). Skipped for noise_eraser. Reuses tube_saturate from
vocal_saturation.py for the waveshaper and consumes the existing VAD frames
and cached F0 contour from upstream stages.

Fundamental-removal HPF defaults to 1.25 x F0 — a balanced compromise that
preserves ~80-90% of h2 while attenuating F0 by ~7-10 dB. The small residual
fundamental that survives produces a genuine sub-bass lift on top of the
psychoacoustic effect; intentional and documented.

Emits a new excessive_bass_enhancement quality advisory flag when mix > 0.5
and post-blend low-band gain exceeds 6 dB.

https://claude.ai/code/session_01KJ4EezUUNjVwzXEk59PTdX