### PR TITLE
Extract chunk result merging logic into registry

### DIFF
--- a/server/pipeline/chunkMergers.js
+++ b/server/pipeline/chunkMergers.js
@@ -1,0 +1,106 @@
+/**
+ * Per-stage result merger registry for the chunked runner.
+ *
+ * Each entry merges per-chunk writes for a single ctx.results key back into
+ * the parent. Adding a new stage to a {chunked: [...]} block means adding
+ * an entry here — no changes to chunkedRunner.js.
+ *
+ * Merge contract:
+ *   - Each merger is keyed by the ctx.results key it owns (NOT the stage
+ *     function name — a stage may write under a differently-named key, e.g.
+ *     clickRemove → ctx.results.clickRemover).
+ *   - The merger receives chunkValues: an array of per-chunk values for the
+ *     key, in chunk order. Entries are `undefined` for chunks that didn't
+ *     write the key. The runner skips the merger entirely when no chunk
+ *     wrote anything, so mergers can assume at least one defined value.
+ *   - The merger returns the merged value to assign to ctx.results[key].
+ *     Returning `undefined` skips the assignment.
+ *
+ * Whole-file metric scalars (noiseFloorDbfs, voicedRmsDbfs, …) are NOT
+ * merged here — refreshPostBlockMetrics in chunkedRunner.js measures the
+ * stitched output instead, which is exact rather than averaged.
+ */
+
+export const CHUNK_MERGERS = {
+  /**
+   * hpf — boolean derived from the parent's pre-block noise floor. Identical
+   * across chunks because every sub-ctx reads the same metrics.noiseFloorDbfs
+   * snapshot. Take the first defined value.
+   */
+  notch60Hz(chunkValues) {
+    return chunkValues.find(v => v !== undefined)
+  },
+
+  /**
+   * vocalSaturation — config snapshot ({applied, drive, wetDry, …}), identical
+   * across chunks. Shallow-copy the first defined entry so the merged value
+   * can be mutated downstream without aliasing a sub-ctx's results object.
+   */
+  vocalSaturation(chunkValues) {
+    const first = chunkValues.find(v => v != null)
+    return first ? { ...first } : undefined
+  },
+
+  /**
+   * clickRemove — structural fields (applied, parameters, per-channel layout)
+   * from chunk 0; cumulative counts SUMMED across chunks for a file-level
+   * total. The per-channel `channels` array is taken from chunk 0 as a
+   * representative sample — per-channel summing would require knowing the
+   * channel layout, and the top-level summed counts already give the
+   * file-level totals.
+   */
+  clickRemover(chunkValues) {
+    const first = chunkValues.find(v => v != null)
+    if (!first) return undefined
+    const merged = { ...first }
+    const summedKeys = ['clicks_detected', 'clicks_repaired', 'clicks_skipped', 'total_clicks_repaired']
+    for (const key of summedKeys) {
+      const total = sumDefined(chunkValues.map(v => v?.[key]))
+      if (total != null) merged[key] = total
+    }
+    return merged
+  },
+
+  /**
+   * noiseReduce — structural fields (model, applied, reason) from chunk 0;
+   * numeric scalars (makeupGainDb, pre/post noise floor) AVERAGED across
+   * chunks for a representative file-level figure.
+   * post_noise_floor_dbfs is overwritten by refreshPostBlockMetrics later
+   * so it agrees exactly with the metrics block.
+   */
+  noiseReduction(chunkValues) {
+    const first = chunkValues.find(v => v != null)
+    if (!first) return undefined
+    const merged = { ...first }
+    const averagedKeys = ['makeupGainDb', 'post_noise_floor_dbfs', 'pre_noise_floor_dbfs']
+    for (const key of averagedKeys) {
+      const avg = meanDefined(chunkValues.map(v => v?.[key]))
+      if (avg != null) merged[key] = round2(avg)
+    }
+    return merged
+  },
+}
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function sumDefined(values) {
+  let sum = 0
+  let count = 0
+  for (const v of values) {
+    if (typeof v === 'number' && isFinite(v)) {
+      sum += v
+      count++
+    }
+  }
+  return count > 0 ? sum : null
+}
+
+function meanDefined(values) {
+  const finite = values.filter(v => typeof v === 'number' && isFinite(v))
+  if (!finite.length) return null
+  return finite.reduce((a, b) => a + b, 0) / finite.length
+}
+
+export function round2(n) {
+  return Math.round(n * 100) / 100
+}

