### PR TITLE
Persistent Python worker for pipeline ML stages

### DIFF
--- a/server/pipeline/airBoost.js
+++ b/server/pipeline/airBoost.js
@@ -42,13 +42,12 @@
  * gain to keep the noise floor below the -60 dBFS ACX ceiling.
  */
 
-import { spawn }           from 'child_process'
 import { fileURLToPath }  from 'url'
 import path               from 'path'
 import { readFile }       from 'fs/promises'
 import { applyParametricEQ, tempPath, removeTmp } from '../lib/ffmpeg.js'
 import { remeasureFrames }    from './frameAnalysis.js'
-import { PYTHON, spawnPython } from './spawnPython.js'
+import { spawnPython }    from './spawnPython.js'
 import { getReferenceCurvePath } from './referenceEQ.js'
 
 const SCRIPTS_DIR    = path.join(path.dirname(fileURLToPath(import.meta.url)), '..', 'scripts')
@@ -356,47 +355,17 @@ export async function applyAirBoostMask(
   attackMs          = 5.0,
   releaseMs         = 20.0,
 ) {
-  const args = [
+  return spawnPython(
     MASK_SCRIPT,
-    '--original',            originalPath,
-    '--boosted',             boostedPath,
-    '--events',              eventsPath,
-    '--output',              outputPath,
-    '--sibilant-gain-floor', String(sibilantGainFloor),
-    '--attack-ms',           String(attackMs),
-    '--release-ms',          String(releaseMs),
-  ]
-
-  return new Promise((resolve, reject) => {
-    const proc = spawn(PYTHON, args, { stdio: ['ignore', 'pipe', 'pipe'] })
-
-    let stderr = ''
-
-    proc.stdout.on('data', chunk => {
-      for (const line of chunk.toString().split('\n')) {
-        if (line.trim()) console.log(`[AirBoostMask] ${line}`)
-      }
-    })
-
-    proc.stderr.on('data', chunk => {
-      const text = chunk.toString()
-      stderr += text
-      for (const line of text.split('\n')) {
-        if (line.trim()) console.log(`[AirBoostMask] ${line}`)
-      }
-    })
-
-    proc.on('close', (code, signal) => {
-      if (code === 0 && signal === null) {
-        resolve()
-      } else {
-        const parts = []
-        if (code   !== null) parts.push(`code ${code}`)
-        if (signal !== null) parts.push(`signal ${signal}`)
-        reject(new Error(`AirBoostMask exited with ${parts.join(', ')}.\n${stderr.slice(-2000)}`))
-      }
-    })
-
-    proc.on('error', err => reject(new Error(`Failed to spawn AirBoostMask: ${err.message}`)))
-  })
+    [
+      '--original',            originalPath,
+      '--boosted',             boostedPath,
+      '--events',              eventsPath,
+      '--output',              outputPath,
+      '--sibilant-gain-floor', String(sibilantGainFloor),
+      '--attack-ms',           String(attackMs),
+      '--release-ms',          String(releaseMs),
+    ],
+    'AirBoostMask',
+  )
 }

--- a/server/pipeline/clipGainDeEsser.js
+++ b/server/pipeline/clipGainDeEsser.js
@@ -15,15 +15,10 @@
  * body, framed by half-Hann fades that prevent clicks at the boundaries.
  */
 
-import { spawn }                 from 'child_process'
 import { fileURLToPath }         from 'url'
-import { readFile, writeFile, rm } from 'fs/promises'
-import os                        from 'os'
+import { writeFile, rm }         from 'fs/promises'
 import path                      from 'path'
-import { PYTHON as SHARED_PYTHON } from './spawnPython.js'
-
-const CLIP_GAIN_PYTHON = process.env.CLIP_GAIN_DEESSER_PYTHON ?? SHARED_PYTHON
-const NUM_THREADS      = process.env.TORCH_NUM_THREADS ?? String(os.cpus().length)
+import { spawnPythonJsonResult } from './spawnPython.js'
 
 const SCRIPTS_DIR  = path.join(path.dirname(fileURLToPath(import.meta.url)), '..', 'scripts')
 const SCRIPT_PATH  = path.join(SCRIPTS_DIR, 'clip_gain_deesser.py')
