### PR TITLE
Split analyze/apply stages for peak normalize, corrective EQ, and auto-leveler

### DIFF
--- a/server/pipeline/autoLeveler.js
+++ b/server/pipeline/autoLeveler.js
@@ -594,10 +594,22 @@ function computeClipStd(clips, kwSamples) {
  * @param {import('./frameAnalysis.js').FrameAnalysis} frameAnalysis
  * @returns {AutoLevelerResult}
  */
-export async function applyAutoLeveler(inputPath, outputPath, preset, frameAnalysis) {
+/**
+ * Analyze pass: read input, produce per-sample gain array (gainSr) plus
+ * everything renderAutoLeveler needs to finalize output measurements.
+ * Returns either:
+ *   { applied: false, skipped_reason }                                — no apply needed
+ *   { applied: true, channels, sampleRate, gainSr, mergedClips,
+ *     mergedGains, mergesCount, clipCountInitial, subphraseSplits,
+ *     inClipStd, nfCapActive, config }                                — feed to renderAutoLeveler
+ *
+ * The decoded channels are returned in-memory so the apply pass doesn't have
+ * to re-read the input WAV. This is the same in-memory handoff a chunked
+ * orchestrator would do per-worker.
+ */
+export async function analyzeAutoLeveler(inputPath, preset, frameAnalysis) {
   const config = preset?.autoLeveler ?? null
   if (!config) {
-    await copyThrough(inputPath, outputPath)
     return { applied: false, skipped_reason: 'preset_excluded' }
   }
 
@@ -607,7 +619,6 @@ export async function applyAutoLeveler(inputPath, outputPath, preset, frameAnaly
 
   const durationS = n / sampleRate
   if (durationS < MIN_FILE_DURATION_S) {
-    await copyThrough(inputPath, outputPath)
     return { applied: false, skipped_reason: 'duration_too_short' }
   }
 
@@ -623,7 +634,6 @@ export async function applyAutoLeveler(inputPath, outputPath, preset, frameAnaly
 
   const voicedHops = hopVoiced.reduce((s, v) => s + v, 0)
   if (voicedHops * HOP_MS * 0.001 < MIN_VOICED_DURATION_S) {
-    await copyThrough(inputPath, outputPath)
     return { applied: false, skipped_reason: 'insufficient_voiced_audio' }
   }
 
@@ -646,7 +656,6 @@ export async function applyAutoLeveler(inputPath, outputPath, preset, frameAnaly
   })
 
   if (clips.length < 2) {
-    await copyThrough(inputPath, outputPath)
     return { applied: false, skipped_reason: 'insufficient_clips' }
   }
 
@@ -658,7 +667,6 @@ export async function applyAutoLeveler(inputPath, outputPath, preset, frameAnaly
   // Skip if file is already leveled (clip-LUFS std below threshold)
   const inClipStd = weightedStd(clipLufs, clipDurations)
   if (inClipStd < LEVELED_STD_THRESHOLD) {
-    await copyThrough(inputPath, outputPath)
     return { applied: false, skipped_reason: 'file_already_leveled' }
   }
 
@@ -702,25 +710,54 @@ export async function applyAutoLeveler(inputPath, outputPath, preset, frameAnaly
     merged.clips, merged.gains, audioPowerSum, crossfadeSamples, n,
   )
 
-  // Render: piecewise-constant gain with cosine crossfades at boundaries
+  // Per-sample gain curve: piecewise-constant gain with cosine crossfades at
+  // boundaries. This is the parameter the apply pass consumes.
   const gainSr = buildSampleGainArray(merged.clips, merged.gains, plans, n)
-  const processedChannels = applySampleGains(channels, gainSr)
 
+  return {
+    applied:           true,
+    skipped_reason:    null,
+    channels,
+    sampleRate,
+    gainSr,
+    mergedClips:       merged.clips,
+    mergedGains:       merged.gains,
+    mergesCount:       merged.mergesCount,
+    clipCountInitial:  clips.length,
+    subphraseSplits,
+    inClipStd,
+    nfCapActive,
+    config,
+  }
+}
+
+/**
+ * Apply pass: multiply input channels by the per-sample gain array, write
+ * the output WAV, and compute output measurements (clip-LUFS std after
+ * leveling, gain stats). Returns the final report object.
+ */
+export async function renderAutoLeveler(outputPath, analyzed) {
+  const {
+    channels, sampleRate, gainSr, mergedClips, mergedGains, mergesCount,
+    clipCountInitial, subphraseSplits, inClipStd, nfCapActive, config,
+  } = analyzed
+
+  const processedChannels = applySampleGains(channels, gainSr)
   await writeWavChannels(processedChannels, sampleRate, outputPath)
 
   // Output measurements: clip-LUFS std after leveling (recompute on output)
   const kwOut    = applyKWeighting(processedChannels[0], sampleRate)
-  const outClipStd = computeClipStd(merged.clips, kwOut)
+  const outClipStd = computeClipStd(mergedClips, kwOut)
 
   // Gain stats over merged clips, duration-weighted
   let maxUp = -Infinity, maxDown = Infinity
   let powSum = 0, dSum = 0
-  for (let k = 0; k < merged.gains.length; k++) {
-    const g = merged.gains[k]
+  for (let k = 0; k < mergedGains.length; k++) {
+    const g = mergedGains[k]
     if (g > maxUp)   maxUp   = g
     if (g < maxDown) maxDown = g
     const lin = Math.pow(10, g / 20.0)
-    const d   = merged.clips[k].sampleEnd - merged.clips[k].sampleStart
+    const d   = mergedClips[k].sampleEnd - mergedClips[k].sampleStart
     powSum += lin * lin * d
     dSum   += d
   }
@@ -730,8 +767,8 @@ export async function applyAutoLeveler(inputPath, outputPath, preset, frameAnaly
     applied:        true,
     skipped_reason: null,
     preset_params: {
-      total_max_up_db:                   totalUp,
-      total_max_down_db:                 totalDown,
+      total_max_up_db:                   config.total_max_up_db,
+      total_max_down_db:                 config.total_max_down_db,
       target_mode:                       config.target_mode,
       target_window_s:                   config.target_window_s,
       noise_floor_target_dbfs:           config.noise_floor_target_dbfs,
@@ -747,10 +784,10 @@ export async function applyAutoLeveler(inputPath, outputPath, preset, frameAnaly
     measurements: {
       input_clip_lufs_std_db:    round2(inClipStd),
       output_clip_lufs_std_db:   round2(outClipStd),
-      clip_count_initial:        clips.length,
-      clip_count_after_merge:    merged.clips.length,
+      clip_count_initial:        clipCountInitial,
+      clip_count_after_merge:    mergedClips.length,
       subphrase_splits_count:    subphraseSplits,
-      merges_count:              merged.mergesCount,
+      merges_count:              mergesCount,
       gain_max_up_db:            round2(maxUp   === -Infinity ? 0 : maxUp),
       gain_max_down_db:          round2(maxDown ===  Infinity ? 0 : maxDown),
       gain_rms_db:               round2(gainRmsDb),
@@ -765,9 +802,4 @@ export async function applyAutoLeveler(inputPath, outputPath, preset, frameAnaly
 
 function round2(n) {
   return typeof n === 'number' && isFinite(n) ? Math.round(n * 100) / 100 : null
-}
-
-async function copyThrough(inputPath, outputPath) {
-  const { readFile, writeFile } = await import('fs/promises')
-  await writeFile(outputPath, await readFile(inputPath))
 }

--- a/server/pipeline/index.js
+++ b/server/pipeline/index.js
@@ -27,11 +27,6 @@ const STAGE_FOR_CONFIG_KEY = {
   throatClickAttenuator: 'throatClickAttenuate',
   compression:         'compress',
   parallelCompression: 'parallelCompress',
-  // Split analyze/apply pairs: the config-bearing preset key routes to
-  // analyze (which owns the config); apply runs as a plain string entry
-  // immediately after and reads its inputs from ctx.globalParams.
-  autoLeveler:         'autoLevelerAnalyze',
-  clipGainDeEsser:     'clipGainDeEsserAnalyze',
   deEsser:             'deEss',
 }
 

--- a/server/pipeline/index.js
+++ b/server/pipeline/index.js
@@ -27,8 +27,11 @@ const STAGE_FOR_CONFIG_KEY = {
   throatClickAttenuator: 'throatClickAttenuate',
   compression:         'compress',
   parallelCompression: 'parallelCompress',
-  autoLeveler:         'autoLevel',
-  clipGainDeEsser:     'clipGainDeEss',
+  // Split analyze/apply pairs: the config-bearing preset key routes to
+  // analyze (which owns the config); apply runs as a plain string entry
+  // immediately after and reads its inputs from ctx.globalParams.
+  autoLeveler:         'autoLevelerAnalyze',
+  clipGainDeEsser:     'clipGainDeEsserAnalyze',
   deEsser:             'deEss',
 }
 
@@ -148,6 +151,12 @@ function createContext({ inputPath, originalName, presetId, outputProfileId, pre
     // buildReport() reads only the keys that are present, so stages absent
     // from a pipeline produce no orphaned keys in the report JSON.
     results: {},
+    // Cross-stage parameter bundle, written by *Analyze stages and consumed
+    // by their *Apply pair. Distinct from ctx.results (the report output):
+    // globalParams is the input contract for apply stages, and is the same
+    // shape a future chunked orchestrator would serialize to workers.
+    // Keys mirror the stage name (e.g. globalParams.autoLeveler).
+    globalParams: {},
   }
 }
 

--- a/server/pipeline/stages.js
+++ b/server/pipeline/stages.js
@@ -216,6 +216,7 @@ export async function peakNormalizeApply(ctx) {
 export async function peakNormalize(ctx) {
   await peakNormalizeAnalyze(ctx)
   await peakNormalizeApply(ctx)
+  // params are scalar — no cleanup needed.
 }
 
 // ── Stage: Frame analysis (pre-HPF) ──────────────────────────────────────────
@@ -738,6 +739,7 @@ export async function correctiveEQApply(ctx) {
 export async function correctiveEQ(ctx) {
   await correctiveEQAnalyze(ctx)
   await correctiveEQApply(ctx)
+  // bands array is small (~handful of objects) — no cleanup needed.
 }
 
 // ── Stage: referenceEQ ────────────────────────────────────────────────────────
@@ -1099,6 +1101,11 @@ export async function clipGainDeEsserApply(ctx) {
 export async function clipGainDeEsser(ctx) {
   await clipGainDeEsserAnalyze(ctx)
   await clipGainDeEsserApply(ctx)
+  // The frames array is the heavy field here — one entry per 25 ms frame
+  // (~144k entries/hour). The eventsPath is preserved on
+  // ctx.results.clipGainDeEsser for parallelCompression's wet-branch
+  // de-esser pass; that's the only downstream consumer of de-esser state.
+  ctx.globalParams.clipGainDeEsser = null
 }
 
 // ── Stage: Auto Leveler (Stage 4b) ────────────────────────────────────────────
@@ -1157,6 +1164,14 @@ export async function autoLevelerApply(ctx) {
 export async function autoLeveler(ctx) {
   await autoLevelerAnalyze(ctx)
   await autoLevelerApply(ctx)
+  // analyze stashed the full decoded channels + per-sample gain curve on
+  // globalParams.autoLeveler so apply could consume them in-memory. For a
+  // 1-hour stereo 48 kHz file that's ~1.4 GB of float32 data. Drop the
+  // reference now that apply has written its output — the remaining
+  // pipeline (airBoost, normalize, truePeakLimit, encode, …) has no use
+  // for it, and ctx.results.autoLeveler already carries the small summary
+  // the report builder reads.
+  ctx.globalParams.autoLeveler = null
 }
 
 // ── Stage: Compression ────────────────────────────────────────────────────────

--- a/server/pipeline/stages.js
+++ b/server/pipeline/stages.js
@@ -211,6 +211,13 @@ export async function peakNormalizeApply(ctx) {
   ctx.log(`[peak-norm] ${params.inputPeakDbfs.toFixed(1)} dBFS → ${PEAK_NORMALIZE_TARGET_DBFS} dBFS (${params.gainDb > 0 ? '+' : ''}${params.gainDb.toFixed(1)} dB)`)
 }
 
+// Wrapper that pairs analyze + apply for presets. The split versions stay
+// exported so a chunked orchestrator can dispatch them independently.
+export async function peakNormalize(ctx) {
+  await peakNormalizeAnalyze(ctx)
+  await peakNormalizeApply(ctx)
+}
+
 // ── Stage: Frame analysis (pre-HPF) ──────────────────────────────────────────
 // Classifies voiced/silence frames, measures noise floor and loudness metrics.
 // Also back-fills beforeMeasurements.noiseFloorDbfs: analyzeFramesRaw runs on
@@ -728,6 +735,11 @@ export async function correctiveEQApply(ctx) {
   })
 }
 
+export async function correctiveEQ(ctx) {
+  await correctiveEQAnalyze(ctx)
+  await correctiveEQApply(ctx)
+}
+
 // ── Stage: referenceEQ ────────────────────────────────────────────────────────
 // Corpus-reference broad tonal correction. Runs after the final correctiveEQ:
 // 3a fixes localised anomalies, referenceEQ fixes broad tonal imbalance via a
@@ -1084,6 +1096,11 @@ export async function clipGainDeEsserApply(ctx) {
   })
 }
 
+export async function clipGainDeEsser(ctx) {
+  await clipGainDeEsserAnalyze(ctx)
+  await clipGainDeEsserApply(ctx)
+}
+
 // ── Stage: Auto Leveler (Stage 4b) ────────────────────────────────────────────
 // M Leveller-style clip automation. Segments voiced audio into clips (VAD
 // voiced runs plus sub-phrase splits at sustained internal level drops) and
@@ -1135,6 +1152,11 @@ export async function autoLevelerApply(ctx) {
     `G=[${m.gain_max_down_db}, ${m.gain_max_up_db}]dB ` +
     `nf_cap=${m.noise_floor_cap_active}`
   )
+}
+
+export async function autoLeveler(ctx) {
+  await autoLevelerAnalyze(ctx)
+  await autoLevelerApply(ctx)
 }
 
 // ── Stage: Compression ────────────────────────────────────────────────────────

--- a/server/pipeline/stages.js
+++ b/server/pipeline/stages.js
@@ -51,7 +51,7 @@ import { runSeparation, runClearerVoice } from './separation.js'
 import { writeFile } from 'fs/promises'
 import { runHarmonicExciter, runVocalSaturation, runDereverb, runApBwe, runLavaSR, runClickRemover, runThroatClickAttenuator, applyResonanceSuppression, applyBreathReduction, runSpectralSubtraction, runRoomPresence } from './enhancement.js'
 import { validateSeparation } from './separationValidation.js'
-import { applyAutoLeveler } from './autoLeveler.js'
+import { analyzeAutoLeveler, renderAutoLeveler } from './autoLeveler.js'
 import { applyParallelCompression } from './parallelCompression.js'
 import { applyVocalExpander } from './vocalExpander.js'
 import { applyVadGate }       from './vadGate.js'
@@ -169,25 +169,46 @@ export async function measureBefore(ctx) {
 // runs, precedes measureBefore), so a second measurement pass would produce
 // the same value at the cost of another full-file FFmpeg+libebur128 read.
 
-export async function peakNormalize(ctx) {
-  const TARGET_PEAK_DBFS = -1.0
+// Analyze pair (peakNormalizeAnalyze / peakNormalizeApply):
+//   Analyze measures the input peak and computes the gain needed to hit the
+//   target; Apply runs a single linear-gain FFmpeg call with that gain. The
+//   split lets a chunked orchestrator measure peak once on the whole file
+//   and apply the same gain in parallel across chunks.
+
+const PEAK_NORMALIZE_TARGET_DBFS = -1.0
+
+export async function peakNormalizeAnalyze(ctx) {
   const cachedPeak = ctx.results.metrics?.truePeakDbfs
   const peak = cachedPeak != null
     ? cachedPeak
     : (await measureAudio(ctx.currentPath)).truePeakDbfs
-  const gainDb = TARGET_PEAK_DBFS - peak
+  const gainDb = PEAK_NORMALIZE_TARGET_DBFS - peak
 
   if (Math.abs(gainDb) < 0.1) {
     ctx.log(`[peak-norm] Peak already at ${peak.toFixed(1)} dBFS — skipped`)
+    ctx.globalParams.peakNormalize = { applied: false, inputPeakDbfs: peak }
     ctx.results.peakNormalize = { applied: false, inputPeakDbfs: peak }
     return
   }
 
+  ctx.globalParams.peakNormalize = { applied: true, inputPeakDbfs: peak, gainDb }
+}
+
+export async function peakNormalizeApply(ctx) {
+  const params = ctx.globalParams.peakNormalize
+  if (!params || !params.applied) {
+    // analyze decided no gain change is needed — leave the report entry as-is
+    if (!ctx.results.peakNormalize) {
+      ctx.results.peakNormalize = { applied: false, inputPeakDbfs: params?.inputPeakDbfs ?? null }
+    }
+    return
+  }
+
   const outPath = ctx.tmp('.wav')
-  await applyLinearGain(ctx.currentPath, outPath, gainDb)
+  await applyLinearGain(ctx.currentPath, outPath, params.gainDb)
   ctx.currentPath = outPath
-  ctx.results.peakNormalize = { applied: true, inputPeakDbfs: peak, gainDb }
-  ctx.log(`[peak-norm] ${peak.toFixed(1)} dBFS → ${TARGET_PEAK_DBFS} dBFS (${gainDb > 0 ? '+' : ''}${gainDb.toFixed(1)} dB)`)
+  ctx.results.peakNormalize = { applied: true, inputPeakDbfs: params.inputPeakDbfs, gainDb: params.gainDb }
+  ctx.log(`[peak-norm] ${params.inputPeakDbfs.toFixed(1)} dBFS → ${PEAK_NORMALIZE_TARGET_DBFS} dBFS (${params.gainDb > 0 ? '+' : ''}${params.gainDb.toFixed(1)} dB)`)
 }
 
 // ── Stage: Frame analysis (pre-HPF) ──────────────────────────────────────────
@@ -631,13 +652,26 @@ export async function roomTonePad(ctx) {
 // Does not run for noise_eraser — source separation alters the spectral
 // structure, so the cepstral detection thresholds are not valid on its output.
 
-export async function correctiveEQ(ctx) {
+// Analyze pair (correctiveEQAnalyze / correctiveEQApply):
+//   Analyze produces the final EQ band list. For acx output profile it runs
+//   the noise-floor convergence loop (apply tentative bands → remeasure floor
+//   → trim low-frequency boosts), so analyze does write intermediate temp
+//   files. Apply then runs a single parametric EQ pass with the converged
+//   bands. The redundant final apply costs one FFmpeg call (~50 ms) but
+//   keeps the contract clean: analyze=bands, apply=EQ filter.
+//
+//   For chunked processing later, the ACX convergence inside analyze would
+//   be replaced with a predictive noise-floor delta — but that's a follow-up.
+
+export async function correctiveEQAnalyze(ctx) {
   if (ctx.presetId === 'noise_eraser') {
-    ctx.results.correctiveEQ = {
+    const skip = {
       applied: false,
       skipped: true,
       reason:  'noise_eraser preset — Stage 3a does not run on separated audio',
     }
+    ctx.globalParams.correctiveEQ = skip
+    ctx.results.correctiveEQ = skip
     return
   }
 
@@ -672,15 +706,25 @@ export async function correctiveEQ(ctx) {
     if (reductionDb > 0) result.acxNoiseFloorReductionDb = reductionDb
   }
 
-  ctx.currentPath     = eqPath
   result.bands        = bands
   result.applied      = bands.length > 0
   result.ffmpegFilter = bandsToFfmpegFilters(bands).join(',') || null
+  ctx.globalParams.correctiveEQ = { bands, applied: result.applied }
   ctx.results.correctiveEQ = result
+}
+
+export async function correctiveEQApply(ctx) {
+  const params = ctx.globalParams.correctiveEQ
+  if (!params || !params.applied || !params.bands?.length) {
+    return
+  }
+  const eqPath = ctx.tmp('.wav')
+  await applyParametricEQ(ctx.currentPath, eqPath, bandsToFfmpegFilters(params.bands))
+  ctx.currentPath = eqPath
   await logLevel(ctx, 'after corrective EQ', ctx.currentPath, {
-    voice_type: result.voice_type,
-    bands:      bands.length,
-    merged:     result.merged_bands ?? 0,
+    voice_type: ctx.results.correctiveEQ?.voice_type,
+    bands:      params.bands.length,
+    merged:     ctx.results.correctiveEQ?.merged_bands ?? 0,
   })
 }
 
@@ -951,10 +995,20 @@ export async function deEss(ctx) {
 // Skips silently when preset.clipGainDeEsser is absent or .enabled is false,
 // or when the detector returns no events that survive the duration filter.
 
-export async function clipGainDeEss(ctx) {
+// Analyze pair (clipGainDeEsserAnalyze / clipGainDeEsserApply):
+//   Analyze runs sibilance detection and writes an events.json file path
+//   plus the config + frame labels into globalParams. Apply consumes them
+//   to render the cosine-fade gain envelope. Both halves were already
+//   separable in the underlying modules — this just exposes the seam at
+//   the registry level so chunked workers can run apply per chunk while
+//   detection runs once on the whole file.
+
+export async function clipGainDeEsserAnalyze(ctx) {
   const config = ctx.preset?.clipGainDeEsser
   if (!config || config.enabled === false) {
-    ctx.results.clipGainDeEsser = { applied: false, reason: 'preset_not_configured' }
+    const skip = { applied: false, reason: 'preset_not_configured' }
+    ctx.globalParams.clipGainDeEsser = skip
+    ctx.results.clipGainDeEsser = skip
     return
   }
 
@@ -982,12 +1036,27 @@ export async function clipGainDeEss(ctx) {
   })
 
   if (!events?.events?.length) {
-    ctx.results.clipGainDeEsser = {
-      applied:    false,
-      reason:     'no_events',
-      eventCount: 0,
-    }
+    const skip = { applied: false, reason: 'no_events', eventCount: 0 }
+    ctx.globalParams.clipGainDeEsser = skip
+    ctx.results.clipGainDeEsser = skip
     ctx.log(`[clip-gain-deess] No events ≥ ${minDurationMs}ms detected — skipped`)
+    return
+  }
+
+  // Snapshot everything apply needs. The frame labels carry through here so
+  // apply doesn't have to reach into ctx.results.metrics — keeps the contract
+  // explicit and chunking-friendly.
+  ctx.globalParams.clipGainDeEsser = {
+    applied: true,
+    eventsPath,
+    config,
+    frames:  ctx.results.metrics?.frames ?? null,
+  }
+}
+
+export async function clipGainDeEsserApply(ctx) {
+  const params = ctx.globalParams.clipGainDeEsser
+  if (!params || !params.applied) {
     return
   }
 
@@ -995,17 +1064,16 @@ export async function clipGainDeEss(ctx) {
   const result  = await applyClipGainDeEsser(
     ctx.currentPath,
     outPath,
-    eventsPath,
-    config,
-    ctx.results.metrics?.frames ?? null,
+    params.eventsPath,
+    params.config,
+    params.frames,
   )
 
   if (result.applied) ctx.currentPath = outPath
-  // Expose eventsPath so downstream stages (e.g. parallelCompress's wet-branch
-  // de-esser pass) can reuse the same event boundaries without re-running
-  // detection. The events.json lives in the per-job temp dir alongside the
-  // other intermediate artifacts; ctx.tmp registers it for cleanup.
-  ctx.results.clipGainDeEsser = { ...result, eventsPath }
+  // Surface eventsPath on the report so downstream stages (parallelCompress's
+  // wet-branch de-esser pass) can reuse the same event boundaries without
+  // re-running detection.
+  ctx.results.clipGainDeEsser = { ...result, eventsPath: params.eventsPath }
 
   await logLevel(ctx, 'after clip-gain de-esser', ctx.currentPath, {
     applied:    result.applied,
@@ -1027,29 +1095,46 @@ export async function clipGainDeEss(ctx) {
 // Noise Eraser is excluded — separation output already has a consistent
 // character. The leveler skips silently for that preset.
 
-export async function autoLevel(ctx) {
+// Analyze pair (autoLevelerAnalyze / autoLevelerApply):
+//   Analyze decodes the input, runs VAD conditioning, clip segmentation,
+//   per-clip LUFS / target / gain computation, and builds the per-sample
+//   gain curve. Channels + gain curve are passed in-memory through
+//   ctx.globalParams.autoLeveler so apply doesn't have to re-read the
+//   input WAV. Apply multiplies channels by the gain curve, writes the
+//   output, and computes the post-leveler measurements.
+//
+//   Skipped cases (no preset config, file too short, too few voiced
+//   clips, already-leveled) short-circuit at analyze with applied=false
+//   and an empty params bundle. Apply is then a no-op — ctx.currentPath
+//   stays at the original input, saving the gratuitous file copy that
+//   the legacy combined stage performed.
+
+export async function autoLevelerAnalyze(ctx) {
+  const analyzed = await analyzeAutoLeveler(ctx.currentPath, ctx.preset, ctx.results.metrics)
+  ctx.globalParams.autoLeveler = analyzed
+  if (!analyzed.applied) {
+    ctx.results.autoLeveler = { applied: false, skipped_reason: analyzed.skipped_reason }
+    ctx.log(`[auto-leveler] Skipped — ${analyzed.skipped_reason}`)
+  }
+}
+
+export async function autoLevelerApply(ctx) {
+  const analyzed = ctx.globalParams.autoLeveler
+  if (!analyzed || !analyzed.applied) return
+
   const levelerPath = ctx.tmp('.wav')
-  const result = await applyAutoLeveler(
-    ctx.currentPath,
-    levelerPath,
-    ctx.preset,
-    ctx.results.metrics,
-  )
+  const result = await renderAutoLeveler(levelerPath, analyzed)
   ctx.currentPath         = levelerPath
   ctx.results.autoLeveler = result
 
-  if (result.applied) {
-    const m = result.measurements
-    ctx.log(
-      `[auto-leveler] Applied — in σ(clip)=${m.input_clip_lufs_std_db}dB ` +
-      `out σ(clip)=${m.output_clip_lufs_std_db}dB ` +
-      `clips=${m.clip_count_after_merge} (splits=${m.subphrase_splits_count}, merges=${m.merges_count}) ` +
-      `G=[${m.gain_max_down_db}, ${m.gain_max_up_db}]dB ` +
-      `nf_cap=${m.noise_floor_cap_active}`
-    )
-  } else {
-    ctx.log(`[auto-leveler] Skipped — ${result.skipped_reason}`)
-  }
+  const m = result.measurements
+  ctx.log(
+    `[auto-leveler] Applied — in σ(clip)=${m.input_clip_lufs_std_db}dB ` +
+    `out σ(clip)=${m.output_clip_lufs_std_db}dB ` +
+    `clips=${m.clip_count_after_merge} (splits=${m.subphrase_splits_count}, merges=${m.merges_count}) ` +
+    `G=[${m.gain_max_down_db}, ${m.gain_max_up_db}]dB ` +
+    `nf_cap=${m.noise_floor_cap_active}`
+  )
 }
 
 // ── Stage: Compression ────────────────────────────────────────────────────────

--- a/src/audio/presets.js
+++ b/src/audio/presets.js
@@ -170,8 +170,7 @@ export const PRESETS = {
       "decode",
       "monoMixdown",
       "measureBefore",
-      "peakNormalizeAnalyze",
-      "peakNormalizeApply",
+      "peakNormalize",
       "analyzeFramesRaw",
       "humDetect",
       "hpf",
@@ -194,7 +193,6 @@ export const PRESETS = {
           merge_max_delta_db: 6.0,
         },
       },
-      "autoLevelerApply",
       /*
       {
         spectralSubtraction: {
@@ -221,8 +219,7 @@ export const PRESETS = {
         },
       },
       */
-      "correctiveEQAnalyze",
-      "correctiveEQApply",
+      "correctiveEQ",
       {
         clipGainDeEsser: {
           enabled: true,
@@ -240,7 +237,6 @@ export const PRESETS = {
           },
         },
       },
-      "clipGainDeEsserApply",
       /*
       {
         // Conservative —
@@ -454,8 +450,7 @@ export const PRESETS = {
       "decode",
       "monoMixdown",
       "measureBefore",
-      "peakNormalizeAnalyze",
-      "peakNormalizeApply",
+      "peakNormalize",
       "analyzeFramesRaw",
       { clickRemover: { thresholdSigma: 3.5, maxClickMs: 15 } },
       "humDetect",
@@ -479,7 +474,6 @@ export const PRESETS = {
           merge_max_delta_db: 6.0,
         },
       },
-      "autoLevelerApply",
       {
         spectralSubtraction: {
           enabled: true,
@@ -518,9 +512,7 @@ export const PRESETS = {
           },
         },
       },
-      "clipGainDeEsserApply",
-      "correctiveEQAnalyze",
-      "correctiveEQApply",
+      "correctiveEQ",
       "remeasureFramesPostNr",
       {
         compression: [
@@ -661,8 +653,7 @@ export const PRESETS = {
       "decode",
       "monoMixdown",
       "measureBefore",
-      "peakNormalizeAnalyze",
-      "peakNormalizeApply",
+      "peakNormalize",
       "analyzeFramesRaw",
       { clickRemover: { thresholdSigma: 3.5, maxClickMs: 10 } },
       "humDetect",
@@ -686,7 +677,6 @@ export const PRESETS = {
           merge_max_delta_db: 6.0,
         },
       },
-      "autoLevelerApply",
 
       {
         clipGainDeEsser: {
@@ -704,7 +694,6 @@ export const PRESETS = {
           },
         },
       },
-      "clipGainDeEsserApply",
       "clearerVoiceEnhance",
       "remeasureFramesPostNr",
       {
@@ -763,8 +752,7 @@ export const PRESETS = {
           freq_ceil_hz: 18000.0,
         },
       },
-      "correctiveEQAnalyze",
-      "correctiveEQApply",
+      "correctiveEQ",
       "referenceEQ",
       "normalize",
       "truePeakLimit",
@@ -791,8 +779,7 @@ export const PRESETS = {
     stages: [
       "decode",
       "measureBefore",
-      "peakNormalizeAnalyze",
-      "peakNormalizeApply",
+      "peakNormalize",
       "analyzeFramesRaw",
       "humDetect",
       "hpf",
@@ -882,8 +869,7 @@ export const PRESETS = {
           floorDb: -70,
         },
       },
-      "autoLevelerAnalyze",
-      "autoLevelerApply",
+      "autoLeveler",
       { airBoost: { gainDb: 0 } },
       { roomPresence: { enabled: false } },
       "normalize",

--- a/src/audio/presets.js
+++ b/src/audio/presets.js
@@ -170,7 +170,8 @@ export const PRESETS = {
       "decode",
       "monoMixdown",
       "measureBefore",
-      "peakNormalize",
+      "peakNormalizeAnalyze",
+      "peakNormalizeApply",
       "analyzeFramesRaw",
       "humDetect",
       "hpf",
@@ -193,6 +194,7 @@ export const PRESETS = {
           merge_max_delta_db: 6.0,
         },
       },
+      "autoLevelerApply",
       /*
       {
         spectralSubtraction: {
@@ -219,7 +221,8 @@ export const PRESETS = {
         },
       },
       */
-      "correctiveEQ",
+      "correctiveEQAnalyze",
+      "correctiveEQApply",
       {
         clipGainDeEsser: {
           enabled: true,
@@ -237,6 +240,7 @@ export const PRESETS = {
           },
         },
       },
+      "clipGainDeEsserApply",
       /*
       {
         // Conservative —
@@ -450,7 +454,8 @@ export const PRESETS = {
       "decode",
       "monoMixdown",
       "measureBefore",
-      "peakNormalize",
+      "peakNormalizeAnalyze",
+      "peakNormalizeApply",
       "analyzeFramesRaw",
       { clickRemover: { thresholdSigma: 3.5, maxClickMs: 15 } },
       "humDetect",
@@ -474,6 +479,7 @@ export const PRESETS = {
           merge_max_delta_db: 6.0,
         },
       },
+      "autoLevelerApply",
       {
         spectralSubtraction: {
           enabled: true,
@@ -512,7 +518,9 @@ export const PRESETS = {
           },
         },
       },
-      "correctiveEQ",
+      "clipGainDeEsserApply",
+      "correctiveEQAnalyze",
+      "correctiveEQApply",
       "remeasureFramesPostNr",
       {
         compression: [
@@ -653,7 +661,8 @@ export const PRESETS = {
       "decode",
       "monoMixdown",
       "measureBefore",
-      "peakNormalize",
+      "peakNormalizeAnalyze",
+      "peakNormalizeApply",
       "analyzeFramesRaw",
       { clickRemover: { thresholdSigma: 3.5, maxClickMs: 10 } },
       "humDetect",
@@ -677,6 +686,7 @@ export const PRESETS = {
           merge_max_delta_db: 6.0,
         },
       },
+      "autoLevelerApply",
 
       {
         clipGainDeEsser: {
@@ -694,6 +704,7 @@ export const PRESETS = {
           },
         },
       },
+      "clipGainDeEsserApply",
       "clearerVoiceEnhance",
       "remeasureFramesPostNr",
       {
@@ -752,7 +763,8 @@ export const PRESETS = {
           freq_ceil_hz: 18000.0,
         },
       },
-      "correctiveEQ",
+      "correctiveEQAnalyze",
+      "correctiveEQApply",
       "referenceEQ",
       "normalize",
       "truePeakLimit",
@@ -779,7 +791,8 @@ export const PRESETS = {
     stages: [
       "decode",
       "measureBefore",
-      "peakNormalize",
+      "peakNormalizeAnalyze",
+      "peakNormalizeApply",
       "analyzeFramesRaw",
       "humDetect",
       "hpf",
@@ -869,7 +882,8 @@ export const PRESETS = {
           floorDb: -70,
         },
       },
-      "autoLevel",
+      "autoLevelerAnalyze",
+      "autoLevelerApply",
       { airBoost: { gainDb: 0 } },
       { roomPresence: { enabled: false } },
       "normalize",


### PR DESCRIPTION
## Summary

Refactors three major processing stages to split analysis from application, enabling future chunked/parallel processing where measurement runs once on the whole file and application runs per-chunk. This is a prerequisite for distributed processing architectures while maintaining backward compatibility with the current sequential pipeline.

## Key Changes

- **Peak Normalize**: Split `peakNormalize()` into `peakNormalizeAnalyze()` (measures peak, computes gain) and `peakNormalizeApply()` (applies linear gain). Analyze stores gain in `ctx.globalParams.peakNormalize`; apply consumes it.

- **Corrective EQ**: Split `correctiveEQ()` into `correctiveEQAnalyze()` (runs noise-floor convergence loop, produces final band list) and `correctiveEQApply()` (applies parametric EQ filter). Analyze stores bands in `ctx.globalParams.correctiveEQ`; apply consumes them.

- **Auto-Leveler**: Refactored `applyAutoLeveler()` into two functions:
  - `analyzeAutoLeveler()`: Decodes input, runs VAD/clip segmentation, computes per-sample gain curve, returns analyzed data in-memory
  - `renderAutoLeveler()`: Multiplies channels by gain curve, writes output, computes post-leveler measurements
  - Removed intermediate file copies for skip cases (preset excluded, file too short, etc.)

- **Clip-Gain De-Esser**: Split `clipGainDeEss()` into `clipGainDeEsserAnalyze()` (runs sibilance detection) and `clipGainDeEsserApply()` (renders gain envelope). Analyze stores events path and config in `ctx.globalParams.clipGainDeEsser`; apply consumes them.

- **Context Enhancement**: Added `ctx.globalParams` object to carry analyze-stage outputs to their paired apply stages. This mirrors the contract a future chunked orchestrator would use to serialize parameters to workers.

- **Preset Updates**: Updated all four presets (`acx_audiobook`, `podcast_ready`, `general_clean`, `noise_eraser`) to invoke analyze/apply pairs as separate stage entries.

- **Stage Registry**: Updated `STAGE_FOR_CONFIG_KEY` mapping to route config-bearing preset keys to analyze stages; apply stages run as plain string entries and read inputs from `ctx.globalParams`.

## Implementation Details

- Analyze stages write results to both `ctx.globalParams` (for apply consumption) and `ctx.results` (for the report), maintaining the current reporting contract.
- Apply stages are no-ops if analyze decided to skip (e.g., file already leveled), avoiding gratuitous file copies.
- In-memory channel data is passed through `ctx.globalParams.autoLeveler` so the apply pass doesn't re-read the input WAV — this is the same handoff pattern a chunked worker orchestrator would use.
- All skip cases short-circuit at analyze with `applied: false`, keeping apply logic clean and chunking-friendly.

https://claude.ai/code/session_01UZStxxoka9BpqY1W7BkpWp