--- a/server/pipeline/chunkMergers.js
+++ b/server/pipeline/chunkMergers.js
@@ -42,9 +42,9 @@ export const CHUNK_MERGERS = {
   },
 
   /**
-   * clickRemove — structural fields (applied, parameters, per-channel layout)
-   * from chunk 0; cumulative counts SUMMED across chunks for a file-level
-   * total. The per-channel `channels` array is taken from chunk 0 as a
+   /**
+    * clickRemove — structural fields (applied, parameters, per-channel layout)
+    * from the first defined chunk value; cumulative counts SUMMED across chunks for a file-level
    * representative sample — per-channel summing would require knowing the
    * channel layout, and the top-level summed counts already give the
    * file-level totals.

--- a/server/pipeline/chunkMergers.js
+++ b/server/pipeline/chunkMergers.js
@@ -83,7 +83,7 @@ export const CHUNK_MERGERS = {
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
 
-function sumDefined(values) {
+export function sumDefined(values) {
   let sum = 0
   let count = 0
   for (const v of values) {
@@ -95,7 +95,7 @@ function sumDefined(values) {
   return count > 0 ? sum : null
 }
 
-function meanDefined(values) {
+export function meanDefined(values) {
   const finite = values.filter(v => typeof v === 'number' && isFinite(v))
   if (!finite.length) return null
   return finite.reduce((a, b) => a + b, 0) / finite.length

--- a/server/pipeline/chunkMergers.js
+++ b/server/pipeline/chunkMergers.js
@@ -62,8 +62,8 @@ export const CHUNK_MERGERS = {
   },
 
   /**
-   * noiseReduce — structural fields (model, applied, reason) from chunk 0;
-   * numeric scalars (makeupGainDb, pre/post noise floor) AVERAGED across
+   /**
+    * noiseReduce — structural fields (model, applied, reason) from the first defined chunk value;
    * chunks for a representative file-level figure.
    * post_noise_floor_dbfs is overwritten by refreshPostBlockMetrics later
    * so it agrees exactly with the metrics block.

--- a/server/pipeline/chunkedRunner.js
+++ b/server/pipeline/chunkedRunner.js
@@ -37,6 +37,7 @@ import { extractAudioRange }                  from '../lib/ffmpeg.js'
 import { remeasureFrames }                    from './frameAnalysis.js'
 import { withThreadLimit }                    from './threadingContext.js'
 import { getChunkedThreadLimit }              from './pythonWorker.js'
+import { CHUNK_MERGERS, round2 }              from './chunkMergers.js'
 
 const OVERLAP_MS = 100
 
@@ -491,77 +492,24 @@ async function stitchChunks(chunks, totalSamples, sampleRate, overlapSamples, ou
  *
  * Each inner stage's writes go to its sub-ctx.results, not the parent —
  * sub-ctx is constructed with a fresh results object aliasing the parent's
- * pre-block snapshot. This function copies relevant keys back. Whole-file
- * metric scalars (noiseFloorDbfs, voicedRmsDbfs, …) are NOT handled here;
- * refreshPostBlockMetrics measures the stitched output instead, which is
- * exact rather than an average across chunks.
+ * pre-block snapshot. This function gathers per-chunk values for each key
+ * registered in CHUNK_MERGERS and delegates the actual merge strategy
+ * (first-wins, sum, average, etc.) to the merger.
  *
- * Keys merged here:
- *   - `notch60Hz` (hpf): boolean, identical across chunks because every
- *     sub-ctx reads the same pre-block ctx.results.metrics.noiseFloorDbfs.
- *     Taken from chunk 0.
- *   - `vocalSaturation` (vocalSaturation): config snapshot, identical
- *     across chunks. Taken from chunk 0.
- *   - `clickRemover` (clickRemove): cumulative counts — clicks_detected,
- *     clicks_repaired, clicks_skipped, total_clicks_repaired — SUMMED
- *     across chunks. Structural fields (applied, parameters) from chunk 0.
- *     The per-channel `channels` array is taken from chunk 0 as a
- *     representative sample; per-channel summing would require knowing the
- *     channel layout, and the top-level summed counts already give the
- *     file-level totals.
- *   - `noiseReduction` (noiseReduce): structural fields (model, applied,
- *     reason) from chunk 0; numeric scalars (makeupGainDb, pre/post noise
- *     floor) averaged across chunks for a representative file-level figure.
- *     post_noise_floor_dbfs is overwritten by refreshPostBlockMetrics later
- *     so it matches the metrics block.
+ * To make a new stage chunk-safe, add an entry to CHUNK_MERGERS keyed by
+ * the ctx.results key the stage writes — no changes needed here.
  *
- * Future inner stages that write their own keys can extend this switch.
+ * Whole-file metric scalars (noiseFloorDbfs, voicedRmsDbfs, …) are NOT
+ * handled here; refreshPostBlockMetrics measures the stitched output
+ * instead, which is exact rather than an average across chunks.
  */
 function mergeChunkResults(ctx, processedChunks) {
-  const first = processedChunks[0].results
-  if (!first) return
+  if (!processedChunks.length) return
 
-  if (typeof first.notch60Hz === 'boolean') {
-    ctx.results.notch60Hz = first.notch60Hz
+  for (const [key, merger] of Object.entries(CHUNK_MERGERS)) {
+    const chunkValues = processedChunks.map(c => c.results?.[key])
+    if (!chunkValues.some(v => v !== undefined)) continue
+    const merged = merger(chunkValues)
+    if (merged !== undefined) ctx.results[key] = merged
   }
-
-  if (first.vocalSaturation) {
-    ctx.results.vocalSaturation = { ...first.vocalSaturation }
-  }
-
-  if (first.clickRemover) {
-    const merged = { ...first.clickRemover }
-    const summedKeys = ['clicks_detected', 'clicks_repaired', 'clicks_skipped', 'total_clicks_repaired']
-    for (const key of summedKeys) {
-      let sum = 0
-      let count = 0
-      for (const c of processedChunks) {
-        const v = c.results.clickRemover?.[key]
-        if (typeof v === 'number' && isFinite(v)) {
-          sum += v
-          count++
-        }
-      }
-      if (count > 0) merged[key] = sum
-    }
-    ctx.results.clickRemover = merged
-  }
-
-  if (first.noiseReduction) {
-    const merged = { ...first.noiseReduction }
-    const averagedKeys = ['makeupGainDb', 'post_noise_floor_dbfs', 'pre_noise_floor_dbfs']
-    for (const key of averagedKeys) {
-      const values = processedChunks
-        .map(c => c.results.noiseReduction?.[key])
-        .filter(v => typeof v === 'number' && isFinite(v))
-      if (values.length) {
-        merged[key] = round2(values.reduce((a, b) => a + b, 0) / values.length)
-      }
-    }
-    ctx.results.noiseReduction = merged
-  }
-}
-
-function round2(n) {
-  return Math.round(n * 100) / 100
 }


### PR DESCRIPTION
## Summary

Refactor the per-chunk result merging logic in `mergeChunkResults()` from inline switch-case handling into a declarative registry pattern. This improves maintainability and makes it easier to add new chunked stages without modifying the runner itself.

## Changes

- **New file: `server/pipeline/chunkMergers.js`**
  - Introduces `CHUNK_MERGERS` registry mapping `ctx.results` keys to their merge strategies
  - Implements mergers for four stages: `notch60Hz` (first-wins), `vocalSaturation` (shallow copy), `clickRemover` (sum counts), and `noiseReduction` (average scalars)
  - Exports helper functions `sumDefined()`, `meanDefined()`, and `round2()` for numeric aggregation
  - Includes detailed merge contract documentation explaining how to add new stages

- **Modified: `server/pipeline/chunkedRunner.js`**
  - Imports `CHUNK_MERGERS` and `round2` from the new module
  - Simplifies `mergeChunkResults()` from ~60 lines of inline logic to ~10 lines of generic registry iteration
  - Removes duplicate `round2()` function (now imported)
  - Updates function documentation to reference the registry pattern

## Implementation Details

The new registry pattern:
- Each merger receives an array of per-chunk values (with `undefined` for chunks that didn't write the key)
- Mergers return the merged value or `undefined` to skip assignment
- The runner skips the merger entirely when no chunk wrote anything, avoiding unnecessary processing
- Adding a new chunked stage now requires only adding an entry to `CHUNK_MERGERS` — no changes to `chunkedRunner.js`

This aligns with the project's preference for declarative, extensible patterns and reduces cognitive load when onboarding new processing stages to the chunked pipeline.

https://claude.ai/code/session_012tFtHnmrQhX5WUG4kjaZwt