### PR TITLE
Parallelize Silero VAD across worker pool for long files

### DIFF
--- a/server/.env.example
+++ b/server/.env.example
@@ -1,0 +1,160 @@
+# server/.env.example
+#
+# Copy this file to `server/.env` and tweak. Every variable below is OPTIONAL —
+# the server boots and processes audio with all of them unset. Use this file to
+# document what's tunable, and to seed deployment configs.
+#
+# Boolean flags are read as the literal strings `'1'` or `'true'`. Everything
+# else is parsed as a number; non-numeric values fall back to the default.
+
+
+# ─── Server ──────────────────────────────────────────────────────────────────
+
+# HTTP listen port for the Express API.
+# Default: 3001
+PORT=3001
+
+# Comma-separated list of allowed CORS origins. Leave unset to use the built-in
+# dev defaults (localhost). Example: https://app.example.com,https://staging.example.com
+# CORS_ORIGINS=
+# CORS_ORIGIN_PATTERNS=
+
+
+# ─── Pipeline logging ────────────────────────────────────────────────────────
+
+# Write a per-run JSON log to PIPELINE_LOG_DIR (or ./logs when unset) capturing
+# every stage's duration and result payload. The runner already times each
+# stage via Date.now() deltas — this just persists them. Enable when you want
+# per-stage timing data across runs (e.g. to rank stages by total compute).
+# Default: off
+# PIPELINE_LOG=1
+
+# Directory for per-run logs. Defaults to ./logs relative to the server cwd.
+# PIPELINE_LOG_DIR=./logs
+
+# Persist a copy of each stage's output WAV under PIPELINE_LOG_DIR. Storage-
+# heavy — useful when diffing two pipeline configs sample-for-sample. Off by
+# default.
+# PIPELINE_LOG_SNAPSHOTS=1
+
+# Same as PIPELINE_LOG_SNAPSHOTS but for the per-chunk outputs inside a
+# {chunked: …} block. Even heavier; only enable when investigating a
+# specific chunk seam.
+# PIPELINE_LOG_CHUNK_SNAPSHOTS=1
+
+# Run an extra `astats` measurement at the end of each stage and write the
+# result into the per-run log. Off by default — astats is a full-file FFmpeg
+# pass and adds nontrivial cost on long files.
+# PIPELINE_LOG_MEASURE=1
+
+# Drop a JSON sidecar of RNNoise's per-frame internal VAD speech_prob curve
+# into this directory. Diagnostic for the Silero-vs-RNNoise disagreement gate;
+# normally unset.
+# RNNOISE_SPEECH_PROB_DIR=./logs/rnnoise
+
+
+# ─── Python worker pool & threading ──────────────────────────────────────────
+
+# Persistent Python worker processes. Each worker keeps torch / numpy / model
+# weights loaded across calls, amortising cold-start cost. Stage-level
+# parallelism (the {chunked: …} block, and the parallel Silero VAD path) is
+# bounded by this — values < 2 disable both. Size to your core budget.
+# Default: 1
+# PYTHON_WORKER_POOL_SIZE=4
+
+# Forces the legacy "fresh subprocess per call" path even when the worker pool
+# is available. Use only for A/B-ing a worker-mode regression.
+# Default: 0
+# WAVELY_DISABLE_PY_WORKER=1
+
+# Per-worker PyTorch thread cap. NOTE: DeepFilterNet3 pins thread count at
+# first inference and ignores later runtime changes, so set this conservatively
+# at process start. Rule of thumb: floor(vCPU / PYTHON_WORKER_POOL_SIZE).
+# Default: floor(cpus / pool_size)
+# TORCH_NUM_THREADS=3
+
+# Per-call PyTorch thread cap used by the chunked block. The chunked runner
+# wraps each inner stage in withThreadLimit() so per-worker counts safe for
+# serial throughput are clamped back down when many chunks dispatch in
+# parallel. Best-effort: NumPy / scipy / RNNoise honor it, DeepFilterNet3 does
+# not (see TORCH_NUM_THREADS above).
+# Default: same as TORCH_NUM_THREADS
+# CHUNKED_TORCH_THREADS=2
+
+# Max chunks processed in parallel inside a single {chunked: …} block. Capped
+# at min(this, PYTHON_WORKER_POOL_SIZE) — there is no benefit to more JS-side
+# concurrency than worker slots. Set to 1 to force serial chunk processing.
+# Default: 1
+# CHUNKED_CONCURRENCY=4
+
+
+# ─── Parallel Silero VAD (analyzeFramesRaw) ──────────────────────────────────
+#
+# The Silero subprocess inside analyzeFramesRaw is split into silence-snapped
+# chunks run in parallel across PYTHON_WORKER_POOL_SIZE workers, then reassembled
+# into global frame labels. Activates automatically when the worker pool has
+# ≥ 2 workers. See server/pipeline/sileroParallel.js for the protocol.
+
+# Master kill-switch. Set to 0 to force the original single whole-file call —
+# useful when A/B-ing parallel-vs-serial frame labels.
+# Default: enabled
+# SILERO_PARALLEL=0
+
+# Warm-up overlap (seconds) prepended to each chunk before its core region.
+# Processed and discarded so the model's GRU state and trigger/neg-trigger
+# hysteresis converge before the first emitted frame. Generous relative to
+# Silero's ~few-hundred-ms effective context.
+# Default: 2
+# SILERO_PARALLEL_WARMUP_S=2
+
+# Planner overrides. Target chunk duration is derived from total length / pool
+# size, clamped to [min, max]. Each seam is snapped to a silence region of at
+# least MIN_SILENCE_MS so the model enters each core from established silence.
+# Defaults: min=20, max=600, min_silence=500
+# SILERO_PARALLEL_MIN_CHUNK_S=20
+# SILERO_PARALLEL_MAX_CHUNK_S=600
+# SILERO_PARALLEL_MIN_SILENCE_MS=500
+
+# VAD backend selector. Default 'silero' uses the neural model; 'energy' falls
+# back to a pure-JS RMS threshold (no subprocess). Used for A/B comparison or
+# when Silero is unavailable.
+# Default: silero
+# VAD_BACKEND=silero
+
+
+# ─── Noise reduction backends ────────────────────────────────────────────────
+
+# Path to a DeepFilterNet3 CLI binary. When set, the JS wrapper invokes the
+# native binary instead of the Python script — significantly faster cold start
+# but requires a per-platform build. Unset to use the Python path.
+# DEEPFILTER_BINARY=/usr/local/bin/deep-filter
+
+# Python interpreter for the DeepFilterNet3 script. Defaults to the worker
+# pool's interpreter; override when DF3's torch install lives in a different
+# venv than the rest of the pipeline.
+# DEEPFILTER_PYTHON=/path/to/.venv/bin/python
+
+# Python interpreter for the de-esser script. Same reasoning as above.
+# DE_ESSER_PYTHON=/path/to/.venv/bin/python
+
+
+# ─── Source separation (Noise Eraser preset only) ────────────────────────────
+
+# Device for Demucs / ConvTasNet. 'auto' selects CUDA if available, else CPU.
+# Default: auto
+# SEPARATION_DEVICE=auto
+
+# Python interpreter for the separation scripts.
+# SEPARATION_PYTHON=/path/to/.venv/bin/python
+
+# Extra path prepended to PYTHONPATH for the worker processes.
+# PYTHONPATH=
+
+
+# ─── Bandwidth extension (currently disabled in presets) ─────────────────────
+
+# AP-BWE checkpoint + repo paths. Used when the bandwidthExtension stage is
+# enabled in a preset (off by default).
+# AP_BWE_REPO=/path/to/ap_bwe
+# AP_BWE_CHECKPOINT=/path/to/ap_bwe/checkpoint.pt
+# LAVASR_MODEL_PATH=/path/to/lavasr/checkpoint.pt