@@ -101,7 +96,6 @@ export async function applyClipGainDeEsser(
   const stridentCeiling   = config.stridentCeilingDb    ?? legacyCeiling
   const nonStridentCeil   = config.nonStridentCeilingDb ?? legacyCeiling
   const args  = [
-    SCRIPT_PATH,
     '--input',                    inputPath,
     '--events-json',              eventsJsonPath,
     '--strident-ceiling-db',      String(stridentCeiling),
@@ -126,7 +120,7 @@ export async function applyClipGainDeEsser(
   }
 
   try {
-    return await runScript(args)
+    return await spawnPythonJsonResult(SCRIPT_PATH, args, 'ClipGainDeEsser')
   } finally {
     if (vadMaskPath) await rm(vadMaskPath, { force: true })
   }
@@ -137,69 +131,4 @@ async function writeTempJson(payload) {
   const p = tempPath('.json')
   await writeFile(p, JSON.stringify(payload))
   return p
-}
-
-function runScript(args) {
-  return new Promise((resolve, reject) => {
-    const proc = spawn(CLIP_GAIN_PYTHON, args, {
-      stdio: ['ignore', 'pipe', 'pipe'],
-      env: {
-        ...process.env,
-        OMP_NUM_THREADS:   NUM_THREADS,
-        MKL_NUM_THREADS:   NUM_THREADS,
-        TORCH_NUM_THREADS: NUM_THREADS,
-      },
-    })
-
-    let stdout = ''
-    let stderr = ''
-    let stdoutBuffer = ''
-
-    proc.stdout.on('data', chunk => {
-      const text   = chunk.toString()
-      stdout      += text
-      stdoutBuffer += text
-      const lines  = stdoutBuffer.split('\n')
-      stdoutBuffer = lines.pop()
-      for (const line of lines) {
-        if (line.trim() && !line.startsWith('JSON_RESULT:')) {
-          console.log(`[ClipGainDeEsser] ${line}`)
-        }
-      }
-    })
-
-    proc.stderr.on('data', chunk => {
-      stderr += chunk.toString()
-      if (stderr.length > 4000) stderr = stderr.slice(-4000)
-    })
-
-    proc.on('close', (code, signal) => {
-      if (stdoutBuffer.trim() && !stdoutBuffer.startsWith('JSON_RESULT:')) {
-        console.log(`[ClipGainDeEsser] ${stdoutBuffer.trim()}`)
-      }
-      if (stderr.trim() && code === 0) console.log(`[ClipGainDeEsser] ${stderr.trim()}`)
-
-      if (code === 0 && signal === null) {
-        const line = stdout.split('\n').find(l => l.startsWith('JSON_RESULT:'))
-        if (!line) {
-          reject(new Error('clip_gain_deesser: exited 0 but emitted no JSON_RESULT line'))
-          return
-        }
-        try {
-          resolve(JSON.parse(line.slice('JSON_RESULT:'.length)))
-        } catch (err) {
-          reject(new Error(`clip_gain_deesser: failed to parse JSON_RESULT: ${err.message}`))
-        }
-      } else {
-        const parts = []
-        if (code   !== null) parts.push(`code ${code}`)
-        if (signal !== null) parts.push(`signal ${signal}`)
-        reject(new Error(`clip_gain_deesser exited with ${parts.join(', ')}.\n${stderr.slice(-2000)}`))
-      }
-    })
-
-    proc.on('error', err => {
-      reject(new Error(`Failed to spawn clip_gain_deesser: ${err.message}`))
-    })
-  })
 }

--- a/server/pipeline/enhancement.js
+++ b/server/pipeline/enhancement.js
@@ -5,25 +5,17 @@
  * Environment:
  *   SEPARATION_PYTHON  — Python executable (default: python3)
  *   SEPARATION_DEVICE  — Compute device for device-aware scripts (default: auto)
- *   RESONANCE_PYTHON   — Python override for resonance suppressor (falls back to SEPARATION_PYTHON)
  *   TORCH_NUM_THREADS  — PyTorch thread count (default: CPU count)
  *   AP_BWE_REPO        — Path to cloned AP-BWE repo (default: vendor/ap_bwe)
  *   AP_BWE_CHECKPOINT  — Path to the .pt checkpoint file (required for AP-BWE)
  *   LAVASR_MODEL_PATH  — HuggingFace Hub ID or local path (default: YatharthS/LavaSR)
  */
 
-import { spawn }               from 'child_process'
 import { fileURLToPath }       from 'url'
 import { writeFile, readFile, rm } from 'fs/promises'
-import os                     from 'os'
 import path                   from 'path'
 import { tempPath }      from '../lib/ffmpeg.js'
-import { spawnPython, spawnPythonCapture, DEVICE, PYTHON as SHARED_PYTHON } from './spawnPython.js'
-
-// Resonance suppressor allows its own Python override before falling back to
-// the shared SEPARATION_PYTHON, matching the original RESONANCE_PYTHON cascade.
-const RESONANCE_PYTHON = process.env.RESONANCE_PYTHON ?? SHARED_PYTHON
-const NUM_THREADS      = process.env.TORCH_NUM_THREADS ?? String(os.cpus().length)
+import { spawnPython, spawnPythonCapture, spawnPythonJsonResult, DEVICE } from './spawnPython.js'
 
 const SCRIPTS_DIR                  = path.join(path.dirname(fileURLToPath(import.meta.url)), '..', 'scripts')
 const HARMONIC_EXCITER_SCRIPT      = path.join(SCRIPTS_DIR, 'harmonic_exciter.py')
@@ -273,7 +265,6 @@ export async function applyResonanceSuppression(inputPath, outputPath, preset, f
   const startTime = Date.now()
 
   const args = [
-    RESONANCE_SCRIPT,
     '--input',  inputPath,
     '--output', outputPath,
   ]
@@ -317,7 +308,7 @@ export async function applyResonanceSuppression(inputPath, outputPath, preset, f
 
   let result
   try {
-    result = await runResonanceScript(args)
+    result = await spawnPythonJsonResult(RESONANCE_SCRIPT, args, 'ResonanceSuppressor')
   } finally {
     if (paramsPath)    await rm(paramsPath,    { force: true })
     if (f0ContourPath) await rm(f0ContourPath, { force: true })
@@ -334,55 +325,6 @@ export async function applyResonanceSuppression(inputPath, outputPath, preset, f
   return result
 }
 
-// The resonance suppressor script uses a JSON_RESULT: line-prefix protocol
-// rather than writing pure JSON to stdout, so it needs its own spawn helper.
-function runResonanceScript(args) {
-  return new Promise((resolve, reject) => {
-    const proc = spawn(RESONANCE_PYTHON, args, {
-      stdio: ['ignore', 'pipe', 'pipe'],
-      env: {
-        ...process.env,
-        OMP_NUM_THREADS:   NUM_THREADS,
-        MKL_NUM_THREADS:   NUM_THREADS,
-        TORCH_NUM_THREADS: NUM_THREADS,
-      },
-    })
-
-    let stdout = ''
-    let stderr = ''
-    proc.stdout.on('data', chunk => { stdout += chunk.toString() })
-
-    proc.stderr.on('data', chunk => {
-      stderr += chunk.toString()
-      if (stderr.length > 4000) stderr = stderr.slice(-4000)
-    })
-
-    proc.on('close', (code, signal) => {
-
-      if (code === 0 && signal === null) {
-        const jsonLine = stdout.split('\n').find(l => l.startsWith('JSON_RESULT:'))
-        if (!jsonLine) {
-          reject(new Error('ResonanceSuppressor: script exited 0 but emitted no JSON_RESULT line'))
-          return
-        }
-        try {
-          resolve(JSON.parse(jsonLine.slice('JSON_RESULT:'.length)))
-        } catch (e) {
-          reject(new Error(`ResonanceSuppressor: failed to parse JSON result: ${e.message}`))
-        }
-      } else {
-        const parts = []
-        if (code   !== null) parts.push(`code ${code}`)
-        if (signal !== null) parts.push(`signal ${signal}`)
-        reject(new Error(`ResonanceSuppressor exited with ${parts.join(', ')}.\n${stderr.slice(-2000)}`))
-      }
-    })
-
-    proc.on('error', err => {
-      reject(new Error(`Failed to spawn ResonanceSuppressor: ${err.message}`))
-    })
-  })
-}
 
 // ── Breath Reducer ────────────────────────────────────────────────────────────
 

--- a/server/pipeline/f0Analysis.js
+++ b/server/pipeline/f0Analysis.js
@@ -33,9 +33,8 @@
 
 import { join, dirname }           from 'path'
 import { writeFile, readFile, rm } from 'fs/promises'
-import { spawn }                   from 'child_process'
 import { fileURLToPath }           from 'url'
-import { PYTHON }                  from './spawnPython.js'
+import { spawnPython }             from './spawnPython.js'
 
 const __dirname   = dirname(fileURLToPath(import.meta.url))
 const F0_SCRIPT   = join(__dirname, '../scripts/estimate_f0_contour.py')
@@ -70,7 +69,7 @@ export async function getF0Contour(ctx, { useCache = false } = {}) {
 
   let contour
   try {
-    await runF0Script(args)
+    await spawnPython(F0_SCRIPT, args, 'F0Contour')
     contour = JSON.parse(await readFile(outputPath, 'utf8'))
   } finally {
     if (vadMaskPath) await rm(vadMaskPath, { force: true })
@@ -87,29 +86,3 @@ export async function getF0Contour(ctx, { useCache = false } = {}) {
   return ctx._f0Contour
 }
 
-// ---------------------------------------------------------------------------
-
-function runF0Script(args) {
-  return new Promise((resolve, reject) => {
-    const proc = spawn(PYTHON, [F0_SCRIPT, ...args], {
-      // stdout: 'pipe' so we can drain it; stderr: 'pipe' for error capture.
-      // Both must be consumed to prevent the child process blocking on a full
-      // pipe buffer once its output exceeds the OS pipe buffer (~64 KB).
-      stdio: ['ignore', 'pipe', 'pipe'],
-    })
-    let stderr = ''
-    // Drain stdout — the script prints a one-line summary; capture it for
-    // debug visibility without blocking the process.
-    let stdout = ''
-    proc.stdout.on('data', d => { stdout += d.toString() })
-    proc.stderr.on('data', d => { stderr += d.toString() })
-    proc.on('close', code => {
-      if (stdout.trim()) process.stdout.write(`[F0Script] ${stdout.trim()}\n`)
-      if (code === 0) resolve()
-      else reject(new Error(
-        `estimate_f0_contour.py exited ${code}: ${stderr.slice(-500)}`,
-      ))
-    })
-    proc.on('error', reject)
-  })
-}

--- a/server/pipeline/frameAnalysis.js
+++ b/server/pipeline/frameAnalysis.js
@@ -36,13 +36,12 @@
  * to keep the stage-by-stage console log readable.
  */
 
-import { spawn }          from 'child_process'
 import { readFileSync }   from 'fs'
 import { readFile, rm }   from 'fs/promises'
 import { fileURLToPath }  from 'url'
-import os                 from 'os'
 import path               from 'path'
 
+import { spawnPython }    from './spawnPython.js'
 import { readWavSamples } from './wavReader.js'
 
 // Loaded from the shared config so JS and Python always use the same value.
@@ -55,14 +54,7 @@ const { FRAME_DURATION_S } = JSON.parse(
 )  // 0.025 s = 25 ms — must match FRAME_DURATION_S in silero_vad.py
 const BOOTSTRAP_FRAMES = 20    // use this many lowest-energy frames to bootstrap noise floor
 
-const NUM_THREADS   = process.env.TORCH_NUM_THREADS ?? String(os.cpus().length)
 const VAD_BACKEND   = process.env.VAD_BACKEND   ?? 'silero'
-// Fall back through the other pipeline Python env vars so all scripts share
-// the same interpreter without requiring a separate SILERO_PYTHON entry.
-const SILERO_PYTHON = process.env.SILERO_PYTHON
-                   ?? process.env.DEEPFILTER_PYTHON
-                   ?? process.env.SEPARATION_PYTHON
-                   ?? 'python3'
 const SILERO_SCRIPT = path.join(
   path.dirname(fileURLToPath(import.meta.url)),
   '..', 'scripts', 'silero_vad.py'
@@ -237,42 +229,19 @@ async function analyzeAudioFramesSilero(wavPath) {
 
 /**
  * Spawn the Silero VAD Python script.
+ *
+ * Routed through spawnPython — in the persistent-worker path the Silero
+ * model load (a few hundred ms for the JIT artifact) happens inside the
+ * worker, but only the first time it's called per server lifetime. The
+ * legacy path spawns a fresh interpreter, matching the pre-worker
+ * behavior. Either way, stdout/stderr are drained by the shared helper.
  */
 function spawnSilero(inputPath, outputJsonPath) {
-  return new Promise((resolve, reject) => {
-    const proc = spawn(SILERO_PYTHON, [
-      SILERO_SCRIPT,
-      '--input',  inputPath,
-      '--output', outputJsonPath,
-    ], {
-      stdio: ['ignore', 'pipe', 'pipe'],
-      env: { ...process.env, OMP_NUM_THREADS: NUM_THREADS, MKL_NUM_THREADS: NUM_THREADS, TORCH_NUM_THREADS: NUM_THREADS },
-    })
-
-    let stdout = ''
-    let stderr = ''
-    // Drain stdout to prevent pipe buffer deadlock — Silero VAD emits model
-    // loading output that can fill the 64 KB OS pipe buffer and block the
-    // child process indefinitely if the parent never reads it.
-    proc.stdout.on('data', chunk => { stdout += chunk.toString() })
-    proc.stderr.on('data', chunk => {
-      stderr += chunk.toString()
-      if (stderr.length > 4000) stderr = stderr.slice(-4000)
-    })
-
-    proc.on('close', (code, signal) => {
-      if (code === 0 && signal === null) {
-        resolve()
-      } else {
-        const reason = code !== null ? `code ${code}` : `signal ${signal}`
-        reject(new Error(`Silero VAD exited with ${reason}.\n${stderr.slice(-2000)}`))
-      }
-    })
-
-    proc.on('error', err => {
-      reject(new Error(`Failed to spawn Silero VAD: ${err.message}`))
-    })
-  })
+  return spawnPython(
+    SILERO_SCRIPT,
+    ['--input', inputPath, '--output', outputJsonPath],
+    'SileroVAD',
+  )
 }
 
 /**

--- a/server/pipeline/noiseReduce.js
+++ b/server/pipeline/noiseReduce.js
@@ -19,14 +19,19 @@ import os from 'os'
 import path from 'path'
 import fs from 'fs'
 import { decodeToFloat32, tempPath, removeTmp, padStart } from '../lib/ffmpeg.js'
+import { spawnPython } from './spawnPython.js'
 
 // --- DeepFilter invocation strategy ---
 // DEEPFILTER_BINARY (env): path to a pre-built deep-filter CLI binary.
 //   Used on platforms where the Python deepfilternet package can't be
 //   compiled (e.g. Windows ARM64 without MSVC Build Tools).
 //   On Linux servers, leave unset — the Python script path is used instead.
-// DEEPFILTER_PYTHON (env): Python executable that has deepfilternet installed.
-//   Defaults to 'python3'. Set to a venv python path if needed.
+// DEEPFILTER_PYTHON (env): Python executable for the local spawn helper.
+//   This now only affects the DTLN path and the CLI-binary error log, since
+//   DeepFilterNet3 and RNNoise are routed through spawnPython() and pick up
+//   the persistent worker (which uses SEPARATION_PYTHON). Setting
+//   DEEPFILTER_PYTHON without SEPARATION_PYTHON will not affect the DF3 or
+//   RNNoise interpreter — set SEPARATION_PYTHON to override that.
 const DEEPFILTER_BINARY = process.env.DEEPFILTER_BINARY ?? null
 const PYTHON = process.env.DEEPFILTER_PYTHON ?? 'python3'
 const NUM_THREADS = process.env.TORCH_NUM_THREADS ?? String(os.cpus().length)
@@ -46,7 +51,7 @@ const DTLN_SCRIPT      = path.join(SCRIPTS_DIR, 'dtln_denoise.py')
  * @returns {Promise<object>} Processing metadata for the pipeline report
  */
 export async function applyNoiseReduction(inputPath, outputPath, { attenLimDb = null } = {}) {
-  const strategy = DEEPFILTER_BINARY ? `CLI binary (${DEEPFILTER_BINARY})` : `Python (${PYTHON})`
+  const strategy = DEEPFILTER_BINARY ? `CLI binary (${DEEPFILTER_BINARY})` : 'Python script'
   console.log(`[DeepFilter] Starting: model=DeepFilterNet3 strategy=${strategy} atten_lim_db=${attenLimDb ?? 'uncapped'}`)
 
   // DeepFilterNet3 introduces exactly 10ms of algorithmic fade-in delay (480 samples at 48kHz).
@@ -124,13 +129,15 @@ async function runDeepFilterCli(inputPath, outputPath, attenLimDb) {
 /**
  * Python script strategy (production default).
  * Calls deepfilter_enhance.py which uses the deepfilternet Python package.
+ * Routed through spawnPython so the persistent worker handles the DF3 model
+ * load once per server lifetime instead of every pipeline run.
  */
 function runDeepFilterPython(inputPath, outputPath, attenLimDb) {
-  const args = [SCRIPT, '--input', inputPath, '--output', outputPath]
+  const args = ['--input', inputPath, '--output', outputPath]
   if (attenLimDb !== null) {
     args.push('--atten-lim-db', String(attenLimDb))
   }
-  return spawnProcess(PYTHON, args, 'DeepFilter Python')
+  return spawnPython(SCRIPT, args, 'DeepFilter Python')
 }
 
 // ── Noise reduction alternatives ──────────────────────────────────────────────
@@ -151,7 +158,7 @@ export async function runRnnoise(inputPath, outputPath) {
 
   const nrPath = tempPath('.wav')
   try {
-    await spawnProcess(PYTHON, [RNNOISE_SCRIPT, '--input', paddedInput, '--output', nrPath], 'RNNoise')
+    await spawnPython(RNNOISE_SCRIPT, ['--input', paddedInput, '--output', nrPath], 'RNNoise')
     await decodeToFloat32(nrPath, outputPath, { trimStartMs: 20 })
   } finally {
     await removeTmp(paddedInput)

--- a/server/pipeline/pythonWorker.js
+++ b/server/pipeline/pythonWorker.js
@@ -1,0 +1,183 @@
+/**
+ * Persistent Python worker — singleton that pipes JSON requests to a
+ * long-lived Python process and resolves their JSON responses.
+ *
+ * The worker process (server/scripts/_worker.py) dispatches each request
+ * to the named script's module-level `run(argv)` function. Modules are
+ * lazy-imported and stay loaded for the lifetime of the worker, so torch /
+ * numpy imports and (where the script caches them) ML model weights are
+ * amortized across every pipeline stage.
+ *
+ * The singleton is lazy: the worker is spawned on the first `runPython`
+ * call. Subsequent calls reuse it. If the worker dies unexpectedly all
+ * in-flight requests reject; the next call respawns a fresh worker.
+ *
+ * Concurrency: requests are queued and processed in FIFO order on the
+ * Python side. Single worker = serial Python work, which matches today's
+ * `spawn()`-per-stage behavior (the pipeline itself is serial). Pooling
+ * can be added later if intra-file chunked parallelism is introduced.
+ *
+ * Environment:
+ *   SEPARATION_PYTHON         — Python executable (default: python3)
+ *   TORCH_NUM_THREADS         — torch thread count (default: CPU count)
+ *   WAVELY_DISABLE_PY_WORKER  — set to '1' to force the legacy spawn path
+ *                                in spawnPython.js (escape hatch)
+ */
+
+import { spawn } from 'child_process'
+import { randomUUID } from 'crypto'
+import os from 'os'
+import path from 'path'
+import { fileURLToPath } from 'url'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname  = path.dirname(__filename)
+
+export const PYTHON       = process.env.SEPARATION_PYTHON ?? 'python3'
+const SCRIPTS_DIR         = path.resolve(__dirname, '..', 'scripts')
+const WORKER_SCRIPT       = path.join(SCRIPTS_DIR, '_worker.py')
+const NUM_THREADS         = process.env.TORCH_NUM_THREADS ?? String(os.cpus().length)
+
+let workerProc    = null
+let stdoutBuffer  = ''
+const pending     = new Map()      // id -> { resolve, reject, label }
+
+function buildWorkerEnv(extraEnv = {}) {
+  return {
+    ...process.env,
+    OMP_NUM_THREADS:   NUM_THREADS,
+    MKL_NUM_THREADS:   NUM_THREADS,
+    TORCH_NUM_THREADS: NUM_THREADS,
+    // PYTHONUNBUFFERED so script print() to stderr surfaces immediately
+    // in our log stream, not after the script returns.
+    PYTHONUNBUFFERED:  '1',
+    // _worker.py imports peer scripts by name (e.g. `import deepfilter_enhance`).
+    // Prepend the scripts dir so those imports resolve regardless of cwd.
+    PYTHONPATH: SCRIPTS_DIR + path.delimiter + (process.env.PYTHONPATH ?? ''),
+    ...extraEnv,
+  }
+}
+
+function startWorker() {
+  if (workerProc) return workerProc
+
+  const proc = spawn(PYTHON, [WORKER_SCRIPT], {
+    cwd:   SCRIPTS_DIR,
+    stdio: ['pipe', 'pipe', 'pipe'],
+    env:   buildWorkerEnv(),
+  })
+
+  proc.stdout.on('data', chunk => {
+    stdoutBuffer += chunk.toString()
+    // The protocol is one JSON object per newline. Drain complete lines;
+    // partial trailing bytes stay in the buffer for the next chunk.
+    let nl
+    while ((nl = stdoutBuffer.indexOf('\n')) >= 0) {
+      const line   = stdoutBuffer.slice(0, nl).trim()
+      stdoutBuffer = stdoutBuffer.slice(nl + 1)
+      if (line) handleResponseLine(line)
+    }
+  })
+
+  proc.stderr.on('data', chunk => {
+    // Script-level print() and our own readiness banner come through here.
+    // We don't know which pending request emitted each line (Python is
+    // single-threaded within the worker, so it's "the currently-running one"),
+    // so we tag with a generic prefix.
+    for (const line of chunk.toString().split('\n')) {
+      if (line.trim()) console.log(`[python] ${line}`)
+    }
+  })
+
+  proc.on('exit', (code, signal) => {
+    const reason = `Python worker exited (code=${code}, signal=${signal})`
+    const err = new Error(reason)
+    for (const p of pending.values()) p.reject(err)
+    pending.clear()
+    stdoutBuffer = ''
+    workerProc   = null
+  })
+
+  proc.on('error', err => {
+    const wrapped = new Error(`Python worker spawn failed: ${err.message}`)
+    for (const p of pending.values()) p.reject(wrapped)
+    pending.clear()
+    workerProc = null
+  })
+
+  workerProc = proc
+  return proc
+}
+
+function handleResponseLine(line) {
+  let res
+  try {
+    res = JSON.parse(line)
+  } catch (err) {
+    // The worker is supposed to keep stdout protocol-clean, but if a
+    // stray write slips through we don't want to lose track of pending
+    // requests. Log and move on.
+    console.warn(`[python] non-JSON stdout: ${line.slice(0, 500)}`)
+    return
+  }
+
+  const p = pending.get(res.id)
+  if (!p) {
+    console.warn(`[python] response with unknown id=${res.id}`)
+    return
+  }
+  pending.delete(res.id)
+
+  if (res.ok) {
+    p.resolve(res.result ?? {})
+  } else {
+    const details = res.traceback ? `\n${res.traceback}` : ''
+    p.reject(new Error(`${p.label} failed: ${res.error}${details}`))
+  }
+}
+
+/**
+ * Dispatch a script to the persistent worker.
+ *
+ * @param {string} script — module name (no .py), matches a file in server/scripts/
+ * @param {string[]} argv — argv-style args (e.g. ['--input', '/tmp/x.wav'])
+ * @param {string} label  — label for log messages and errors
+ * @returns {Promise<object>} — the dict returned by the script's run(argv)
+ */
+export function runPython(script, argv = [], label = script) {
+  const proc = startWorker()
+  const id   = randomUUID()
+  return new Promise((resolve, reject) => {
+    pending.set(id, { resolve, reject, label })
+    const payload = JSON.stringify({ id, script, args: argv }) + '\n'
+    proc.stdin.write(payload, err => {
+      if (err) {
+        pending.delete(id)
+        reject(new Error(`${label} failed to send to worker: ${err.message}`))
+      }
+    })
+  })
+}
+
+/**
+ * Health check — returns the worker's pid (spawns it if not running).
+ */
+export async function pingWorker() {
+  return runPython('__ping__', [], 'worker-ping')
+}
+
+/**
+ * Stop the worker if running. Intended for tests and graceful shutdown.
+ */
+export function stopWorker() {
+  if (!workerProc) return Promise.resolve()
+  return new Promise(resolve => {
+    workerProc.once('exit', () => resolve())
+    try {
+      workerProc.stdin.write(JSON.stringify({ script: '__shutdown__' }) + '\n')
+      workerProc.stdin.end()
+    } catch {
+      workerProc.kill()
+    }
+  })
+}

--- a/server/pipeline/sibilanceEvents.js
+++ b/server/pipeline/sibilanceEvents.js
@@ -23,15 +23,10 @@
  * needs the result twice it should hold the return value itself.
  */
 
-import { spawn }                  from 'child_process'
 import { fileURLToPath }          from 'url'
 import { readFile, writeFile, rm } from 'fs/promises'
-import os                         from 'os'
 import path                       from 'path'
-import { PYTHON as SHARED_PYTHON } from './spawnPython.js'
-
-const SIBILANCE_PYTHON = process.env.RESONANCE_PYTHON ?? SHARED_PYTHON
-const NUM_THREADS      = process.env.TORCH_NUM_THREADS ?? String(os.cpus().length)
+import { spawnPythonJsonResult }  from './spawnPython.js'
 
 const SCRIPTS_DIR     = path.join(path.dirname(fileURLToPath(import.meta.url)), '..', 'scripts')
 const ANALYZER_SCRIPT = path.join(SCRIPTS_DIR, 'analyze_sibilance_events.py')
@@ -69,7 +64,6 @@ export async function analyzeSibilanceEvents(ctx, { params, f0Contour } = {}) {
   await writeFile(contourPath, JSON.stringify(f0Contour))
 
   const args = [
-    ANALYZER_SCRIPT,
     '--input',            ctx.currentPath,
     '--output',           eventsPath,
     '--f0-contour-json',  contourPath,
@@ -115,7 +109,12 @@ export async function analyzeSibilanceEvents(ctx, { params, f0Contour } = {}) {
   const startTime = Date.now()
 
   try {
-    await runAnalyzerScript(args)
+    // The analyzer uses the JSON_RESULT: line-prefix protocol (summary
+    // line on stdout, the heavy event map written to --output). We don't
+    // need the summary value here — it's mirrored in the event map JSON
+    // we read off disk below — but spawnPythonJsonResult is still the
+    // right shape (it'll route through the worker for migrated scripts).
+    await spawnPythonJsonResult(ANALYZER_SCRIPT, args, 'SibilanceAnalyzer')
   } finally {
     if (vadMaskPath) await rm(vadMaskPath, { force: true })
     if (paramsPath)  await rm(paramsPath,  { force: true })
@@ -132,59 +131,4 @@ export async function analyzeSibilanceEvents(ctx, { params, f0Contour } = {}) {
   )
 
   return { events, path: eventsPath }
-}
-
-// The analyzer uses the same JSON_RESULT: line-prefix protocol as the
-// suppressor (summary line on stdout, heavy data written to --output).
-function runAnalyzerScript(args) {
-  return new Promise((resolve, reject) => {
-    const proc = spawn(SIBILANCE_PYTHON, args, {
-      stdio: ['ignore', 'pipe', 'pipe'],
-      env: {
-        ...process.env,
-        OMP_NUM_THREADS:   NUM_THREADS,
-        MKL_NUM_THREADS:   NUM_THREADS,
-        TORCH_NUM_THREADS: NUM_THREADS,
-      },
-    })
-
-    let stderr = ''
-    let stdoutBuffer = ''
-
-    proc.stdout.on('data', chunk => {
-      stdoutBuffer += chunk.toString()
-      const lines  = stdoutBuffer.split('\n')
-      stdoutBuffer = lines.pop()
-      for (const line of lines) {
-        if (line.trim() && !line.startsWith('JSON_RESULT:')) {
-          console.log(`[SibilanceAnalyzer] ${line}`)
-        }
-      }
-    })
-
-    proc.stderr.on('data', chunk => {
-      stderr += chunk.toString()
-      if (stderr.length > 4000) stderr = stderr.slice(-4000)
-    })
-
-    proc.on('close', (code, signal) => {
-      if (stdoutBuffer.trim() && !stdoutBuffer.startsWith('JSON_RESULT:')) {
-        console.log(`[SibilanceAnalyzer] ${stdoutBuffer.trim()}`)
-      }
-      if (stderr.trim() && code === 0) console.log(`[SibilanceAnalyzer] ${stderr.trim()}`)
-
-      if (code === 0 && signal === null) {
-        resolve()
-      } else {
-        const parts = []
-        if (code   !== null) parts.push(`code ${code}`)
-        if (signal !== null) parts.push(`signal ${signal}`)
-        reject(new Error(`SibilanceAnalyzer exited with ${parts.join(', ')}.\n${stderr.slice(-2000)}`))
-      }
-    })
-
-    proc.on('error', err => {
-      reject(new Error(`Failed to spawn SibilanceAnalyzer: ${err.message}`))
-    })
-  })
 }

--- a/server/pipeline/spawnPython.js
+++ b/server/pipeline/spawnPython.js
@@ -1,81 +1,114 @@
 /**
- * Shared Python subprocess spawners for ML pipeline stages.
+ * Python subprocess spawners for ML pipeline stages.
  *
- * spawnPython        — fire-and-forget; streams stdout/stderr in real time
- * spawnPythonCapture — collects stdout, returns parsed JSON
+ * Two execution paths:
+ *
+ *   1. Persistent worker (default) — scripts listed in WORKER_SCRIPTS are
+ *      dispatched into a long-lived Python process (server/scripts/_worker.py).
+ *      Imports and (where the script caches them) ML models persist across
+ *      calls, so the second invocation of any given stage is much faster
+ *      than today's cold-start spawn.
+ *
+ *   2. Legacy spawn — every other script (and everything if the env var
+ *      WAVELY_DISABLE_PY_WORKER=1 is set) still goes through a fresh
+ *      `spawn(python, [script, ...args])` invocation, identical to the
+ *      pre-worker behavior. This is the fallback while individual scripts
+ *      are migrated to expose a top-level `run(argv)` function.
+ *
+ * Call sites do not need to know which path is taken — `spawnPython` and
+ * `spawnPythonCapture` keep their existing signatures.
  *
  * Environment:
- *   SEPARATION_PYTHON  — Python executable (default: python3)
- *   SEPARATION_DEVICE  — Compute device for device-aware scripts (default: auto)
- *   TORCH_NUM_THREADS  — PyTorch thread count (default: CPU count)
+ *   SEPARATION_PYTHON         — Python executable (default: python3)
+ *   SEPARATION_DEVICE         — Compute device for device-aware scripts
+ *   TORCH_NUM_THREADS         — torch thread count (default: CPU count)
+ *   WAVELY_DISABLE_PY_WORKER  — set to '1' to force the legacy path
  */
 
 import { spawn } from 'child_process'
 import os from 'os'
+import path from 'path'
+
+import { runPython } from './pythonWorker.js'
 
 export const PYTHON = process.env.SEPARATION_PYTHON ?? 'python3'
 export const DEVICE = process.env.SEPARATION_DEVICE ?? 'auto'
 const NUM_THREADS = process.env.TORCH_NUM_THREADS ?? String(os.cpus().length)
 
-/**
- * Spawn a Python script, streaming stdout/stderr line-by-line in real time.
- * Resolves when the script exits 0; rejects on non-zero exit or spawn error.
- */
-export function spawnPython(script, args, label, extraEnv = {}) {
-  return new Promise((resolve, reject) => {
-    const proc = spawn(PYTHON, [script, ...args], {
-      stdio: ['ignore', 'pipe', 'pipe'],
-      env: {
-        ...process.env,
-        OMP_NUM_THREADS:   NUM_THREADS,
-        MKL_NUM_THREADS:   NUM_THREADS,
-        TORCH_NUM_THREADS: NUM_THREADS,
-        ...extraEnv,
-      },
-    })
+// Scripts that have been refactored to expose a top-level `run(argv)` function
+// callable from _worker.py. Anything not in this set falls through to the
+// legacy spawn path. Add a script name (no .py) once its main() has been
+// updated to accept an `argv` parameter and return its result dict.
+const WORKER_SCRIPTS = new Set([
+  'deepfilter_enhance',
+  'rnnoise_denoise',
+  'corrective_eq',
+  'reference_eq',
+  'vocal_saturation',
+  'air_boost_precut',
+  'click_remover',
+  'room_presence',
+])
 
-    let stderr = ''
+function workerEnabled() {
+  return process.env.WAVELY_DISABLE_PY_WORKER !== '1'
+}
 
-    // Stream stdout line-by-line — tqdm and other model progress bars are
-    // visible in server logs without waiting for the process to finish.
-    proc.stdout.on('data', chunk => {
-      for (const line of chunk.toString().split('\n')) {
-        if (line.trim()) console.log(`[${label}] ${line}`)
-      }
-    })
+function scriptBaseName(scriptPath) {
+  // Callers pass an absolute path to the .py file; the worker dispatches by
+  // module name (the filename without extension).
+  return path.basename(scriptPath, '.py')
+}
 
-    // Drain stderr in real time; keep a rolling tail for error messages.
-    proc.stderr.on('data', chunk => {
-      const text = chunk.toString()
-      stderr += text
-      if (stderr.length > 8000) stderr = stderr.slice(-8000)
-      for (const line of text.split('\n')) {
-        if (line.trim()) console.log(`[${label}] ${line}`)
-      }
-    })
-
-    proc.on('close', (code, signal) => {
-      if (code === 0 && signal === null) {
-        resolve()
-      } else {
-        const parts = []
-        if (code   !== null) parts.push(`code ${code}`)
-        if (signal !== null) parts.push(`signal ${signal}`)
-        reject(new Error(`${label} exited with ${parts.join(', ') || 'unknown reason'}.\n${stderr.slice(-3000)}`))
-      }
-    })
-
-    proc.on('error', err => {
-      reject(new Error(`Failed to spawn ${label}: ${err.message}`))
-    })
-  })
+function shouldUseWorker(scriptPath) {
+  if (!workerEnabled()) return false
+  return WORKER_SCRIPTS.has(scriptBaseName(scriptPath))
 }
 
 /**
- * Like spawnPython but collects all stdout and returns it as parsed JSON.
- * Stderr is still streamed to console in real time.
+ * Fire-and-forget: run a Python script, stream its stdout/stderr to the
+ * server log, resolve when it exits 0.
+ *
+ * Worker path: the script's run(argv) is dispatched into the persistent
+ * worker; its return dict is discarded.
+ *
+ * Legacy path: spawn a fresh `python <script> <args>` process.
  */
-export function spawnPythonCapture(script, args, label, extraEnv = {}) {
+export async function spawnPython(script, args, label, extraEnv = {}) {
+  if (shouldUseWorker(script)) {
+    // The worker doesn't accept per-call env overrides — extraEnv was used
+    // by the legacy path to set things like SEPARATION_DEVICE per call. In
+    // practice every caller passes the same values, so the worker's process
+    // env (set once at startup) is fine. If a future caller needs a true
+    // per-call override, gate that script out of WORKER_SCRIPTS.
+    await runPython(scriptBaseName(script), args, label)
+    return
+  }
+  return legacySpawn(script, args, label, extraEnv, /* capture */ false)
+}
+
+/**
+ * Run a Python script and parse its stdout as JSON. Stderr is streamed
+ * to the server log.
+ *
+ * Worker path: the script's run(argv) is dispatched into the persistent
+ * worker; its return dict is the resolved value.
+ *
+ * Legacy path: spawn + capture stdout + JSON.parse.
+ */
+export async function spawnPythonCapture(script, args, label, extraEnv = {}) {
+  if (shouldUseWorker(script)) {
+    return runPython(scriptBaseName(script), args, label)
+  }
+  return legacySpawn(script, args, label, extraEnv, /* capture */ true)
+}
+
+// ---------------------------------------------------------------------------
+// Legacy spawn path — used for scripts not yet migrated to the worker.
+// Behavior matches the pre-worker implementation exactly.
+// ---------------------------------------------------------------------------
+
+function legacySpawn(script, args, label, extraEnv, capture) {
   return new Promise((resolve, reject) => {
     const proc = spawn(PYTHON, [script, ...args], {
       stdio: ['ignore', 'pipe', 'pipe'],
@@ -91,7 +124,15 @@ export function spawnPythonCapture(script, args, label, extraEnv = {}) {
     let stdout = ''
     let stderr = ''
 
-    proc.stdout.on('data', chunk => { stdout += chunk.toString() })
+    proc.stdout.on('data', chunk => {
+      if (capture) {
+        stdout += chunk.toString()
+      } else {
+        for (const line of chunk.toString().split('\n')) {
+          if (line.trim()) console.log(`[${label}] ${line}`)
+        }
+      }
+    })
 
     proc.stderr.on('data', chunk => {
       const text = chunk.toString()
@@ -104,15 +145,19 @@ export function spawnPythonCapture(script, args, label, extraEnv = {}) {
 
     proc.on('close', (code, signal) => {
       if (code === 0 && signal === null) {
-        try {
-          resolve(JSON.parse(stdout))
-        } catch (err) {
-          const details = [
-            `${label} produced invalid JSON on stdout: ${err.message}`,
-            `stdout (tail):\n${stdout.trim().slice(-3000) || '(empty)'}`,
-          ]
-          if (stderr.trim()) details.push(`stderr (tail):\n${stderr.trim().slice(-3000)}`)
-          reject(new Error(details.join('\n')))
+        if (capture) {
+          try {
+            resolve(JSON.parse(stdout))
+          } catch (err) {
+            const details = [
+              `${label} produced invalid JSON on stdout: ${err.message}`,
+              `stdout (tail):\n${stdout.trim().slice(-3000) || '(empty)'}`,
+            ]
+            if (stderr.trim()) details.push(`stderr (tail):\n${stderr.trim().slice(-3000)}`)
+            reject(new Error(details.join('\n')))
+          }
+        } else {
+          resolve()
         }
       } else {
         const parts = []

--- a/server/pipeline/spawnPython.js
+++ b/server/pipeline/spawnPython.js
@@ -46,8 +46,14 @@ const WORKER_SCRIPTS = new Set([
   'reference_eq',
   'vocal_saturation',
   'air_boost_precut',
+  'air_boost_masked',
   'click_remover',
   'room_presence',
+  'silero_vad',
+  'estimate_f0_contour',
+  'clip_gain_deesser',
+  'analyze_sibilance_events',
+  'resonance_suppressor',
 ])
 
 function workerEnabled() {
@@ -101,6 +107,29 @@ export async function spawnPythonCapture(script, args, label, extraEnv = {}) {
     return runPython(scriptBaseName(script), args, label)
   }
   return legacySpawn(script, args, label, extraEnv, /* capture */ true)
+}
+
+/**
+ * Run a Python script that uses the `JSON_RESULT:` line-prefix protocol —
+ * progress logs go to stdout/stderr, the result is a single line beginning
+ * with `JSON_RESULT:` followed by the JSON payload. Used by stages whose
+ * scripts emit chatty progress logs but still need to return a summary
+ * dict to JS (clip_gain_deesser, analyze_sibilance_events, resonance_suppressor).
+ *
+ * Worker path: identical to spawnPythonCapture — the script's run(argv)
+ * returns the dict directly through the protocol, so the JSON_RESULT
+ * line is irrelevant and ignored. Progress prints in stdout are routed to
+ * stderr by the worker and end up in the server log.
+ *
+ * Legacy path: spawn, stream stdout to the log line-by-line, suppress
+ * lines starting with `JSON_RESULT:`, and parse the final JSON_RESULT
+ * line as the resolved value.
+ */
+export async function spawnPythonJsonResult(script, args, label, extraEnv = {}) {
+  if (shouldUseWorker(script)) {
+    return runPython(scriptBaseName(script), args, label)
+  }
+  return legacySpawnJsonResult(script, args, label, extraEnv)
 }
 
 // ---------------------------------------------------------------------------
@@ -158,6 +187,80 @@ function legacySpawn(script, args, label, extraEnv, capture) {
           }
         } else {
           resolve()
+        }
+      } else {
+        const parts = []
+        if (code   !== null) parts.push(`code ${code}`)
+        if (signal !== null) parts.push(`signal ${signal}`)
+        reject(new Error(`${label} exited with ${parts.join(', ') || 'unknown reason'}.\n${stderr.slice(-3000)}`))
+      }
+    })
+
+    proc.on('error', err => {
+      reject(new Error(`Failed to spawn ${label}: ${err.message}`))
+    })
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Legacy spawn path with JSON_RESULT: prefix protocol.
+// ---------------------------------------------------------------------------
+
+function legacySpawnJsonResult(script, args, label, extraEnv) {
+  return new Promise((resolve, reject) => {
+    const proc = spawn(PYTHON, [script, ...args], {
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env: {
+        ...process.env,
+        OMP_NUM_THREADS:   NUM_THREADS,
+        MKL_NUM_THREADS:   NUM_THREADS,
+        TORCH_NUM_THREADS: NUM_THREADS,
+        ...extraEnv,
+      },
+    })
+
+    let stdout       = ''
+    let stderr       = ''
+    let stdoutBuffer = ''
+
+    proc.stdout.on('data', chunk => {
+      const text = chunk.toString()
+      stdout      += text
+      stdoutBuffer += text
+      // Stream non-JSON_RESULT lines to the log as they arrive.
+      const lines  = stdoutBuffer.split('\n')
+      stdoutBuffer = lines.pop()
+      for (const line of lines) {
+        if (line.trim() && !line.startsWith('JSON_RESULT:')) {
+          console.log(`[${label}] ${line}`)
+        }
+      }
+    })
+
+    proc.stderr.on('data', chunk => {
+      const text = chunk.toString()
+      stderr += text
+      if (stderr.length > 8000) stderr = stderr.slice(-8000)
+      for (const line of text.split('\n')) {
+        if (line.trim()) console.log(`[${label}] ${line}`)
+      }
+    })
+
+    proc.on('close', (code, signal) => {
+      // Flush any partial trailing stdout line that wasn't terminated.
+      if (stdoutBuffer.trim() && !stdoutBuffer.startsWith('JSON_RESULT:')) {
+        console.log(`[${label}] ${stdoutBuffer.trim()}`)
+      }
+      if (code === 0 && signal === null) {
+        const line = stdout.split('\n').find(l => l.startsWith('JSON_RESULT:'))
+        if (!line) {
+          reject(new Error(`${label}: exited 0 but emitted no JSON_RESULT line`))
+          return
+        }
+        try {
+          resolve(JSON.parse(line.slice('JSON_RESULT:'.length)))
+        } catch (err) {
+          reject(new Error(`${label}: failed to parse JSON_RESULT: ${err.message}`))
         }
       } else {
         const parts = []

--- a/server/scripts/_worker.py
+++ b/server/scripts/_worker.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""
+Persistent Python worker for the Wavely pipeline.
+
+A long-lived Python process that dispatches per-stage work to module-level
+`run(argv)` functions. Replacing per-stage `python3 <script>.py` invocations
+with calls into this worker amortizes interpreter startup, torch/numpy
+imports, and (where the script caches them) model weights across the whole
+pipeline run.
+
+Protocol — newline-delimited JSON on stdin (in) and stdout (out):
+
+  Request:   {"id": "<uuid>", "script": "<module_name>", "args": ["--input", "..."]}
+  Success:   {"id": "<uuid>", "ok": true, "result": <jsonable>}
+  Failure:   {"id": "<uuid>", "ok": false, "error": "...", "traceback": "..."}
+
+  Control requests (script name starts with "__"):
+    {"script": "__ping__"}      -> {"ok": true, "result": {"pid": ...}}
+    {"script": "__shutdown__"}  -> exits with code 0
+
+Anything written to stdout from inside a dispatched script is silently
+redirected to stderr — stdout is reserved for the protocol. Scripts that
+need to return structured data should `return` a dict from their `main()`
+function (the dispatcher forwards it as the `result` field). Stderr is
+the worker's "log channel" and the JS side streams it to the server log.
+"""
+
+import importlib
+import io
+import json
+import os
+import sys
+import traceback
+
+
+_LOADED_MODULES = {}
+
+
+def _load(script_name):
+    """Lazy-import a script module by name. Cached on success."""
+    mod = _LOADED_MODULES.get(script_name)
+    if mod is not None:
+        return mod
+    mod = importlib.import_module(script_name)
+    _LOADED_MODULES[script_name] = mod
+    return mod
+
+
+def _dispatch(script, argv):
+    """Run the named script's `run(argv)` and return its result (a dict)."""
+    if script == '__ping__':
+        return {'pid': os.getpid()}
+    if script == '__shutdown__':
+        sys.exit(0)
+
+    mod = _load(script)
+    if not hasattr(mod, 'run'):
+        raise RuntimeError(
+            f"Script '{script}' does not expose a top-level run(argv) function. "
+            "Refactor its main() to accept an argv list and add `def run(argv): return main(argv)`."
+        )
+    result = mod.run(argv or [])
+    return result if result is not None else {}
+
+
+def _write_response(real_stdout, payload):
+    real_stdout.write(json.dumps(payload, default=str) + '\n')
+    real_stdout.flush()
+
+
+def main():
+    # Reserve stdout for protocol traffic. Redirect any script-level print()
+    # to stderr so log messages don't corrupt the response stream.
+    real_stdout = sys.stdout
+    sys.stdout = sys.stderr
+
+    # Announce readiness on stderr (visible to JS log stream, ignored by protocol).
+    print(f'[worker] ready pid={os.getpid()}', file=sys.stderr, flush=True)
+
+    for raw_line in sys.stdin:
+        line = raw_line.strip()
+        if not line:
+            continue
+
+        req_id = None
+        try:
+            req = json.loads(line)
+            req_id = req.get('id')
+            script = req['script']
+            argv   = req.get('args', [])
+            if not isinstance(argv, list):
+                raise TypeError(f"args must be a list of strings, got {type(argv).__name__}")
+            result = _dispatch(script, argv)
+            _write_response(real_stdout, {'id': req_id, 'ok': True, 'result': result})
+        except SystemExit:
+            # __shutdown__ propagates up — let it exit cleanly.
+            raise
+        except BaseException as exc:
+            _write_response(real_stdout, {
+                'id': req_id,
+                'ok': False,
+                'error': f'{type(exc).__name__}: {exc}',
+                'traceback': traceback.format_exc(),
+            })
+
+    # stdin closed — JS side has disconnected. Exit cleanly.
+    print('[worker] stdin closed, exiting', file=sys.stderr, flush=True)
+
+
+if __name__ == '__main__':
+    main()

--- a/server/scripts/air_boost_masked.py
+++ b/server/scripts/air_boost_masked.py
@@ -128,8 +128,8 @@ def blend_stft_channel(orig_ch, boost_ch, envelope, sample_rate):
     return out.astype(np.float32)
 
 
-if __name__ == "__main__":
-    logging.basicConfig(level=logging.INFO, stream=sys.stdout, format="%(message)s")
+def main(argv=None):
+    logging.basicConfig(level=logging.INFO, stream=sys.stderr, format="%(message)s")
 
     parser = argparse.ArgumentParser(description="Sibilant-aware air boost blend (STFT)")
     parser.add_argument("--original",            required=True)
@@ -139,7 +139,7 @@ if __name__ == "__main__":
     parser.add_argument("--sibilant-gain-floor", type=float, default=0.0)
     parser.add_argument("--attack-ms",           type=float, default=5.0)
     parser.add_argument("--release-ms",          type=float, default=20.0)
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
 
     sr_o, original = wavfile.read(args.original)
     sr_b, boosted  = wavfile.read(args.boosted)
@@ -158,7 +158,7 @@ if __name__ == "__main__":
     if not sibilant_frame_indices:
         logger.info("AirBoostMask: no sibilant frames — writing boosted as-is")
         wavfile.write(args.output, sr_o, boosted)
-        sys.exit(0)
+        return {'sibilant_frames': 0, 'applied': False}
 
     logger.info(
         f"AirBoostMask: {len(sibilant_frame_indices)} sibilant frames | "
@@ -190,3 +190,19 @@ if __name__ == "__main__":
         f"AirBoostMask: done | sibilant≈{sib_pct:.1f}% | "
         f"envelope min={envelope.min():.3f}"
     )
+
+    return {
+        'sibilant_frames': len(sibilant_frame_indices),
+        'sibilant_pct': sib_pct,
+        'envelope_min': float(envelope.min()),
+        'applied': True,
+    }
+
+
+def run(argv):
+    """Entry point used by the persistent worker (_worker.py)."""
+    return main(argv)
+
+
+if __name__ == "__main__":
+    main()

--- a/server/scripts/air_boost_precut.py
+++ b/server/scripts/air_boost_precut.py
@@ -309,8 +309,8 @@ def size_precut(measured_db, reference_db, air_boost_db, max_cut_db, min_excess_
 
 # ── Entry point ───────────────────────────────────────────────────────────────
 
-def run(audio, sr, reference_levels, noise_floor_db, air_boost_db,
-        max_cut_db, min_excess_db):
+def analyze_precut(audio, sr, reference_levels, noise_floor_db, air_boost_db,
+                   max_cut_db, min_excess_db):
     measured_db, n_speech = speech_spectrum(audio, sr, noise_floor_db)
     if measured_db is None:
         return {
@@ -325,7 +325,7 @@ def run(audio, sr, reference_levels, noise_floor_db, air_boost_db,
     return out
 
 
-if __name__ == '__main__':
+def main(argv=None):
     logging.basicConfig(level=logging.INFO, stream=sys.stderr, format='%(message)s')
     parser = argparse.ArgumentParser(description='airBoost predictive pre-attenuation')
     parser.add_argument('--input',         required=True, help='Input WAV (float32, 44.1 kHz, mono)')
@@ -336,7 +336,7 @@ if __name__ == '__main__':
     parser.add_argument('--min-excess-db', type=float, default=DEFAULT_MIN_EXCESS_DB)
     parser.add_argument('--noise-floor',   type=float, default=None,
                         help='Canonical pipeline noise floor (dBFS) for the speech gate')
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
 
     with open(args.curve) as fh:
         curve = json.load(fh)
@@ -348,7 +348,7 @@ if __name__ == '__main__':
         )
 
     sr, audio = _load_audio(args.input)
-    result = run(
+    result = analyze_precut(
         audio, sr, curve_levels, args.noise_floor,
         args.air_boost_db, args.max_cut_db, args.min_excess_db,
     )
@@ -368,3 +368,17 @@ if __name__ == '__main__':
         )
     else:
         print(f"airBoostPrecut: skipped — {result.get('reason')}", flush=True)
+
+    return {
+        'applied': result.get('applied', False),
+        'gain_db': result.get('gain_db'),
+    }
+
+
+def run(argv):
+    """Entry point used by the persistent worker (_worker.py)."""
+    return main(argv)
+
+
+if __name__ == '__main__':
+    main()

--- a/server/scripts/analyze_sibilance_events.py
+++ b/server/scripts/analyze_sibilance_events.py
@@ -40,8 +40,7 @@ logger = logging.getLogger(__name__)
 # CLI
 # ---------------------------------------------------------------------------
 
-if __name__ == "__main__":
-    logging.basicConfig(level=logging.INFO, stream=sys.stdout, format="%(message)s")
+def main(argv=None):
     parser = argparse.ArgumentParser(description="Sibilance event analyzer")
     parser.add_argument("--input",            required=True)
     parser.add_argument("--output",           required=True,
@@ -57,7 +56,7 @@ if __name__ == "__main__":
                              "preset.airBoost.sibilanceDetection or "
                              "preset.resonanceSuppressor[i].sibilanceDetection).")
     parser.add_argument("--vad-mask-json",    default=None)
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
 
     sr, audio = wavfile.read(args.input)
     if np.issubdtype(audio.dtype, np.integer):
@@ -185,9 +184,26 @@ if __name__ == "__main__":
                 _fmt(bd.get("head", [])), _fmt(bd.get("tail", [])),
             )
 
-    print("JSON_RESULT:" + json.dumps({
+    return {
         "frameCount":         events["frameCount"],
         "sibilantFrameCount": len(events["sibilantFrameIndices"]),
         "eventCount":         len(events["events"]),
         "f0Median":           events["f0"]["median"],
-    }), flush=True)
+    }
+
+
+def run(argv):
+    """Entry point used by the persistent worker (_worker.py).
+
+    Returns the summary dict directly via the worker protocol — no
+    JSON_RESULT line is emitted in worker mode.
+    """
+    return main(argv)
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO, stream=sys.stdout, format="%(message)s")
+    # Legacy CLI / spawnPythonJsonResult contract: progress logs on stdout
+    # plus a single trailing JSON_RESULT: line that the JS side parses.
+    result = main()
+    print("JSON_RESULT:" + json.dumps(result), flush=True)

--- a/server/scripts/click_remover.py
+++ b/server/scripts/click_remover.py
@@ -313,7 +313,7 @@ def process_file(input_path, output_path, **kwargs):
 # CLI entry point
 # ---------------------------------------------------------------------------
 
-if __name__ == "__main__":
+def main(argv=None):
     parser = argparse.ArgumentParser(
         description="Click and lip-smack remover for speech/narration audio"
     )
@@ -333,9 +333,9 @@ if __name__ == "__main__":
         help="High-pass cutoff Hz for detection residual (default: 800).")
     parser.add_argument("--ar-order",     type=int,   default=None,
         help="AR model order (default: context_samples // 2).")
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
 
-    report = process_file(
+    return process_file(
         args.input,
         args.output,
         threshold_sigma=args.threshold,
@@ -346,5 +346,19 @@ if __name__ == "__main__":
         ar_order=args.ar_order,
     )
 
+
+def run(argv):
+    """Entry point used by the persistent worker (_worker.py).
+
+    Returns the report dict directly. The legacy spawnPythonCapture path
+    parses it from stdout; the worker path receives it as the response payload.
+    """
+    return main(argv)
+
+
+if __name__ == "__main__":
+    report = main()
+    # spawnPythonCapture reads JSON from stdout — preserve that contract for
+    # the legacy CLI path.
     print(json.dumps(report, indent=2))
     sys.exit(0)

--- a/server/scripts/clip_gain_deesser.py
+++ b/server/scripts/clip_gain_deesser.py
@@ -251,7 +251,7 @@ def _render_event_envelope(
 # Main
 # ---------------------------------------------------------------------------
 
-def main() -> int:
+def main(argv=None):
     parser = argparse.ArgumentParser(description="Clip-gain de-esser.")
     parser.add_argument("--input",          required=True)
     parser.add_argument("--output",         default=None,
@@ -275,7 +275,7 @@ def main() -> int:
                              "boundaries instead of reading it from events.json.")
     parser.add_argument("--no-render", action="store_true",
                         help="Skip writing --output. JSON_RESULT is still emitted.")
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
 
     if not args.no_render and not args.output:
         parser.error("--output is required unless --no-render is set")
@@ -429,10 +429,22 @@ def main() -> int:
         "reductionRatio":             args.reduction_ratio,
         "maxReductionCapDb":          args.max_reduction_db,
     }
-    print("JSON_RESULT:" + json.dumps(summary), flush=True)
-    return 0
+    return summary
+
+
+def run(argv):
+    """Entry point used by the persistent worker (_worker.py).
+
+    Returns the summary dict directly via the worker protocol — no
+    JSON_RESULT line is emitted in worker mode.
+    """
+    return main(argv)
 
 
 if __name__ == "__main__":
     logging.basicConfig(level=logging.INFO, stream=sys.stdout, format="%(message)s")
-    sys.exit(main())
+    # Legacy CLI / spawnPythonJsonResult contract: progress logs on stdout
+    # plus a single trailing JSON_RESULT: line that the JS side parses.
+    result = main()
+    print("JSON_RESULT:" + json.dumps(result), flush=True)
+    sys.exit(0)

--- a/server/scripts/corrective_eq.py
+++ b/server/scripts/corrective_eq.py
@@ -461,7 +461,7 @@ def _load_voiced_mask(path, n_samples):
     return mask
 
 
-if __name__ == "__main__":
+def main(argv=None):
     logging.basicConfig(level=logging.INFO, stream=sys.stderr, format="%(message)s")
     parser = argparse.ArgumentParser(description="Stage 3a Corrective EQ analysis")
     parser.add_argument("--input",         required=True, help="Input WAV (float32, 44.1 kHz, mono)")
@@ -469,7 +469,7 @@ if __name__ == "__main__":
     parser.add_argument("--vad-mask-json", default=None,  help="VAD frame list JSON")
     parser.add_argument("--f0-median",     type=float, required=True, help="Median F0 (Hz)")
     parser.add_argument("--f0-p5",         type=float, required=True, help="5th-percentile F0 (Hz)")
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
 
     sr, audio = wavfile.read(args.input)
     if np.issubdtype(audio.dtype, np.integer):
@@ -495,3 +495,19 @@ if __name__ == "__main__":
         f"bands={len(result['bands'])} merged={result['merged_bands']}",
         flush=True,
     )
+
+    return {
+        'voice_type': result['voice_type'],
+        'voiced_frames_used': result['voiced_frames_used'],
+        'bands_count': len(result['bands']),
+        'merged_bands': result['merged_bands'],
+    }
+
+
+def run(argv):
+    """Entry point used by the persistent worker (_worker.py)."""
+    return main(argv)
+
+
+if __name__ == "__main__":
+    main()

--- a/server/scripts/deepfilter_enhance.py
+++ b/server/scripts/deepfilter_enhance.py
@@ -8,6 +8,11 @@ Usage:
 Reads a WAV file, resamples to 48 kHz for DeepFilterNet3, applies noise
 reduction, then writes the result as 32-bit float PCM WAV at 48 kHz.
 The caller (noiseReduce.js) resamples back to 44.1 kHz via FFmpeg.
+
+Worker integration: when invoked through the persistent worker (_worker.py),
+the model is loaded once on the first call and cached in module state for
+every subsequent call. The standalone CLI path re-loads it each invocation,
+matching pre-worker behavior.
 """
 import argparse
 import os
@@ -16,7 +21,33 @@ import warnings
 warnings.filterwarnings('ignore')
 
 
-def main():
+# Module-level model cache. Populated lazily on the first call; reused by
+# every subsequent run() inside the persistent worker.
+_DF_STATE = None
+
+
+def _get_model():
+    """Load DeepFilterNet3 once per process. Returns (model, df_state, model_sr)."""
+    global _DF_STATE
+    if _DF_STATE is not None:
+        return _DF_STATE
+
+    import torch
+    from df.enhance import init_df
+
+    num_threads = int(os.environ.get('TORCH_NUM_THREADS', os.cpu_count() or 4))
+    torch.set_num_threads(num_threads)
+
+    # Weights cached at ~/.cache/DeepFilterNet/DeepFilterNet3
+    model, df_state, _ = init_df()
+    model_sr = df_state.sr()  # 48000
+    print(f'[deepfilter] model=DeepFilterNet3 sr={model_sr} loaded', flush=True)
+
+    _DF_STATE = (model, df_state, model_sr)
+    return _DF_STATE
+
+
+def main(argv=None):
     parser = argparse.ArgumentParser(description='Apply DeepFilterNet3 noise reduction')
     parser.add_argument('--input', required=True, help='Input WAV file path')
     parser.add_argument('--output', required=True, help='Output WAV file path')
@@ -24,18 +55,14 @@ def main():
         '--atten-lim-db', type=float, default=None,
         help='Maximum noise attenuation in dB (omit for no limit)',
     )
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
 
     import torch
-    from df.enhance import enhance, init_df, load_audio, save_audio
+    import torch.nn.functional as F
+    from df.enhance import enhance, load_audio, save_audio
 
-    num_threads = int(os.environ.get('TORCH_NUM_THREADS', os.cpu_count() or 4))
-    torch.set_num_threads(num_threads)
-
-    # Load model — weights cached at ~/.cache/DeepFilterNet/DeepFilterNet3
-    model, df_state, _ = init_df()
-    model_sr = df_state.sr()  # 48000
-    print(f'[deepfilter] model=DeepFilterNet3 sr={model_sr} atten_lim_db={args.atten_lim_db}', flush=True)
+    model, df_state, model_sr = _get_model()
+    print(f'[deepfilter] atten_lim_db={args.atten_lim_db}', flush=True)
 
     # Load input and resample to 48 kHz for the model
     audio, _ = load_audio(args.input, sr=model_sr)
@@ -47,7 +74,6 @@ def main():
     # which makes the audio appear to shift forward by a few milliseconds.
     # Pre-padding ensures the actual audio starts in a fully reconstructed window.
     hop_size = df_state.hop_size()
-    import torch.nn.functional as F
     audio_padded = F.pad(audio, (hop_size, 0))
 
     # Apply DeepFilterNet3; atten_lim_db=None means no attenuation limit (Tier 5)
@@ -58,7 +84,19 @@ def main():
 
     # Write 32-bit float WAV at 48 kHz — caller resamples to 44.1 kHz
     save_audio(args.output, enhanced, sr=model_sr, dtype=torch.float32)
-    print(f'[deepfilter] done', flush=True)
+    print('[deepfilter] done', flush=True)
+
+    return {
+        'model': 'DeepFilterNet3',
+        'model_sr': model_sr,
+        'atten_lim_db': args.atten_lim_db,
+        'duration_s': duration_s,
+    }
+
+
+def run(argv):
+    """Entry point used by the persistent worker (_worker.py)."""
+    return main(argv)
 
 
 if __name__ == '__main__':

--- a/server/scripts/estimate_f0_contour.py
+++ b/server/scripts/estimate_f0_contour.py
@@ -180,15 +180,15 @@ def estimate_f0_contour(
 # CLI
 # ---------------------------------------------------------------------------
 
-if __name__ == "__main__":
-    logging.basicConfig(level=logging.INFO, stream=sys.stdout, format="%(message)s")
+def main(argv=None):
+    logging.basicConfig(level=logging.INFO, stream=sys.stderr, format="%(message)s")
     parser = argparse.ArgumentParser(description="Per-frame F0 contour estimator")
     parser.add_argument("--input",         required=True,  help="Input WAV (float32, 44.1 kHz)")
     parser.add_argument("--output",        required=True,  help="Output JSON path")
     parser.add_argument("--vad-mask-json", default=None,   help="VAD frame list JSON")
     parser.add_argument("--n-fft",         type=int, default=2048)
     parser.add_argument("--hop-length",    type=int, default=512)
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
 
     sr, audio = wavfile.read(args.input)
     # Normalize integer PCM to [-1, 1] so autocorrelation ratios are correct
@@ -219,3 +219,17 @@ if __name__ == "__main__":
         f"F0Contour: median={result['median']}Hz frames={len(result['perFrame'])}",
         flush=True,
     )
+
+    return {
+        'median': result['median'],
+        'frames': len(result['perFrame']),
+    }
+
+
+def run(argv):
+    """Entry point used by the persistent worker (_worker.py)."""
+    return main(argv)
+
+
+if __name__ == "__main__":
+    main()

--- a/server/scripts/reference_eq.py
+++ b/server/scripts/reference_eq.py
@@ -225,7 +225,7 @@ def build_fir(applied_db, sr):
 
 # ── Main ──────────────────────────────────────────────────────────────────────
 
-def run(audio, sr, reference_levels, noise_floor_db, lf_max_boost_db):
+def apply_reference_eq(audio, sr, reference_levels, noise_floor_db, lf_max_boost_db):
     recording_levels, n_speech = speech_spectrum(audio, sr, noise_floor_db)
     if recording_levels is None:
         return {
@@ -297,7 +297,7 @@ def _load_audio(path):
     return sr, audio
 
 
-if __name__ == '__main__':
+def main(argv=None):
     logging.basicConfig(level=logging.INFO, stream=sys.stderr, format='%(message)s')
     parser = argparse.ArgumentParser(description='referenceEQ broad tonal correction')
     parser.add_argument('--input',       required=True, help='Input WAV (float32, 44.1 kHz, mono)')
@@ -308,7 +308,7 @@ if __name__ == '__main__':
                         help='Canonical pipeline noise floor (dBFS) for the speech gate')
     parser.add_argument('--lf-max-boost-db', type=float, default=DEFAULT_LF_MAX_BOOST_DB,
                         help='Sub-500 Hz boost cap (dB) — tightened on the ACX retry')
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
 
     with open(args.curve) as fh:
         curve = json.load(fh)
@@ -321,7 +321,7 @@ if __name__ == '__main__':
         )
 
     sr, audio = _load_audio(args.input)
-    result, corrected = run(
+    result, corrected = apply_reference_eq(
         audio, sr, curve_levels, args.noise_floor,
         min(args.lf_max_boost_db, DEFAULT_LF_MAX_BOOST_DB),
     )
@@ -341,3 +341,17 @@ if __name__ == '__main__':
         f"max_correction={result.get('max_correction_db', 0)} dB",
         flush=True,
     )
+
+    return {
+        'status': result['status'],
+        'max_correction_db': result.get('max_correction_db', 0),
+    }
+
+
+def run(argv):
+    """Entry point used by the persistent worker (_worker.py)."""
+    return main(argv)
+
+
+if __name__ == '__main__':
+    main()

--- a/server/scripts/resonance_suppressor.py
+++ b/server/scripts/resonance_suppressor.py
@@ -1310,11 +1310,10 @@ def resonance_suppressor_report_entry(result: dict) -> dict:
 # CLI
 # ---------------------------------------------------------------------------
 
-if __name__ == "__main__":
-    import argparse, json, sys
+def main(argv=None):
+    import argparse, json
     from scipy.io import wavfile
 
-    logging.basicConfig(level=logging.INFO, stream=sys.stdout, format="%(message)s")
     parser = argparse.ArgumentParser(description="Stage 3b -- Resonance Suppressor")
     parser.add_argument("--input",         required=True)
     parser.add_argument("--output",        required=True)
@@ -1336,7 +1335,7 @@ if __name__ == "__main__":
                              "analyze_sibilance_events.py (or the cached map "
                              "from sibilanceEvents.js).  Required when any pass "
                              "sets sibilant_only=True; ignored otherwise.")
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
 
     sr, audio = wavfile.read(args.input)
     audio = audio.astype(np.float32)
@@ -1374,4 +1373,22 @@ if __name__ == "__main__":
         audio, sr, params, vad_voiced_mask, args.f0, f0_contour, events_map,
     )
     wavfile.write(args.output, sr, result["audio"])
-    print("JSON_RESULT:" + json.dumps(resonance_suppressor_report_entry(result)), flush=True)
+    return resonance_suppressor_report_entry(result)
+
+
+def run(argv):
+    """Entry point used by the persistent worker (_worker.py).
+
+    Returns the report dict directly via the worker protocol — no
+    JSON_RESULT line is emitted in worker mode.
+    """
+    return main(argv)
+
+
+if __name__ == "__main__":
+    import json, sys
+    logging.basicConfig(level=logging.INFO, stream=sys.stdout, format="%(message)s")
+    # Legacy CLI / spawnPythonJsonResult contract: progress logs on stdout
+    # plus a single trailing JSON_RESULT: line that the JS side parses.
+    report = main()
+    print("JSON_RESULT:" + json.dumps(report), flush=True)

--- a/server/scripts/rnnoise_denoise.py
+++ b/server/scripts/rnnoise_denoise.py
@@ -27,11 +27,11 @@ RNNOISE_SR   = 48000   # RNNoise internal sample rate
 PIPELINE_SR  = 44100   # Pipeline internal format
 
 
-def main():
+def main(argv=None):
     parser = argparse.ArgumentParser(description='Apply RNNoise pre-separation pass')
     parser.add_argument('--input',  required=True, help='Input WAV (32-bit float, 44.1 kHz)')
     parser.add_argument('--output', required=True, help='Output WAV (32-bit float, 44.1 kHz)')
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
 
     import numpy as np
     from math import gcd
@@ -118,6 +118,17 @@ def main():
 
     # Write 32-bit float WAV at 44.1 kHz, mono
     wavfile.write(args.output, PIPELINE_SR, waveform[0].astype(np.float32))
+
+    return {
+        'model': 'RNNoise',
+        'input_sr': int(sr),
+        'output_sr': PIPELINE_SR,
+    }
+
+
+def run(argv):
+    """Entry point used by the persistent worker (_worker.py)."""
+    return main(argv)
 
 
 if __name__ == '__main__':

--- a/server/scripts/room_presence.py
+++ b/server/scripts/room_presence.py
@@ -239,7 +239,7 @@ def apply_room_presence_ir(
 # ---------------------------------------------------------------------------
 # CLI entry point — called by the Node pipeline via spawnPython
 # ---------------------------------------------------------------------------
-if __name__ == "__main__":
+def main(argv=None):
     import argparse
 
     parser = argparse.ArgumentParser(description="Room Presence (convolution reverb)")
@@ -253,7 +253,7 @@ if __name__ == "__main__":
     parser.add_argument("--diffusion",         type=float, default=0.7,  help="Tail density for synthetic IR (0.0–1.0)")
     parser.add_argument("--normalize-ir",      action="store_true", default=True)
     parser.add_argument("--result-path",       default=None,   help="Path to write JSON result (ir_source etc.)")
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
 
     input_path  = args.input
     output_path = args.output
@@ -293,3 +293,14 @@ if __name__ == "__main__":
         import json
         with open(args.result_path, "w") as _f:
             json.dump(ir_info, _f)
+
+    return ir_info
+
+
+def run(argv):
+    """Entry point used by the persistent worker (_worker.py)."""
+    return main(argv)
+
+
+if __name__ == "__main__":
+    main()

--- a/server/scripts/silero_vad.py
+++ b/server/scripts/silero_vad.py
@@ -55,7 +55,7 @@ def resolve_device(device_arg):
     return device_arg
 
 
-def main():
+def main(argv=None):
     parser = argparse.ArgumentParser(description='Silero VAD frame classifier')
     parser.add_argument('--input',     required=True,  help='Input WAV (32-bit float, 44.1 kHz)')
     parser.add_argument('--output',    required=True,  help='Output JSON file path')
@@ -63,7 +63,7 @@ def main():
                         help='Speech probability threshold (default: 0.5)')
     parser.add_argument('--device',    default='auto', choices=['auto', 'cpu', 'cuda'],
                         help='Compute device (default: auto)')
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
 
     import torch
     import numpy as np
@@ -287,6 +287,11 @@ def main():
           f'({sum(1 for f in frame_results if not f["isSilence"])} voiced, '
           f'{sum(1 for f in frame_results if f["isSilence"])} silence)',
           flush=True)
+
+
+def run(argv):
+    """Entry point used by the persistent worker (_worker.py)."""
+    return main(argv)
 
 
 if __name__ == '__main__':

--- a/server/scripts/test_worker_smoke.mjs
+++ b/server/scripts/test_worker_smoke.mjs
@@ -1,0 +1,44 @@
+/**
+ * Smoke test for the persistent Python worker.
+ *
+ * Run from anywhere:   node server/scripts/test_worker_smoke.mjs
+ *
+ * Verifies:
+ *   1. Worker spawns and answers __ping__
+ *   2. Invalid script name produces a clear error
+ *   3. The same worker pid handles multiple requests (no respawn per call)
+ *   4. Shutdown is clean
+ *
+ * Does NOT test actual audio processing — that requires the heavy Python
+ * deps (torch, numpy, scipy, deepfilternet, pyrnnoise) and a real input
+ * WAV. End-to-end verification belongs in a normal pipeline run.
+ */
+
+import { runPython, pingWorker, stopWorker } from '../pipeline/pythonWorker.js'
+
+function assert(cond, msg) {
+  if (!cond) {
+    console.error('FAIL:', msg)
+    process.exit(1)
+  }
+  console.log('OK:', msg)
+}
+
+const ping1 = await pingWorker()
+assert(typeof ping1.pid === 'number', `ping returned pid=${ping1.pid}`)
+
+const ping2 = await pingWorker()
+assert(ping2.pid === ping1.pid, `second ping reuses worker (pid ${ping2.pid} === ${ping1.pid})`)
+
+let caught = null
+try {
+  await runPython('definitely_does_not_exist_xyz', [], 'BadScript')
+} catch (err) {
+  caught = err
+}
+assert(caught && /BadScript|definitely_does_not_exist/.test(caught.message),
+  'unknown script name produces a labeled error')
+
+await stopWorker()
+console.log('\nAll smoke checks passed.')
+process.exit(0)

--- a/server/scripts/vocal_saturation.py
+++ b/server/scripts/vocal_saturation.py
@@ -151,7 +151,7 @@ def vocal_saturation(
 # CLI
 # ---------------------------------------------------------------------------
 
-def main():
+def main(argv=None):
     parser = argparse.ArgumentParser(
         description='Parallel tube-style vocal saturation with preset-defined band crossovers'
     )
@@ -175,7 +175,7 @@ def main():
                         help='Mid-band drive multiplier on base drive (default: 0.1)')
     parser.add_argument('--high-drive-mult', type=float, default=0.1,
                         help='High-band drive multiplier on base drive (default: 0.1)')
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
 
     sr, audio = wavfile.read(args.input)
     audio = audio.astype(np.float32)
@@ -210,6 +210,13 @@ def main():
         f'  band mults       : low={info["low_drive_mult"]}  mid={info["mid_drive_mult"]}  high={info["high_drive_mult"]}\n'
         f'  drive={args.drive}  wet_dry={args.wet_dry}  bias={args.bias}'
     )
+
+    return info
+
+
+def run(argv):
+    """Entry point used by the persistent worker (_worker.py)."""
+    return main(argv)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Replace per-stage `python3 <script>.py` cold-starts with a long-lived
worker process (server/scripts/_worker.py) that dispatches to module-level
run(argv) functions. Imports of torch, numpy, scipy, and cached ML model
weights persist across the pipeline run, so the second call into any
given stage no longer pays interpreter+import startup.

Architecture:
- server/scripts/_worker.py — dispatches newline-delimited JSON requests
  on stdin to the named script's run(argv); stdout reserved for protocol,
  script print() routed to stderr.
- server/pipeline/pythonWorker.js — lazy singleton; spawns the worker on
  first runPython() call, pipes requests over stdin, demuxes JSON
  responses by request id. Crashes reject in-flight requests and
  respawn on the next call.
- server/pipeline/spawnPython.js — keeps existing (script, argv, label)
  signature. Scripts in WORKER_SCRIPTS allowlist route through the
  worker; the rest fall back to the legacy spawn-per-call path. Set
  WAVELY_DISABLE_PY_WORKER=1 to force the legacy path globally.

Migrated for the acx_audiobook hot path:
- deepfilter_enhance — DF3 model cached at module level so the second
  noiseReduce call reuses loaded weights (the largest single win)
- rnnoise_denoise
- corrective_eq, reference_eq, air_boost_precut — pre-existing run()
  helpers renamed (apply_reference_eq, analyze_precut) to free the name
  for the worker entry point convention
- vocal_saturation, click_remover, room_presence

Each migrated script now exposes main(argv=None) and run(argv); the
standalone `python3 <script>` path is preserved via __main__ → main().

Smoke test: server/scripts/test_worker_smoke.mjs verifies worker spawns,
reuses pid across requests, and propagates script-not-found errors.

Remaining preset-specific scripts (harmonic_exciter, dereverb,
spectral_subtraction, breath_reducer, dtln_denoise, throat_click_attenuator,
ap_bwe_extend, lavasr_extend, bass_enhance, clearervoice_enhance) still
use the legacy path and migrate to the same pattern as needed.