### PR TITLE
Align frame boundaries across JS and Python using time-based calculation

### DIFF
--- a/server/pipeline/frameAnalysis.js
+++ b/server/pipeline/frameAnalysis.js
@@ -55,6 +55,14 @@ const { FRAME_DURATION_S } = JSON.parse(
 )  // 0.025 s = 25 ms — must match FRAME_DURATION_S in silero_vad.py
 const BOOTSTRAP_FRAMES = 20    // use this many lowest-energy frames to bootstrap noise floor
 
+// Time-based frame boundary: frame f starts at sample Math.round(f * FRAME_DURATION_S * sampleRate).
+// Frame sizes alternate by ±1 sample but boundaries stay aligned in time across sample rates.
+export function frameBoundary(f, sampleRate) {
+  return Math.round(f * FRAME_DURATION_S * sampleRate)
+}
+
+export { FRAME_DURATION_S }
+
 const VAD_BACKEND   = process.env.VAD_BACKEND   ?? 'silero'
 const SILERO_SCRIPT = path.join(
   path.dirname(fileURLToPath(import.meta.url)),
@@ -123,8 +131,7 @@ export async function analyzeFrames(wavPath) {
 async function analyzeAudioFramesSilero(wavPath) {
   const { samples, sampleRate } = await readWavSamples(wavPath)
 
-  const frameLengthSamples = Math.round(FRAME_DURATION_S * sampleRate)
-  const numFrames = Math.floor(samples.length / frameLengthSamples)
+  const numFrames = Math.floor(samples.length / (FRAME_DURATION_S * sampleRate))
 
   if (numFrames === 0) {
     return emptyResult()
@@ -133,11 +140,12 @@ async function analyzeAudioFramesSilero(wavPath) {
   // Stage A — energy metrics (always run regardless of VAD backend)
   const frameRms = new Float64Array(numFrames)
   for (let f = 0; f < numFrames; f++) {
-    const start = f * frameLengthSamples
-    const end   = start + frameLengthSamples
+    const start = frameBoundary(f, sampleRate)
+    const end   = frameBoundary(f + 1, sampleRate)
+    const len   = end - start
     let sumSq = 0
     for (let i = start; i < end; i++) sumSq += samples[i] * samples[i]
-    frameRms[f] = Math.sqrt(sumSq / frameLengthSamples)
+    frameRms[f] = Math.sqrt(sumSq / len)
   }
 
   const noiseRmsLinear   = bootstrapNoiseRms(frameRms)
@@ -173,10 +181,11 @@ async function analyzeAudioFramesSilero(wavPath) {
     // frame index not present in Silero output (±1 frame edge case).
     const isSilence = sileroMap.has(f) ? sileroMap.get(f) : (rmsDbfs < silenceThreshold)
 
+    const start = frameBoundary(f, sampleRate)
     frames.push({
       index:         f,
-      offsetSamples: f * frameLengthSamples,
-      lengthSamples: frameLengthSamples,
+      offsetSamples: start,
+      lengthSamples: frameBoundary(f + 1, sampleRate) - start,
       rmsDbfs:       round2(rmsDbfs),
       isSilence,
     })
@@ -222,7 +231,7 @@ async function analyzeAudioFramesSilero(wavPath) {
     ? rmsToDbfs(Math.sqrt(voicedSumSq / voicedFrameCount))
     : noiseFloorDbfs
 
-  const quietestSilenceSegment = findQuietestSilenceSegment(frames, frameRms, frameLengthSamples)
+  const quietestSilenceSegment = findQuietestSilenceSegment(frames, frameRms)
 
   return {
     noiseFloorDbfs:       round2(noiseFloorDbfs),
@@ -258,8 +267,7 @@ function spawnSilero(inputPath, outputJsonPath) {
 async function analyzeAudioFramesEnergy(wavPath) {
   const { samples, sampleRate } = await readWavSamples(wavPath)
 
-  const frameLengthSamples = Math.round(FRAME_DURATION_S * sampleRate)
-  const numFrames = Math.floor(samples.length / frameLengthSamples)
+  const numFrames = Math.floor(samples.length / (FRAME_DURATION_S * sampleRate))
 
   if (numFrames === 0) {
     return emptyResult()
@@ -268,13 +276,14 @@ async function analyzeAudioFramesEnergy(wavPath) {
   // Compute RMS for every frame
   const frameRms = new Float64Array(numFrames)
   for (let f = 0; f < numFrames; f++) {
-    const start = f * frameLengthSamples
-    const end   = start + frameLengthSamples
+    const start = frameBoundary(f, sampleRate)
+    const end   = frameBoundary(f + 1, sampleRate)
+    const len   = end - start
     let sumSq = 0
     for (let i = start; i < end; i++) {
       sumSq += samples[i] * samples[i]
     }
-    frameRms[f] = Math.sqrt(sumSq / frameLengthSamples)
+    frameRms[f] = Math.sqrt(sumSq / len)
   }
 
   // Bootstrap noise floor: RMS over the BOOTSTRAP_FRAMES lowest-energy frames
@@ -291,10 +300,11 @@ async function analyzeAudioFramesEnergy(wavPath) {
     const rmsDbfs  = rmsToDbfs(frameRms[f])
     const isSilence = rmsDbfs < silenceThreshold
 
+    const start = frameBoundary(f, sampleRate)
     frames.push({
       index:         f,
-      offsetSamples: f * frameLengthSamples,
-      lengthSamples: frameLengthSamples,
+      offsetSamples: start,
+      lengthSamples: frameBoundary(f + 1, sampleRate) - start,
       rmsDbfs:       round2(rmsDbfs),
       isSilence,
     })
@@ -310,7 +320,7 @@ async function analyzeAudioFramesEnergy(wavPath) {
     : noiseFloorDbfs
 
   // Find quietest contiguous silence segment (≥ 5 frames = 0.5 s)
-  const quietestSilenceSegment = findQuietestSilenceSegment(frames, frameRms, frameLengthSamples)
+  const quietestSilenceSegment = findQuietestSilenceSegment(frames, frameRms)
 
   return {
     noiseFloorDbfs:       round2(noiseFloorDbfs),
@@ -339,18 +349,19 @@ async function analyzeAudioFramesEnergy(wavPath) {
 export async function remeasureFrames(wavPath, reference) {
   const { samples, sampleRate } = await readWavSamples(wavPath)
 
-  const frameLengthSamples = Math.round(FRAME_DURATION_S * sampleRate)
-  const numFrames = Math.floor(samples.length / frameLengthSamples)
+  const numFrames = Math.floor(samples.length / (FRAME_DURATION_S * sampleRate))
 
   if (numFrames === 0) return emptyResult()
 
   // Re-compute per-frame RMS from the current (processed) audio
   const frameRms = new Float64Array(numFrames)
   for (let f = 0; f < numFrames; f++) {
-    const start = f * frameLengthSamples
+    const start = frameBoundary(f, sampleRate)
+    const end   = frameBoundary(f + 1, sampleRate)
+    const len   = end - start
     let sumSq = 0
-    for (let i = start; i < start + frameLengthSamples; i++) sumSq += samples[i] * samples[i]
-    frameRms[f] = Math.sqrt(sumSq / frameLengthSamples)
+    for (let i = start; i < end; i++) sumSq += samples[i] * samples[i]
+    frameRms[f] = Math.sqrt(sumSq / len)
   }
 
   const noiseRmsLinear   = bootstrapNoiseRms(frameRms)
@@ -371,10 +382,11 @@ export async function remeasureFrames(wavPath, reference) {
       ? reference.frames[f].isSilence
       : (rmsDbfs < silenceThreshold)
 
+    const start = frameBoundary(f, sampleRate)
     frames.push({
       index:         f,
-      offsetSamples: f * frameLengthSamples,
-      lengthSamples: frameLengthSamples,
+      offsetSamples: start,
+      lengthSamples: frameBoundary(f + 1, sampleRate) - start,
       rmsDbfs:       round2(rmsDbfs),
       isSilence,
     })
@@ -389,7 +401,7 @@ export async function remeasureFrames(wavPath, reference) {
     ? rmsToDbfs(Math.sqrt(voicedSumSq / voicedFrameCount))
     : noiseFloorDbfs
 
-  const quietestSilenceSegment = findQuietestSilenceSegment(frames, frameRms, frameLengthSamples)
+  const quietestSilenceSegment = findQuietestSilenceSegment(frames, frameRms)
 
   return {
     noiseFloorDbfs:       round2(noiseFloorDbfs),
@@ -405,7 +417,7 @@ export async function remeasureFrames(wavPath, reference) {
  * Find the quietest contiguous silence segment of at least MIN_SEGMENT_FRAMES.
  * Used for room tone extraction.
  */
-function findQuietestSilenceSegment(frames, frameRms, frameLengthSamples) {
+function findQuietestSilenceSegment(frames, frameRms) {
   const MIN_FRAMES = 5  // at least 125 ms (5 × 25 ms frames)
 
   let bestSegment  = null
@@ -423,9 +435,11 @@ function findQuietestSilenceSegment(frames, frameRms, frameLengthSamples) {
 
     if (avgRms < bestAvgRms) {
       bestAvgRms = avgRms
+      const startSample = frames[segStart].offsetSamples
+      const lastFrame   = frames[end - 1]
       bestSegment = {
-        offsetSamples: segStart * frameLengthSamples,
-        lengthSamples: len * frameLengthSamples,
+        offsetSamples: startSample,
+        lengthSamples: (lastFrame.offsetSamples + lastFrame.lengthSamples) - startSample,
       }
     }
     segStart = -1

--- a/server/scripts/silero_vad.py
+++ b/server/scripts/silero_vad.py
@@ -184,9 +184,12 @@ def main(argv=None):
         g = gcd(SILERO_SR, sr)
         audio_np = resample_poly(audio_np, SILERO_SR // g, sr // g).astype(np.float32)
 
-    # Frame alignment: 25 ms * 16000 Hz = 400 samples per pipeline frame
-    samples_per_frame = round(FRAME_DURATION_S * SILERO_SR)  # 400
-    n_frames          = len(audio_np) // samples_per_frame
+    # Time-based frame boundaries: frame f starts at round(f * FRAME_DURATION_S * SILERO_SR).
+    # Frame sizes alternate by ±1 sample but boundaries stay aligned in time with the JS side.
+    def frame_boundary(f):
+        return round(f * FRAME_DURATION_S * SILERO_SR)
+
+    n_frames = int(len(audio_np) // (FRAME_DURATION_S * SILERO_SR))
 
     frame_results = []
 
@@ -215,13 +218,24 @@ def main(argv=None):
                 threshold=args.threshold,
             )
 
-        # Map segments to pipeline frames.
+        # Map segments to pipeline frames using time-based boundaries.
         # Segment boundaries are at 512-sample chunk resolution; a frame is
-        # voiced if any segment overlaps its [f*400, (f+1)*400) sample range.
+        # voiced if any segment overlaps its [frame_boundary(f), frame_boundary(f+1)) range.
+        samples_per_frame_approx = FRAME_DURATION_S * SILERO_SR
+
+        def frame_at_sample(s):
+            """Return the frame index whose boundary range contains sample s."""
+            f = int(s / samples_per_frame_approx)
+            if f > 0 and frame_boundary(f) > s:
+                f -= 1
+            elif f + 1 <= n_frames and frame_boundary(f + 1) <= s:
+                f += 1
+            return min(f, n_frames - 1)
+
         voiced_frames = set()
         for seg in speech_segs:
-            first_frame = seg['start'] // samples_per_frame
-            last_frame  = (seg['end'] - 1) // samples_per_frame
+            first_frame = frame_at_sample(seg['start'])
+            last_frame  = frame_at_sample(seg['end'] - 1)
             for f in range(first_frame, min(last_frame + 1, n_frames)):
                 voiced_frames.add(f)
 
@@ -242,12 +256,13 @@ def main(argv=None):
         audio_16k = torch.from_numpy(audio_np)
         with torch.no_grad():
             for f in range(n_frames):
-                frame_start = f * samples_per_frame
-                frame_end   = frame_start + samples_per_frame
-                frame_audio = audio_16k[frame_start:frame_end]   # 400 samples
+                fb_start    = frame_boundary(f)
+                fb_end      = frame_boundary(f + 1)
+                frame_len   = fb_end - fb_start
+                frame_audio = audio_16k[fb_start:fb_end]
 
                 chunk_probs = []
-                for chunk_start in range(0, samples_per_frame, SILERO_CHUNK_SAMPLES):
+                for chunk_start in range(0, frame_len, SILERO_CHUNK_SAMPLES):
                     chunk = frame_audio[chunk_start : chunk_start + SILERO_CHUNK_SAMPLES]
 
                     # Zero-pad last chunk if shorter than SILERO_CHUNK_SAMPLES

--- a/server/scripts/silero_vad.py
+++ b/server/scripts/silero_vad.py
@@ -185,7 +185,7 @@ def main(argv=None):
         audio_np = resample_poly(audio_np, SILERO_SR // g, sr // g).astype(np.float32)
 
     # Time-based frame boundaries: frame f starts at round(f * FRAME_DURATION_S * SILERO_SR).
-    # Frame sizes alternate by ±1 sample but boundaries stay aligned in time with the JS side.
+    # With the current 25 ms/16 kHz config this remains 400 samples per frame; the formula matches the JS side.
     def frame_boundary(f):
         return round(f * FRAME_DURATION_S * SILERO_SR)
 


### PR DESCRIPTION
## Summary

Refactors frame boundary calculation to use a consistent time-based approach across both JavaScript and Python implementations. Previously, frame boundaries were computed by multiplying frame index by a rounded sample count, which could cause misalignment between the two sides. Now both use `Math.round(f * FRAME_DURATION_S * sampleRate)` to ensure frame boundaries stay synchronized regardless of sample rate.

## Key Changes

- **New `frameBoundary()` function** in `frameAnalysis.js`: Exports a helper that computes frame `f`'s start sample as `Math.round(f * FRAME_DURATION_S * sampleRate)`. This replaces inline calculations and ensures consistency.

- **Export `FRAME_DURATION_S`** from `frameAnalysis.js` for use by other modules that need the frame duration constant.

- **Updated all frame boundary calculations** in three functions (`analyzeAudioFramesSilero`, `analyzeAudioFramesEnergy`, `remeasureFrames`) to use `frameBoundary(f, sampleRate)` and `frameBoundary(f + 1, sampleRate)` instead of `f * frameLengthSamples`.

- **Frame length now computed per-frame** as `end - start` rather than using a pre-rounded `frameLengthSamples` value. This accounts for the ±1 sample variation that occurs when frame boundaries are time-aligned.

- **Simplified `findQuietestSilenceSegment()`** by removing the `frameLengthSamples` parameter. The function now derives segment boundaries directly from frame metadata (`offsetSamples` and `lengthSamples`), which are already computed using the time-based approach.

- **Python side (`silero_vad.py`)** updated with matching `frame_boundary()` function and new `frame_at_sample()` helper to map segment boundaries to frames using the same time-based logic. Segment-to-frame mapping now uses this helper instead of integer division.

## Implementation Details

- Frame sizes alternate by ±1 sample due to rounding, but frame boundaries remain aligned in time across different sample rates (e.g., 16 kHz and 44.1 kHz).
- The change ensures that a frame's `offsetSamples` and `lengthSamples` are always computed consistently, eliminating potential drift between JS and Python VAD analysis.
- No functional change to the VAD algorithm itself — this is purely a boundary alignment fix to improve cross-platform consistency.

https://claude.ai/code/session_01XLQi79mAg6q3UyaYTGuHRb