### PR TITLE
Remove remeasureFramesPostNr passes from acx_audiobook pipeline

### DIFF
--- a/server/pipeline/parallelCompression.js
+++ b/server/pipeline/parallelCompression.js
@@ -126,12 +126,14 @@ export async function applyParallelCompression(
   const analysisCh = channels[0]
   const numSamples = analysisCh.length
 
-  // ── 1. Adaptive threshold ────────────────────────────────────────────────
-  const voicedRms    = frameAnalysis.voicedRmsDbfs ?? frameAnalysis.averageVoicedRmsDbfs ?? -24
-  const threshold    = Math.max(voicedRms - PARALLEL_THRESHOLD_OFFSET_DB, PARALLEL_THRESHOLD_FLOOR_DB)
+  // ── 1. Voiced-frame stats (peak, RMS, crest factor) ─────────────────────
+  // Measured locally from the input channel + isSilence labels so no upstream
+  // remeasureFramesPostNr is required between compression and this stage.
+  const { crestFactorDb: prePcCrestFactor, voicedRmsDbfs: voicedRms } =
+    measureVoicedStats(analysisCh, frameAnalysis)
 
-  // ── 2. Pre-PC crest factor ───────────────────────────────────────────────
-  const prePcCrestFactor = measureCrestFactor(analysisCh, frameAnalysis)
+  // ── 2. Adaptive threshold ────────────────────────────────────────────────
+  const threshold    = Math.max(voicedRms - PARALLEL_THRESHOLD_OFFSET_DB, PARALLEL_THRESHOLD_FLOOR_DB)
 
   // ── 3. Crest factor guard ────────────────────────────────────────────────
   const guardThresh = config.crestGuardThresholdDb
@@ -309,10 +311,14 @@ function synthesizeWetAnalysisSignal(analysisCh, compCurve, makeupLinear) {
 // ── Crest Factor ─────────────────────────────────────────────────────────────
 
 /**
- * Voiced-frame crest factor: peak_dBFS − voiced_RMS_dBFS.
- * Same algorithm as compression.js (inlined — not exported from that module).
+ * Voiced-frame peak / RMS / crest factor measured from the input channel,
+ * using the upstream Silero VAD isSilence labels (which are stable across
+ * pipeline stages). Returning both values lets the caller use them for the
+ * adaptive threshold AND the crest-factor guard from one pass over the audio,
+ * without depending on a preceding remeasureFramesPostNr to refresh
+ * frameAnalysis.voicedRmsDbfs.
  */
-function measureCrestFactor(samples, frameAnalysis) {
+function measureVoicedStats(samples, frameAnalysis) {
   let sumSq = 0
   let count = 0
   let peak  = 0
@@ -329,13 +335,14 @@ function measureCrestFactor(samples, frameAnalysis) {
     }
   }
 
-  if (count === 0 || peak === 0) return 20  // safe default — guard won't activate
+  // Safe defaults — guard won't activate, threshold falls back to floor.
+  if (count === 0 || peak === 0) return { crestFactorDb: 20, voicedRmsDbfs: -24 }
 
-  const voicedRms = Math.sqrt(sumSq / count)
-  const peakDb    = 20 * Math.log10(peak)
-  const rmsDb     = voicedRms > 0 ? 20 * Math.log10(voicedRms) : -120
+  const voicedRms    = Math.sqrt(sumSq / count)
+  const peakDb       = 20 * Math.log10(peak)
+  const voicedRmsDbfs = voicedRms > 0 ? 20 * Math.log10(voicedRms) : -120
 
-  return peakDb - rmsDb
+  return { crestFactorDb: peakDb - voicedRmsDbfs, voicedRmsDbfs }
 }
 
 // ── Compressor Gain Curve ────────────────────────────────────────────────────

--- a/server/pipeline/stages.js
+++ b/server/pipeline/stages.js
@@ -528,8 +528,10 @@ export async function noiseReduce(ctx) {
   // compression has raised the noise floor, causing the model to mask more
   // aggressively. Measure the voiced-RMS delta and apply linear makeup gain
   // so downstream stages (compression, expander) see the expected level.
+  let postFa = null
+  let appliedMakeupDb = 0
   if (preVoicedRms !== null && preVoicedRms !== undefined) {
-    const postFa = await remeasureFrames(ctx.currentPath, ctx.results.metrics)
+    postFa = await remeasureFrames(ctx.currentPath, ctx.results.metrics)
     const postVoicedRms = postFa.voicedRmsDbfs
 
     if (postVoicedRms !== null && postVoicedRms !== undefined) {
@@ -540,6 +542,7 @@ export async function noiseReduce(ctx) {
         const gainedPath = ctx.tmp('.wav')
         await applyLinearGain(ctx.currentPath, gainedPath, makeupDb)
         ctx.currentPath = gainedPath
+        appliedMakeupDb = makeupDb
         ctx.results.noiseReduction.makeupGainDb = round2(makeupDb)
         ctx.log(
           `[NR] Makeup gain: +${makeupDb.toFixed(2)} dB ` +
@@ -552,6 +555,27 @@ export async function noiseReduce(ctx) {
           `≤ ${NR_MAKEUP_THRESHOLD_DB} dB threshold`
         )
       }
+    }
+  }
+
+  // Update ctx.results.metrics with fresh post-NR (post-makeup-gain) scalars
+  // so downstream stages (autoLeveler.noiseFloorDbfs, the next noiseReduce
+  // pass's skipBelowDb check, vocalExpander.noiseFloorDbfs, etc.) see current
+  // values without a dedicated remeasureFramesPostNr stage. Makeup gain is
+  // linear so we offset postFa's dB scalars by the applied gain rather than
+  // re-reading the file. isSilence labels are Silero-derived and stable, so
+  // ctx.results.metrics.frames is left untouched.
+  if (postFa !== null) {
+    ctx.results.metrics.noiseFloorDbfs       = round2(postFa.noiseFloorDbfs       + appliedMakeupDb)
+    ctx.results.metrics.voicedRmsDbfs        = round2(postFa.voicedRmsDbfs        + appliedMakeupDb)
+    ctx.results.metrics.averageVoicedRmsDbfs = round2(postFa.averageVoicedRmsDbfs + appliedMakeupDb)
+    ctx.results.metrics.silenceThresholdDbfs = round2(postFa.silenceThresholdDbfs + appliedMakeupDb)
+
+    // rnnoise/dtln branches left post_noise_floor_dbfs null because they had
+    // no measurement source. Fill it from our authoritative post-makeup floor
+    // so qualityAdvisory / ACX cert have a value to consume for those models.
+    if (ctx.results.noiseReduction && ctx.results.noiseReduction.post_noise_floor_dbfs == null) {
+      ctx.results.noiseReduction.post_noise_floor_dbfs = ctx.results.metrics.noiseFloorDbfs
     }
   }
 

--- a/src/audio/presets.js
+++ b/src/audio/presets.js
@@ -176,7 +176,6 @@ export const PRESETS = {
       "hpf",
       { noiseReduce: { model: "df3" } }, //"df3", "rnnoise", "dtln"
       { noiseReduce: { model: "rnnoise" } }, //"df3", "rnnoise", "dtln"
-      "remeasureFramesPostNr",
       {
         autoLeveler: {
           total_max_up_db: 10.0,
@@ -252,8 +251,7 @@ export const PRESETS = {
       },
       */
      /* { clickRemover: { thresholdSigma: 3.0, maxClickMs: 15 } }, */
-      "remeasureFramesPostNr",
-      { 
+      {
         compression: [
         /*  
           {
@@ -279,7 +277,6 @@ export const PRESETS = {
   { targetCrestFactorDb: 12, maxRatio: 2, threshold: "auto", follow: true,  attack: 3,   release: 250 }
         ],
       },
-      "remeasureFramesPostNr",
       //{ noiseReduce: { model: "rrnoise", skipBelowDb: -90 } },
       {
         parallelCompression: {


### PR DESCRIPTION
noiseReduce now publishes fresh post-NR (post-makeup-gain) noise floor and voiced RMS onto ctx.results.metrics at end of stage, so autoLeveler and any second NR pass see current values without a dedicated remeasure stage. Makeup gain is linear so the post-measurement is offset by the applied dB rather than re-reading the file.

parallelCompression now derives voicedRmsDbfs locally from its input channel + isSilence labels (rolled into measureCrestFactor → returns both crest factor and RMS), removing its dependency on a preceding remeasureFramesPostNr.

compression already only consumed frame.isSilence labels (stable across stages) and computed its own RMS internally, so the remeasure before it was redundant.

Drops the three remeasureFramesPostNr entries from acx_audiobook. Other presets (podcast_ready, general_clean, noise_eraser) untouched — similar cleanup applies but their second-NR skipBelowDb interactions need preset-specific review.