--- a/server/pipeline/frameAnalysis.js
+++ b/server/pipeline/frameAnalysis.js
@@ -172,12 +172,26 @@ async function analyzeAudioFramesSilero(wavPath) {
     // through to the single whole-file call below. Seams are silence-snapped
     // and warm-up-padded, so core-region labels match the whole-file run; set
     // SILERO_PARALLEL=0 to force the single call for A/B comparison.
-    const parallel = await classifySileroVadParallel(vadInput, {
-      energyFrameRms:       frameRms,
-      silenceThresholdDbfs: silenceThreshold,
-      numFrames,
-      runVad:               spawnSilero,
-    })
+    //
+    // A failure in the parallel path (FFmpeg carve / JSON parse / worker error)
+    // degrades to the single whole-file Silero call below — NOT to the energy
+    // backend. The energy fallback is reserved for Silero itself being broken;
+    // a chunking-layer hiccup should still get neural VAD, just non-parallel.
+    let parallel = null
+    try {
+      parallel = await classifySileroVadParallel(vadInput, {
+        energyFrameRms:       frameRms,
+        silenceThresholdDbfs: silenceThreshold,
+        numFrames,
+        runVad:               spawnSilero,
+      })
+    } catch (err) {
+      console.warn(
+        `[silence] parallel Silero VAD failed — falling back to the single ` +
+        `whole-file call. Reason: ${err.message}`
+      )
+      parallel = null
+    }
 
     if (parallel) {
       sileroFrames = parallel.frames

--- a/server/pipeline/frameAnalysis.js
+++ b/server/pipeline/frameAnalysis.js
@@ -22,13 +22,15 @@
  *     No subprocess. Use as fallback or for A/B comparison.
  *
  * Performance note (Silero backend): ~50–100x real-time on CPU. analyzeFrames
- * (and therefore the Silero subprocess) runs exactly once per job, in the
- * analyzeFramesRaw stage. measureBefore no longer calls analyzeFrames —
- * analyzeFramesRaw back-fills beforeMeasurements.noiseFloorDbfs after correcting
- * for the peakNormalize gain. All subsequent pipeline stages call
- * remeasureFrames instead, which re-derives energy metrics from the current
- * audio while preserving the Silero isSilence labels. Set SILERO_DEVICE=cuda to
- * reduce the single-pass latency further.
+ * runs exactly once per job, in the analyzeFramesRaw stage; on long files the
+ * Silero subprocess underneath it is split into silence-snapped chunks run in
+ * parallel across the worker pool (see sileroParallel.js), so the wall-clock of
+ * this stage scales down with the pool size. measureBefore no longer calls
+ * analyzeFrames — analyzeFramesRaw back-fills beforeMeasurements.noiseFloorDbfs
+ * after correcting for the peakNormalize gain. All subsequent pipeline stages
+ * call remeasureFrames instead, which re-derives energy metrics from the
+ * current audio while preserving the Silero isSilence labels. Set
+ * SILERO_PARALLEL=0 to force the single whole-file call.
  *
  * Logging: frame analysis results are merged into ctx.results.metrics and
  * written to the pipeline file log (PIPELINE_LOG=true).
@@ -43,6 +45,7 @@ import path               from 'path'
 
 import { spawnPython }    from './spawnPython.js'
 import { readWavSamples } from './wavReader.js'
+import { classifySileroVadParallel } from './sileroParallel.js'
 import { decodeToFloat32Mono16k, tempPath, removeTmp } from '../lib/ffmpeg.js'
 
 // Loaded from the shared config so JS and Python always use the same value.
@@ -161,9 +164,28 @@ async function analyzeAudioFramesSilero(wavPath) {
   let sileroFrames = []
   try {
     await decodeToFloat32Mono16k(wavPath, vadInput)
-    await spawnSilero(vadInput, jsonPath)
-    const raw = JSON.parse(await readFile(jsonPath, 'utf8'))
-    sileroFrames = raw.frames
+
+    // Parallel path: split the 16 kHz VAD input at energy-silence seams and run
+    // the (unchanged) Silero subprocess on each chunk across the worker pool,
+    // reassembling global frame labels. Returns null when the file is too
+    // short / unsplittable or parallelism is disabled, in which case fall
+    // through to the single whole-file call below. Seams are silence-snapped
+    // and warm-up-padded, so core-region labels match the whole-file run; set
+    // SILERO_PARALLEL=0 to force the single call for A/B comparison.
+    const parallel = await classifySileroVadParallel(vadInput, {
+      energyFrameRms:       frameRms,
+      silenceThresholdDbfs: silenceThreshold,
+      numFrames,
+      runVad:               spawnSilero,
+    })
+
+    if (parallel) {
+      sileroFrames = parallel.frames
+    } else {
+      await spawnSilero(vadInput, jsonPath)
+      const raw = JSON.parse(await readFile(jsonPath, 'utf8'))
+      sileroFrames = raw.frames
+    }
   } finally {
     await rm(jsonPath, { force: true })
     await removeTmp(vadInput)

--- a/server/pipeline/noiseReduce.js
+++ b/server/pipeline/noiseReduce.js
@@ -227,6 +227,11 @@ export async function runRnnoise(
   return {
     speechProbOut: sidecarPath,
     vadGate:       result?.vad_gate ?? null,
+    // Python-side bucket timings (load / resample_in / denoise / vad_gate /
+    // resample_out / write / sidecar / total, all milliseconds). The caller's
+    // sub-stage log line surfaces these alongside the JS-side harness buckets
+    // so the codec-vs-harness ratio is readable in one line.
+    timingMs:      result?.timing_ms ?? null,
   }
 }
 

--- a/server/pipeline/sileroParallel.js
+++ b/server/pipeline/sileroParallel.js
@@ -64,6 +64,24 @@ const { FRAME_DURATION_S } = JSON.parse(
 const SILERO_SR = 16000  // VAD input is pre-resampled to 16 kHz mono by the caller
 
 /**
+ * Read a numeric env var, falling back to `fallback` for unset, empty,
+ * non-numeric, non-finite, or out-of-range values. Keeps a fat-fingered .env
+ * from poisoning the planner/carve math with NaN (which would otherwise throw
+ * at targetS.toFixed() or propagate into extractAudioRange sample indices).
+ *
+ * @param {string} name
+ * @param {number} fallback
+ * @param {{ min?: number, integer?: boolean }} [opts]
+ */
+function envNum(name, fallback, { min = 0, integer = false } = {}) {
+  const raw = process.env[name]
+  if (raw == null || raw === '') return fallback
+  const n = integer ? parseInt(raw, 10) : parseFloat(raw)
+  if (!Number.isFinite(n) || n < min) return fallback
+  return n
+}
+
+/**
  * Classify a 16 kHz mono VAD input in parallel. See module header.
  *
  * @param {string} vadInputPath  16 kHz mono float32 WAV (the caller's pre-resampled VAD input)
@@ -120,9 +138,11 @@ export async function classifySileroVadParallel(vadInputPath, {
   // Aim for roughly one chunk per worker; planChunkBoundaries clamps to its
   // min/max and snaps each seam to the nearest qualifying silence region.
   const totalS    = total16k / sr16
-  const minChunkS = parseFloat(process.env.SILERO_PARALLEL_MIN_CHUNK_S ?? '20')
-  const maxChunkS = parseFloat(process.env.SILERO_PARALLEL_MAX_CHUNK_S ?? '600')
-  const minSilMs  = parseInt(process.env.SILERO_PARALLEL_MIN_SILENCE_MS ?? '500', 10)
+  const minChunkS = envNum('SILERO_PARALLEL_MIN_CHUNK_S', 20, { min: 1 })
+  // Keep max ≥ min even if the operator inverts them, so the planner clamp
+  // window stays well-formed.
+  const maxChunkS = Math.max(minChunkS, envNum('SILERO_PARALLEL_MAX_CHUNK_S', 600, { min: 1 }))
+  const minSilMs  = envNum('SILERO_PARALLEL_MIN_SILENCE_MS', 500, { min: 0, integer: true })
   const targetS   = Math.min(maxChunkS, Math.max(minChunkS, totalS / poolSize))
 
   const plan = planChunkBoundaries({
@@ -152,7 +172,7 @@ export async function classifySileroVadParallel(vadInputPath, {
   cores[0].coreStartFrame              = 0
   cores[cores.length - 1].coreEndFrame = nPlan
 
-  const warmupS      = parseFloat(process.env.SILERO_PARALLEL_WARMUP_S ?? '2')
+  const warmupS      = envNum('SILERO_PARALLEL_WARMUP_S', 2, { min: 0 })
   const warmupFrames = Math.max(0, Math.round(warmupS * SILERO_SR / samplesPerFrame))
 
   const limit = Math.min(cores.length, poolSize)

--- a/server/pipeline/sileroParallel.js
+++ b/server/pipeline/sileroParallel.js
@@ -1,0 +1,222 @@
+/**
+ * Parallel Silero VAD classification.
+ *
+ * The whole-file Silero subprocess — one call over the full 16 kHz stream in
+ * the analyzeFramesRaw stage — is the slowest analysis pass in the pipeline,
+ * and (unlike the NR block) it runs whole-file with no parallelism because the
+ * chunk planner downstream consumes its output. This module breaks that
+ * chicken-and-egg: it splits the 16 kHz VAD input into silence-snapped chunks,
+ * runs the UNCHANGED silero_vad.py on each in parallel across the worker pool,
+ * and reassembles a global per-frame isSilence array identical in shape to the
+ * single-call output. The caller's energy/noise-floor math and the Silero↔energy
+ * merge are untouched — only the subprocess dispatch is parallelized.
+ *
+ * Determinism. Two mechanisms keep the chunked labels equal to the whole-file
+ * run within each chunk's core region:
+ *
+ *   1. Silence-snapped seams. Split points are chosen in energy-silence regions
+ *      (the cheap per-frame RMS the caller already computed), so the model
+ *      enters each core from established silence rather than mid-word.
+ *   2. Warm-up overlap. Each core is preceded by a warm-up region that is fed
+ *      to the model but whose frames are discarded. Silero's GRU hidden state
+ *      and its trigger / neg-trigger hysteresis (get_speech_timestamps runs
+ *      with min_speech/min_silence = 0, so the only cross-frame dependency is
+ *      that 2-state machine) converge during warm-up before the first emitted
+ *      frame. Warm-up duration is generous relative to the model's ~few-hundred
+ *      -ms effective context.
+ *
+ * Any residual ±1-frame difference at a seam lands inside silence and is
+ * absorbed by the downstream energy-gated boundary expansion in
+ * frameAnalysis.js. To A/B the parallel vs. whole-file labels, set
+ * SILERO_PARALLEL=0 to force the single-call path.
+ *
+ * Returns { frames: [{ index, isSilence }] } with GLOBAL frame indices — the
+ * same shape the single Silero call's JSON produces — or null when the file is
+ * too short / unsplittable or parallelism is disabled, signalling the caller to
+ * use the single whole-file call.
+ *
+ * Env knobs:
+ *   SILERO_PARALLEL            — '0' disables (default: enabled)
+ *   PYTHON_WORKER_POOL_SIZE    — bounds concurrency; <2 disables (no benefit)
+ *   SILERO_PARALLEL_WARMUP_S   — warm-up overlap seconds (default: 2)
+ *   SILERO_PARALLEL_MIN_CHUNK_S, _MAX_CHUNK_S, _MIN_SILENCE_MS — planner overrides
+ */
+
+import { readFile, rm }   from 'fs/promises'
+import { readFileSync }   from 'fs'
+import { fileURLToPath }  from 'url'
+import path               from 'path'
+
+import { readWavHeader }                          from './wavReader.js'
+import { planChunkBoundaries }                    from './chunking.js'
+import { extractAudioRange, tempPath, removeTmp } from '../lib/ffmpeg.js'
+
+// Read the shared frame duration directly (same source silero_vad.py and
+// frameAnalysis.js use) rather than importing from frameAnalysis.js, which
+// would form an import cycle (frameAnalysis → this module → frameAnalysis).
+const { FRAME_DURATION_S } = JSON.parse(
+  readFileSync(
+    path.join(path.dirname(fileURLToPath(import.meta.url)), '..', 'config', 'frame_config.json'),
+    'utf8',
+  )
+)
+
+const SILERO_SR = 16000  // VAD input is pre-resampled to 16 kHz mono by the caller
+
+/**
+ * Classify a 16 kHz mono VAD input in parallel. See module header.
+ *
+ * @param {string} vadInputPath  16 kHz mono float32 WAV (the caller's pre-resampled VAD input)
+ * @param {object} opts
+ * @param {Float64Array|number[]} opts.energyFrameRms  Per-frame linear RMS (caller's whole-file energy pass)
+ * @param {number} opts.silenceThresholdDbfs           Energy silence threshold (noise floor + 6 dB)
+ * @param {number} opts.numFrames                      Caller's frame count
+ * @param {(inputPath: string, outputJsonPath: string) => Promise<any>} opts.runVad
+ *        Dispatcher that runs silero_vad.py on inputPath and writes labels to outputJsonPath
+ *        (the caller's spawnSilero — keeps the worker-pool routing in one place).
+ * @param {(msg: string) => void} [opts.log]
+ * @returns {Promise<{ frames: Array<{ index: number, isSilence: boolean }> } | null>}
+ */
+export async function classifySileroVadParallel(vadInputPath, {
+  energyFrameRms,
+  silenceThresholdDbfs,
+  numFrames,
+  runVad,
+  log = console.log,
+}) {
+  if (process.env.SILERO_PARALLEL === '0') return null
+
+  const poolSize = Math.max(1, parseInt(process.env.PYTHON_WORKER_POOL_SIZE ?? '1', 10) || 1)
+  if (poolSize < 2) return null  // single worker — chunks would run serially anyway
+
+  const samplesPerFrame = Math.round(FRAME_DURATION_S * SILERO_SR)  // 400 @ 25 ms / 16 kHz
+
+  const { numSamples: total16k, sampleRate: sr16 } = await readWavHeader(vadInputPath)
+  if (sr16 !== SILERO_SR) {
+    // Caller is expected to pre-resample to 16 kHz. If that contract ever
+    // changes, fall back to the single-call path rather than mis-mapping frames.
+    log(`[silero] parallel VAD skipped — input is ${sr16} Hz, expected ${SILERO_SR}`)
+    return null
+  }
+
+  // Frames whose 16 kHz sample range fits in the VAD input. The caller's
+  // energyFrameRms is on the same 25 ms time grid, so index f maps to 16 kHz
+  // sample f * samplesPerFrame regardless of the 44.1 kHz source rate.
+  const nPlan = Math.min(numFrames, Math.floor(total16k / samplesPerFrame))
+  if (nPlan < 2) return null
+
+  // Build a synthetic frame array carrying only the energy silence mask — all
+  // planChunkBoundaries needs to snap seams to quiet regions.
+  const threshLinear = Math.pow(10, silenceThresholdDbfs / 20)
+  const planFrames = new Array(nPlan)
+  for (let f = 0; f < nPlan; f++) {
+    planFrames[f] = {
+      offsetSamples: f * samplesPerFrame,
+      lengthSamples: samplesPerFrame,
+      isSilence:     energyFrameRms[f] < threshLinear,
+    }
+  }
+
+  // Aim for roughly one chunk per worker; planChunkBoundaries clamps to its
+  // min/max and snaps each seam to the nearest qualifying silence region.
+  const totalS    = total16k / sr16
+  const minChunkS = parseFloat(process.env.SILERO_PARALLEL_MIN_CHUNK_S ?? '20')
+  const maxChunkS = parseFloat(process.env.SILERO_PARALLEL_MAX_CHUNK_S ?? '600')
+  const minSilMs  = parseInt(process.env.SILERO_PARALLEL_MIN_SILENCE_MS ?? '500', 10)
+  const targetS   = Math.min(maxChunkS, Math.max(minChunkS, totalS / poolSize))
+
+  const plan = planChunkBoundaries({
+    frames:       planFrames,
+    sampleRate:   sr16,
+    totalSamples: nPlan * samplesPerFrame,
+    options: {
+      targetChunkDurationS: targetS,
+      minChunkDurationS:    minChunkS,
+      maxChunkDurationS:    maxChunkS,
+      minSilenceMs:         minSilMs,
+    },
+  })
+
+  if (plan.chunks.length < 2) {
+    log(`[silero] parallel VAD skipped — ${plan.reason ?? 'single-chunk plan'}`)
+    return null
+  }
+
+  // Snap each chunk boundary to the frame grid so global frame indices map
+  // cleanly to 16 kHz samples (frame f ↔ sample f * samplesPerFrame). Seams sit
+  // in silence, so a sub-frame snap is inaudible and label-neutral.
+  const cores = plan.chunks.map((c) => ({
+    coreStartFrame: Math.round(c.startSample / samplesPerFrame),
+    coreEndFrame:   Math.round(c.endSample   / samplesPerFrame),
+  }))
+  cores[0].coreStartFrame              = 0
+  cores[cores.length - 1].coreEndFrame = nPlan
+
+  const warmupS      = parseFloat(process.env.SILERO_PARALLEL_WARMUP_S ?? '2')
+  const warmupFrames = Math.max(0, Math.round(warmupS * SILERO_SR / samplesPerFrame))
+
+  const limit = Math.min(cores.length, poolSize)
+  log(
+    `[silero] parallel VAD: ${cores.length} chunks across ${limit} workers ` +
+    `(target ${targetS.toFixed(0)}s, warmup ${warmupS}s)`
+  )
+
+  const perChunkFrames = new Array(cores.length)
+
+  const processChunk = async (i) => {
+    const { coreStartFrame, coreEndFrame } = cores[i]
+    // Warm-up only needs to PRECEDE the core (the hysteresis is causal); a
+    // trailing pad guards the boundary-frame mapping at the core's tail.
+    const carveStartFrame = Math.max(0,     coreStartFrame - warmupFrames)
+    const carveEndFrame   = Math.min(nPlan, coreEndFrame   + warmupFrames)
+    const carveStart      = carveStartFrame * samplesPerFrame
+    const carveEnd        = Math.min(total16k, carveEndFrame * samplesPerFrame)
+
+    const subWav  = tempPath('.wav')
+    const subJson = subWav.replace(/\.wav$/i, '') + '.silvad.json'
+    try {
+      await extractAudioRange(vadInputPath, subWav, carveStart, carveEnd)
+      await runVad(subWav, subJson)
+      const raw = JSON.parse(await readFile(subJson, 'utf8'))
+
+      // Rebase local frame indices to global and keep only the core region.
+      // Local frame k starts at global sample carveStart + k * samplesPerFrame;
+      // carveStart is frame-aligned, so global frame = carveStartFrame + k.
+      const kept = []
+      for (const fr of raw.frames) {
+        const g = carveStartFrame + fr.index
+        if (g >= coreStartFrame && g < coreEndFrame) {
+          kept.push({ index: g, isSilence: fr.isSilence })
+        }
+      }
+      perChunkFrames[i] = kept
+    } finally {
+      await rm(subJson, { force: true })
+      await removeTmp(subWav)
+    }
+  }
+
+  // Bounded-concurrency dispatch. Inlined (rather than importing the chunked
+  // runner's helper) to avoid an import cycle through frameAnalysis.js. First
+  // rejection propagates; a thrown error lets the caller fall back to the
+  // energy backend via analyzeFrames()'s existing try/catch.
+  let next = 0
+  let firstError = null
+  const workers = Array.from({ length: limit }, async () => {
+    while (firstError == null) {
+      const i = next++
+      if (i >= cores.length) return
+      try {
+        await processChunk(i)
+      } catch (err) {
+        if (firstError == null) firstError = err
+        return
+      }
+    }
+  })
+  await Promise.all(workers)
+  if (firstError) throw firstError
+
+  // Cores tile [0, nPlan) in ascending order; flattening preserves global order.
+  return { frames: perChunkFrames.flat() }
+}

--- a/server/pipeline/stages.js
+++ b/server/pipeline/stages.js
@@ -557,8 +557,19 @@ export async function noiseReduce(ctx) {
   // Uses the existing Silero VAD isSilence labels so only speech frames
   // contribute. This isolates the speech-level delta from the (desired)
   // noise-floor reduction.
+  // Sub-stage timings collected for the diagnostic log line at the bottom of
+  // this function. Lets us see whether the codec call or the JS-side harness
+  // (the two remeasureFrames passes + optional makeupGain ffmpeg) dominates,
+  // and — for models that report it — surfaces the Python-side bucket
+  // breakdown returned in the result dict.
+  const tNr     = Date.now()
+  const tPreRem = Date.now()
   const preFa = await remeasureFrames(ctx.currentPath, ctx.results.metrics)
+  const preRemeasureMs = Date.now() - tPreRem
   const preVoicedRms = preFa.voicedRmsDbfs
+
+  let runMs           = 0
+  let pythonTimingMs  = null   // {load, resample_in, denoise, vad_gate, resample_out, write, sidecar, total} when present
 
   if (model === 'rnnoise') {
     // Pass the pipeline's Silero VAD labels through to the RNNoise script so
@@ -567,10 +578,13 @@ export async function noiseReduce(ctx) {
     // internal VAD on fricative onsets it misclassifies as noise.
     const sileroFrames = ctx.results.metrics?.frames ?? null
     const vadGate      = ctx.preset.noiseReduce?.vadGate ?? null
+    const tRun = Date.now()
     const rnnInfo = await runRnnoise(ctx.currentPath, outPath, {
       sileroFrames,
       vadGate,
     })
+    runMs = Date.now() - tRun
+    pythonTimingMs = rnnInfo?.timingMs ?? null
     ctx.currentPath = outPath
     ctx.results.noiseReduction = {
       applied: true,
@@ -586,7 +600,9 @@ export async function noiseReduce(ctx) {
       ctx.log(`[NR] RNNoise speech_prob sidecar → ${rnnInfo.speechProbOut}`)
     }
   } else if (model === 'dtln') {
+    const tRun = Date.now()
     await runDtln(ctx.currentPath, outPath)
+    runMs = Date.now() - tRun
     ctx.currentPath = outPath
     ctx.results.noiseReduction = {
       applied: true,
@@ -597,7 +613,10 @@ export async function noiseReduce(ctx) {
     }
   } else {
     // df3 (default) — uncapped; the model adapts per time-frequency bin
+    const tRun = Date.now()
     const nrResult = await applyNoiseReduction(ctx.currentPath, outPath)
+    runMs = Date.now() - tRun
+    pythonTimingMs = nrResult?.timingMs ?? null
     nrResult.pre_noise_floor_dbfs = preNoiseFloor
     ctx.currentPath = outPath
     ctx.results.noiseReduction = nrResult
@@ -610,9 +629,13 @@ export async function noiseReduce(ctx) {
   // aggressively. Measure the voiced-RMS delta and apply linear makeup gain
   // so downstream stages (compression, expander) see the expected level.
   let postFa = null
-  let appliedMakeupDb = 0
+  let appliedMakeupDb   = 0
+  let postRemeasureMs   = 0
+  let makeupGainMs      = 0
   if (preVoicedRms !== null && preVoicedRms !== undefined) {
+    const tPostRem = Date.now()
     postFa = await remeasureFrames(ctx.currentPath, ctx.results.metrics)
+    postRemeasureMs = Date.now() - tPostRem
     const postVoicedRms = postFa.voicedRmsDbfs
 
     if (postVoicedRms !== null && postVoicedRms !== undefined) {
@@ -621,7 +644,9 @@ export async function noiseReduce(ctx) {
 
       if (makeupDb > NR_MAKEUP_THRESHOLD_DB) {
         const gainedPath = ctx.tmp('.wav')
+        const tMakeup = Date.now()
         await applyLinearGain(ctx.currentPath, gainedPath, makeupDb)
+        makeupGainMs = Date.now() - tMakeup
         ctx.currentPath = gainedPath
         appliedMakeupDb = makeupDb
         ctx.results.noiseReduction.makeupGainDb = round2(makeupDb)
@@ -659,6 +684,31 @@ export async function noiseReduce(ctx) {
       ctx.results.noiseReduction.post_noise_floor_dbfs = ctx.results.metrics.noiseFloorDbfs
     }
   }
+
+  // Sub-stage timing breakdown. JS-side buckets tell us whether the codec
+  // call (run) or the harness (preRem + postRem + makeup) dominates; the
+  // Python-side bucket array (when present) breaks the run bucket down
+  // further into load / resample / denoise / vad_gate / resample_out / write.
+  // harnessMs is the sum of the JS-only passes around the codec call, so
+  // run / harness is the headline ratio.
+  const totalMs   = Date.now() - tNr
+  const harnessMs = preRemeasureMs + postRemeasureMs + makeupGainMs
+  let timingLine =
+    `[NR-timing] model=${model} total=${totalMs}ms ` +
+    `run=${runMs}ms harness=${harnessMs}ms ` +
+    `(preRem=${preRemeasureMs}ms postRem=${postRemeasureMs}ms makeup=${makeupGainMs}ms)`
+  if (pythonTimingMs && typeof pythonTimingMs === 'object') {
+    const py = pythonTimingMs
+    // Only surface buckets that fired; vad_gate/sidecar are conditional.
+    const parts = []
+    for (const key of ['load','resample_in','denoise','vad_gate','resample_out','write','sidecar']) {
+      const v = py[key]
+      if (typeof v === 'number' && v > 0) parts.push(`${key}=${Math.round(v)}ms`)
+    }
+    const pyTotal = typeof py.total === 'number' ? `${Math.round(py.total)}ms` : '?'
+    timingLine += `  py=${pyTotal} {${parts.join(' ')}}`
+  }
+  ctx.log(timingLine)
 
   await logLevel(ctx, `after NR (${model})`, ctx.currentPath, {
     preNoiseFloor: `${preNoiseFloor}dBFS`,

--- a/server/scripts/rnnoise_denoise.py
+++ b/server/scripts/rnnoise_denoise.py
@@ -43,6 +43,7 @@ Artifact assessment is deferred to Stage NE-4 (post-separation validation).
 import argparse
 import json
 import sys
+import time
 import warnings
 
 warnings.filterwarnings('ignore')
@@ -274,6 +275,23 @@ def main(argv=None):
                   file=sys.stderr)
             silero_mask = None
 
+    # Sub-stage timing buckets. Surfaced to JS in the result dict as
+    # `timing_ms` so the harness-vs-codec ratio is readable in a single log
+    # line. perf_counter is monotonic and high-resolution; bucket totals add
+    # up to total_ms within a few ms of `time.perf_counter()` jitter.
+    timing_ms = {
+        'load':         0.0,
+        'resample_in':  0.0,
+        'denoise':      0.0,
+        'vad_gate':     0.0,
+        'resample_out': 0.0,
+        'write':        0.0,
+        'sidecar':      0.0,
+        'total':        0.0,
+    }
+    _total_start = time.perf_counter()
+    _t = time.perf_counter()
+
     # Load input — pipeline format is 32-bit float 44.1 kHz
     # wavfile returns (samples,) mono or (samples, channels) stereo
     sr, audio_np = wavfile.read(args.input)
@@ -301,9 +319,12 @@ def main(argv=None):
         np.zeros((waveform.shape[0], pad_samples_in), dtype=waveform.dtype),
         waveform,
     ], axis=1)
+    timing_ms['load'] = (time.perf_counter() - _t) * 1000.0
+    _t = time.perf_counter()
 
     # Resample to 48 kHz for RNNoise
     waveform = _resample(waveform, sr, RNNOISE_SR)
+    timing_ms['resample_in'] = (time.perf_counter() - _t) * 1000.0
 
     # Apply RNNoise via the streaming denoise_chunk API.
     #
@@ -328,6 +349,7 @@ def main(argv=None):
     speech_probs = None      # np.ndarray[float32] when populated
     silero_per_rnn = None    # np.ndarray[bool], one entry per RNNoise frame
     vad_gate_stats = None
+    _t = time.perf_counter()
     if rnn is not None:
         pcm16 = np.clip(waveform[0] * 32767, -32768, 32767).astype(np.int16)
 
@@ -405,6 +427,9 @@ def main(argv=None):
                 # sample it cleaned, so a naïve same-index mix would splice
                 # the onset's "future" onto its denoised position — audible
                 # as a 20 ms doubled onset at every override boundary.
+                # Subtract this from the denoise bucket so the gate's cost
+                # is reported in isolation.
+                _t_gate = time.perf_counter()
                 vad_gate_stats = _apply_vad_gate(
                     denoised_pcm16,
                     pcm16,
@@ -415,6 +440,7 @@ def main(argv=None):
                     algo_delay_samples=algo_delay_frames * (RNNOISE_SR // 100),
                     hangover_frames=args.hangover_frames,
                 )
+                timing_ms['vad_gate'] = (time.perf_counter() - _t_gate) * 1000.0
                 # _apply_vad_gate returns the gated buffer under '_buffer'
                 # alongside the stats; pop it out before reporting.
                 denoised_pcm16 = vad_gate_stats.pop('_buffer')
@@ -428,8 +454,14 @@ def main(argv=None):
         print('[rnnoise] WARNING: pyrnnoise not installed — NE-1 pre-pass skipped, '
               'passing audio through unchanged.', file=sys.stderr)
 
+    # Bucket includes the silero_per_rnn resolve + denoise loop; vad_gate has
+    # already been subtracted into its own bucket above when active.
+    timing_ms['denoise'] = max(0.0, (time.perf_counter() - _t) * 1000.0 - timing_ms['vad_gate'])
+
     # Resample back to 44.1 kHz (pipeline internal format)
+    _t = time.perf_counter()
     waveform = _resample(waveform, RNNOISE_SR, PIPELINE_SR)
+    timing_ms['resample_out'] = (time.perf_counter() - _t) * 1000.0
 
     # Strip 20 ms internal pad + 20 ms RNNoise algorithmic delay = 40 ms total.
     # After the strip the leading edge is the original audio at its correct
@@ -451,13 +483,16 @@ def main(argv=None):
         ], axis=1)
 
     # Write 32-bit float WAV at 44.1 kHz, mono
+    _t = time.perf_counter()
     wavfile.write(args.output, PIPELINE_SR, waveform[0].astype(np.float32))
+    timing_ms['write'] = (time.perf_counter() - _t) * 1000.0
 
     # Diagnostic: dump per-frame VAD speech_prob curve from pyrnnoise.
     # Each yielded frame is 10 ms at 48 kHz. Output frame index `i` aligns
     # with original-audio time `(i - strip_frames) * 10` ms. The Silero mask
     # (if any) was already resolved onto the RNNoise frame grid above so the
     # gate and the dump share the same alignment.
+    _t = time.perf_counter()
     if args.speech_prob_out and speech_probs is not None and speech_probs.size > 0:
         arr = speech_probs.astype(np.float64, copy=False)
         sidecar = {
@@ -505,9 +540,13 @@ def main(argv=None):
             print(f"[rnnoise] WARNING: failed to write speech_prob sidecar "
                   f"({args.speech_prob_out}): {e}", file=sys.stderr)
 
+    timing_ms['sidecar'] = (time.perf_counter() - _t) * 1000.0
+    timing_ms['total']   = (time.perf_counter() - _total_start) * 1000.0
+
     result = {
         'model': 'RNNoise',
         'speech_prob_out': args.speech_prob_out if args.speech_prob_out else None,
+        'timing_ms': {k: round(v, 1) for k, v in timing_ms.items()},
     }
     if vad_gate_stats is not None:
         # Strip any internal-only keys before surfacing to the caller.

--- a/server/test/sileroParallel.test.js
+++ b/server/test/sileroParallel.test.js
@@ -86,7 +86,20 @@ async function stubRunVad(inputPath, outputJsonPath) {
   await writeFile(outputJsonPath, JSON.stringify({ frames }))
 }
 
+// Env keys this suite mutates. Captured in before() and restored in after()
+// so leaked values can't make sibling tests order-dependent when node:test
+// shares a process.
+const MUTATED_ENV = [
+  'PYTHON_WORKER_POOL_SIZE',
+  'SILERO_PARALLEL',
+  'SILERO_PARALLEL_MIN_CHUNK_S',
+  'SILERO_PARALLEL_MAX_CHUNK_S',
+  'SILERO_PARALLEL_WARMUP_S',
+]
+const SAVED_ENV = {}
+
 before(() => {
+  for (const k of MUTATED_ENV) SAVED_ENV[k] = process.env[k]
   // Parallelism is gated on a multi-worker pool; the planner minimum is lowered
   // so the short fixture splits.
   process.env.PYTHON_WORKER_POOL_SIZE     = '4'
@@ -97,6 +110,10 @@ before(() => {
 })
 
 after(async () => {
+  for (const k of MUTATED_ENV) {
+    if (SAVED_ENV[k] === undefined) delete process.env[k]
+    else process.env[k] = SAVED_ENV[k]
+  }
   for (const f of TEMP_FILES) await removeTmp(f)
 })
 

--- a/server/test/sileroParallel.test.js
+++ b/server/test/sileroParallel.test.js
@@ -1,0 +1,184 @@
+/**
+ * Tests for the parallel Silero VAD path (sileroParallel.js).
+ *
+ * The model itself is replaced by a deterministic, frame-local energy stub:
+ * each 25 ms frame is labelled silence/voiced purely from its own RMS against a
+ * fixed threshold. Because that labelling is context-independent, the parallel
+ * carve → per-chunk dispatch → rebase → reassemble pipeline MUST reproduce a
+ * whole-file run exactly (the warm-up overlap and seam placement only matter
+ * for the real GRU's state; they cannot change a frame-local label). Any
+ * off-by-one in global-frame rebasing or core-region keeping shows up as a
+ * mismatch here.
+ *
+ * Real FFmpeg is used for the sub-chunk carves (extractAudioRange), matching
+ * the rest of the suite. No Python / torch is involved.
+ *
+ * Run with:  cd server && npm test
+ */
+
+import { test, after, before } from 'node:test'
+import assert from 'node:assert/strict'
+import { writeFile, readFile } from 'node:fs/promises'
+
+import { tempPath, removeTmp }            from '../lib/ffmpeg.js'
+import { runFfmpeg }                      from '../lib/exec-ffmpeg.js'
+import { readWavSamples }                 from '../pipeline/wavReader.js'
+import { classifySileroVadParallel }      from '../pipeline/sileroParallel.js'
+
+const TEMP_FILES = []
+const SR             = 16000
+const FRAME_SAMPLES  = Math.round(0.025 * SR)  // 400 — must match frame_config.json
+const STUB_THRESH_DB = -50                     // fixed silence threshold for the stub VAD
+
+/**
+ * Build a 16 kHz mono WAV: alternating sine tones and 1 s digital-silence pads,
+ * long enough (and with enough qualifying silences) to force a multi-chunk plan
+ * once the planner minimum is overridden down.
+ */
+async function makeSplittableWav(durationSec) {
+  const outPath = tempPath('.wav')
+  TEMP_FILES.push(outPath)
+  const segSec = durationSec / 4 - 0.75
+  const sil = `anullsrc=cl=mono:r=${SR}`
+  await runFfmpeg([
+    '-f', 'lavfi', '-i', `sine=frequency=300:sample_rate=${SR}:duration=${segSec}`,
+    '-f', 'lavfi', '-i', sil,
+    '-f', 'lavfi', '-i', `sine=frequency=400:sample_rate=${SR}:duration=${segSec}`,
+    '-f', 'lavfi', '-i', sil,
+    '-f', 'lavfi', '-i', `sine=frequency=500:sample_rate=${SR}:duration=${segSec}`,
+    '-f', 'lavfi', '-i', sil,
+    '-f', 'lavfi', '-i', `sine=frequency=600:sample_rate=${SR}:duration=${segSec}`,
+    '-filter_complex',
+      `[1:a]atrim=duration=1,asetpts=PTS-STARTPTS[s1];` +
+      `[3:a]atrim=duration=1,asetpts=PTS-STARTPTS[s2];` +
+      `[5:a]atrim=duration=1,asetpts=PTS-STARTPTS[s3];` +
+      `[0:a][s1][2:a][s2][4:a][s3][6:a]concat=n=7:v=0:a=1[out]`,
+    '-map', '[out]',
+    '-c:a', 'pcm_f32le',
+    '-ac', '1',
+    outPath,
+  ])
+  return outPath
+}
+
+/** Per-frame RMS (linear) over 400-sample frames of a mono buffer. */
+function frameRmsLinear(samples) {
+  const n = Math.floor(samples.length / FRAME_SAMPLES)
+  const rms = new Float64Array(n)
+  for (let f = 0; f < n; f++) {
+    let sumSq = 0
+    const start = f * FRAME_SAMPLES
+    for (let i = start; i < start + FRAME_SAMPLES; i++) sumSq += samples[i] * samples[i]
+    rms[f] = Math.sqrt(sumSq / FRAME_SAMPLES)
+  }
+  return rms
+}
+
+/** Frame-local energy stub standing in for silero_vad.py. */
+async function stubRunVad(inputPath, outputJsonPath) {
+  const { samples } = await readWavSamples(inputPath)
+  const rms = frameRmsLinear(samples)
+  const threshLin = Math.pow(10, STUB_THRESH_DB / 20)
+  const frames = []
+  for (let f = 0; f < rms.length; f++) {
+    frames.push({ index: f, isSilence: rms[f] < threshLin })
+  }
+  await writeFile(outputJsonPath, JSON.stringify({ frames }))
+}
+
+before(() => {
+  // Parallelism is gated on a multi-worker pool; the planner minimum is lowered
+  // so the short fixture splits.
+  process.env.PYTHON_WORKER_POOL_SIZE     = '4'
+  process.env.SILERO_PARALLEL             = '1'
+  process.env.SILERO_PARALLEL_MIN_CHUNK_S = '5'
+  process.env.SILERO_PARALLEL_MAX_CHUNK_S = '600'
+  process.env.SILERO_PARALLEL_WARMUP_S    = '1'
+})
+
+after(async () => {
+  for (const f of TEMP_FILES) await removeTmp(f)
+})
+
+test('parallel Silero reassembles frame labels identically to a whole-file run', async () => {
+  const input = await makeSplittableWav(60)  // 60 s → target ≈ 15 s/chunk → multi-chunk
+
+  const { samples } = await readWavSamples(input)
+  const energyFrameRms = frameRmsLinear(samples)
+  const numFrames      = energyFrameRms.length
+
+  // Whole-file reference: run the same stub once over the entire input.
+  const wholeJson = tempPath('.json')
+  TEMP_FILES.push(wholeJson)
+  await stubRunVad(input, wholeJson)
+  const wholeFrames = JSON.parse(await readFile(wholeJson, 'utf8')).frames
+  const wholeLabel  = new Map(wholeFrames.map(f => [f.index, f.isSilence]))
+
+  // Parallel run — count dispatches to confirm the multi-chunk path was taken.
+  let dispatches = 0
+  const countingStub = (inp, out) => { dispatches++; return stubRunVad(inp, out) }
+
+  const result = await classifySileroVadParallel(input, {
+    energyFrameRms,
+    silenceThresholdDbfs: STUB_THRESH_DB,
+    numFrames,
+    runVad: countingStub,
+  })
+
+  assert.ok(result, 'expected a parallel result (not the single-call fallback)')
+  assert.ok(dispatches >= 2, `expected ≥2 chunk dispatches, got ${dispatches}`)
+
+  const nPlan = Math.min(numFrames, Math.floor(samples.length / FRAME_SAMPLES))
+
+  // Cores must tile [0, nPlan) with no gaps, no duplicates, ascending.
+  const indices = result.frames.map(f => f.index)
+  assert.equal(indices.length, nPlan, 'reassembled frame count should cover the planned range')
+  for (let f = 0; f < nPlan; f++) {
+    assert.equal(indices[f], f, `frame index gap/disorder at position ${f}`)
+  }
+
+  // Every reassembled label must equal the whole-file label exactly.
+  for (const { index, isSilence } of result.frames) {
+    assert.equal(isSilence, wholeLabel.get(index),
+      `label mismatch at frame ${index}: parallel=${isSilence} whole=${wholeLabel.get(index)}`)
+  }
+})
+
+test('SILERO_PARALLEL=0 forces the single-call fallback (returns null)', async () => {
+  const input = await makeSplittableWav(60)
+  const { samples } = await readWavSamples(input)
+  const energyFrameRms = frameRmsLinear(samples)
+
+  process.env.SILERO_PARALLEL = '0'
+  try {
+    const result = await classifySileroVadParallel(input, {
+      energyFrameRms,
+      silenceThresholdDbfs: STUB_THRESH_DB,
+      numFrames: energyFrameRms.length,
+      runVad: () => { throw new Error('runVad should not be called when disabled') },
+    })
+    assert.equal(result, null, 'expected null (caller falls back to single call)')
+  } finally {
+    process.env.SILERO_PARALLEL = '1'
+  }
+})
+
+test('single-worker pool disables parallelism (returns null)', async () => {
+  const input = await makeSplittableWav(60)
+  const { samples } = await readWavSamples(input)
+  const energyFrameRms = frameRmsLinear(samples)
+
+  const prev = process.env.PYTHON_WORKER_POOL_SIZE
+  process.env.PYTHON_WORKER_POOL_SIZE = '1'
+  try {
+    const result = await classifySileroVadParallel(input, {
+      energyFrameRms,
+      silenceThresholdDbfs: STUB_THRESH_DB,
+      numFrames: energyFrameRms.length,
+      runVad: () => { throw new Error('runVad should not be called with a single worker') },
+    })
+    assert.equal(result, null, 'expected null with a single-worker pool')
+  } finally {
+    process.env.PYTHON_WORKER_POOL_SIZE = prev
+  }
+})


### PR DESCRIPTION
## Summary

Adds parallel processing of Silero VAD (voice activity detection) across the worker pool to reduce wall-clock latency on long audio files. The single whole-file subprocess call — the slowest analysis pass in the pipeline — is now split into silence-snapped chunks that run concurrently, then reassembled into identical global frame labels.

## Key Changes

- **New module `sileroParallel.js`**: Implements chunked VAD processing with deterministic label reassembly
  - Splits 16 kHz VAD input at energy-silence seams to avoid mid-word boundaries
  - Adds warm-up overlap (default 2s) before each chunk's core region so the GRU hidden state and hysteresis converge before emitted frames
  - Rebases local frame indices to global and keeps only core-region labels
  - Returns null (falls back to single-call path) when file is too short, unsplittable, or parallelism is disabled
  - Configurable via environment variables: `SILERO_PARALLEL`, `PYTHON_WORKER_POOL_SIZE`, `SILERO_PARALLEL_WARMUP_S`, chunk size bounds, and minimum silence duration

- **Updated `frameAnalysis.js`**: Integrates parallel VAD path
  - Calls `classifySileroVadParallel()` before falling back to single whole-file `spawnSilero()` call
  - Passes energy frame RMS and silence threshold so the chunker can snap seams to quiet regions
  - Preserves existing energy/noise-floor math and Silero↔energy merge logic

- **New test suite `sileroParallel.test.js`**: Validates correctness of the parallel path
  - Uses a frame-local energy stub (context-independent labeling) in place of the real Silero model
  - Confirms reassembled labels match whole-file run exactly (off-by-one errors in rebasing or core-region keeping would show up as mismatches)
  - Tests fallback behavior when parallelism is disabled or pool size is 1
  - Generates a 60-second fixture with alternating tones and silence pads to force multi-chunk plans

## Implementation Details

**Determinism mechanisms:**
1. Silence-snapped seams: split points chosen in energy-silence regions so the model enters each core from established quiet
2. Warm-up overlap: each core is preceded by a discarded warm-up region where the GRU state and hysteresis converge before the first emitted frame

Any residual ±1-frame difference at a seam lands inside silence and is absorbed by downstream energy-gated boundary expansion in `frameAnalysis.js`.

**Bounded concurrency:** Inlined worker pool dispatch (avoiding import cycles) with first-error propagation to allow caller fallback via existing try/catch.

**Fallback conditions:** Returns null (triggering single-call path) when:
- `SILERO_PARALLEL=0` (disabled)
- Worker pool size < 2 (no concurrency benefit)
- File too short or unsplittable into multiple chunks
- Input sample rate is not 16 kHz (contract violation)

Set `SILERO_PARALLEL=0` to force the single whole-file call for A/B comparison.

https://claude.ai/code/session_01W9Jscy2VAaGM8JKRBrTbQD