### PR TITLE
Decouple serial thread budget from DF3 via SERIAL_TORCH_THREADS

### DIFF
--- a/server/.env.example
+++ b/server/.env.example
@@ -67,19 +67,38 @@ PORT=3001
 # Default: 0
 # WAVELY_DISABLE_PY_WORKER=1
 
-# Per-worker PyTorch thread cap. NOTE: DeepFilterNet3 pins thread count at
-# first inference and ignores later runtime changes, so set this conservatively
-# at process start. Rule of thumb: floor(vCPU / PYTHON_WORKER_POOL_SIZE).
+# Per-worker thread count applied at WORKER SPAWN (sets OMP/MKL/TORCH/RAYON env).
+# This is the value DeepFilterNet3 pins to at first inference and never changes
+# at runtime — so it's effectively the DF3 + chunked-block budget. Set it to
+# what's safe at full chunked concurrency: roughly floor(vCPU / CHUNKED_CONCURRENCY),
+# i.e. LOW. Do NOT raise this to speed up serial stages — that oversubscribes
+# DF3 in the chunked block. Use SERIAL_TORCH_THREADS for serial speed instead.
 # Default: floor(cpus / pool_size)
-# TORCH_NUM_THREADS=3
+# TORCH_NUM_THREADS=2
+
+# Per-call thread count for SERIAL (non-chunked) dispatches, applied at runtime.
+# NumPy / scipy / torch honor a runtime RAISE, so serial stages (corrective &
+# reference EQ, de-essers, sibilance, etc.) can run with more threads than the
+# low spawn-time default above. DF3 is unaffected — it only runs in the chunked
+# block and ignores runtime changes. This is the knob that decouples serial
+# throughput from the DF3/chunked budget. Unset → serial uses the spawn default.
+# Recommended pairing: TORCH_NUM_THREADS=2 (DF3/chunked) + SERIAL_TORCH_THREADS=6.
+# Default: unset (serial uses spawn env-default)
+# SERIAL_TORCH_THREADS=6
 
 # Per-call PyTorch thread cap used by the chunked block. The chunked runner
-# wraps each inner stage in withThreadLimit() so per-worker counts safe for
-# serial throughput are clamped back down when many chunks dispatch in
-# parallel. Best-effort: NumPy / scipy / RNNoise honor it, DeepFilterNet3 does
-# not (see TORCH_NUM_THREADS above).
+# wraps each inner stage in withThreadLimit() so concurrent chunks stay lean.
+# Best-effort: NumPy / scipy / RNNoise honor it, DeepFilterNet3 does not (it
+# uses the spawn-time TORCH_NUM_THREADS above).
 # Default: same as TORCH_NUM_THREADS
 # CHUNKED_TORCH_THREADS=2
+
+# libdf (DeepFilterNet's Rust core) Rayon pool size. Rayon reads this once at
+# first use and ignores runtime changes, so it MUST be set via env, not per
+# call — the reason a runtime RAYON_NUM_THREADS override has no effect. Defaults
+# to TORCH_NUM_THREADS (the DF3/chunked budget); rarely needs overriding.
+# Default: TORCH_NUM_THREADS
+# RAYON_NUM_THREADS=2
 
 # Max chunks processed in parallel inside a single {chunked: …} block. Capped
 # at min(this, PYTHON_WORKER_POOL_SIZE) — there is no benefit to more JS-side

--- a/server/pipeline/pythonWorker.js
+++ b/server/pipeline/pythonWorker.js
@@ -35,9 +35,15 @@
  * shrink the already-spawned worker threads. Empirical result on 8 vCPU:
  * TORCH_NUM_THREADS=6 + per-call=2 → DF3 oversubscribes anyway (1300+ s/chunk);
  * TORCH_NUM_THREADS=3 env-consistent → DF3 healthy (~85 s/chunk).
- * For stages where this matters (currently only DF3), set TORCH_NUM_THREADS
- * to the value that's safe at full chunked concurrency rather than relying
- * on the per-call path to clamp it. See GitHub issue for revisit.
+ * The fix exploits the asymmetry: non-DF3 stages can be RAISED at runtime, but
+ * DF3 cannot be LOWERED after its first inference. So spawn LOW (set
+ * TORCH_NUM_THREADS to the value safe at full chunked concurrency — this is
+ * what DF3 pins to) and RAISE serial stages via SERIAL_TORCH_THREADS, a
+ * per-call runtime hint that NumPy/scipy/torch honor. DF3 only runs inside the
+ * chunked block, so it is never raised; serial NumPy/scipy stages get more
+ * threads while DF3/chunked stay lean — no separate worker pools needed.
+ * (DF3 running *alone* still can't be raised — that single-process pin would
+ * need a second pool — but DF3 is always chunked here, so it doesn't arise.)
  *
  * Environment:
  *   SEPARATION_PYTHON         — Python executable (default: python3)
@@ -52,6 +58,16 @@
  *                                see note above on the DF3 limitation.
  *                                Defaults to min(TORCH_NUM_THREADS,
  *                                floor(cpus/pool_size)).
+ *   SERIAL_TORCH_THREADS      — per-call thread count for serial (non-chunked)
+ *                                dispatches, applied at runtime (raises NumPy/
+ *                                scipy/torch above the spawn-time DF3 budget).
+ *                                Unset → serial calls use the spawn env-default
+ *                                (prior behaviour). Typical: set TORCH_NUM_THREADS
+ *                                low for DF3/chunked and this higher for serial.
+ *   RAYON_NUM_THREADS         — libdf (DeepFilterNet Rust core) Rayon pool size,
+ *                                applied at worker spawn. Defaults to
+ *                                TORCH_NUM_THREADS. Runtime changes are ignored
+ *                                by Rayon, so it must be set via env.
  *   WAVELY_DISABLE_PY_WORKER  — set to '1' to force the legacy spawn path
  *                                in spawnPython.js (escape hatch)
  */
@@ -102,6 +118,30 @@ const CHUNKED_THREADS = (() => {
   return Math.min(torchDefault, safeDefault)
 })()
 
+// Serial-stage thread count. Serial (non-chunked) dispatches carry no
+// AsyncLocalStorage thread hint, so historically they ran at the worker's
+// spawn-time env default (NUM_THREADS). That couples them to the chunked/DF3
+// budget: raising NUM_THREADS to speed up serial NumPy/scipy stages also
+// raises the value DF3 pins to at first inference, oversubscribing the
+// chunked block.
+//
+// SERIAL_TORCH_THREADS breaks that coupling. When set, serial dispatches send
+// it as a per-call hint and _worker.py raises torch + OMP/MKL/OpenBLAS at
+// runtime (which those libraries honor) for that call. DF3 is unaffected — it
+// only runs inside the chunked block, and its threads are pinned to the spawn
+// env regardless of runtime hints. So the intended production setup is:
+//
+//   TORCH_NUM_THREADS=2     # spawn env → DF3 + chunked stages (concurrency × 2)
+//   SERIAL_TORCH_THREADS=6  # runtime raise → serial NumPy/scipy stages
+//
+// Unset → null → serial calls send no hint → identical to prior behaviour.
+const SERIAL_THREADS = (() => {
+  const explicit = process.env.SERIAL_TORCH_THREADS
+  if (!explicit) return null
+  const n = parseInt(explicit, 10)
+  return (Number.isFinite(n) && n > 0) ? n : null
+})()
+
 // ─── WorkerHandle ────────────────────────────────────────────────────────────
 
 /**
@@ -130,6 +170,15 @@ class WorkerHandle {
         OMP_NUM_THREADS:   NUM_THREADS,
         MKL_NUM_THREADS:   NUM_THREADS,
         TORCH_NUM_THREADS: NUM_THREADS,
+        // libdf (DeepFilterNet's Rust core) parallelises its DSP via Rayon,
+        // whose global pool reads RAYON_NUM_THREADS once at first use and
+        // ignores any later/runtime change — so it must be set here at spawn,
+        // not per-call. Pin it to the same DF3-safe budget as the torch pools
+        // so the chunked block doesn't oversubscribe through Rayon. Honor an
+        // explicit RAYON_NUM_THREADS from the environment if the operator set
+        // one. (A runtime RAYON_NUM_THREADS override is silently ignored by
+        // Rayon — the likely reason prior attempts had no effect.)
+        RAYON_NUM_THREADS: process.env.RAYON_NUM_THREADS ?? NUM_THREADS,
         PYTHONUNBUFFERED:  '1',
         PYTHONPATH: SCRIPTS_DIR + path.delimiter + (process.env.PYTHONPATH ?? ''),
       },
@@ -288,9 +337,13 @@ function drainQueue() {
 /**
  * Dispatch a script to an idle worker, or queue if all workers are busy.
  *
- * The per-call PyTorch thread count is read from the AsyncLocalStorage hint
- * set by the chunked runner; serial calls (no hint) fall back to the
- * worker's env-default. See threadingContext.js.
+ * Per-call thread count, in priority order:
+ *   1. the chunked runner's AsyncLocalStorage hint (set inside a chunked
+ *      block via withThreadLimit) — keeps concurrent chunks lean;
+ *   2. SERIAL_THREADS (SERIAL_TORCH_THREADS env) for serial dispatches —
+ *      raises NumPy/scipy/torch serial stages above the spawn-time DF3 budget;
+ *   3. null → no hint → the worker's spawn-time env-default.
+ * See threadingContext.js and the SERIAL_THREADS note above.
  *
  * @param {string}   script — module name (no .py), matches a file in server/scripts/
  * @param {string[]} argv   — argv-style args (e.g. ['--input', '/tmp/x.wav'])
@@ -299,7 +352,7 @@ function drainQueue() {
  */
 export function runPython(script, argv = [], label = script) {
   return new Promise((resolve, reject) => {
-    const threads = getThreadLimit()
+    const threads = getThreadLimit() ?? SERIAL_THREADS
     const task = { script, argv, label, threads, resolve, reject }
     const worker = findIdleWorker()
     if (worker) {

--- a/server/test/pythonWorkerPool.test.js
+++ b/server/test/pythonWorkerPool.test.js
@@ -142,3 +142,36 @@ test('pool size 1 preserves single-worker behaviour', async () => {
       `pool size 1 should route every call to the same worker; got pid ${r.pid} vs ${lonePid}`)
   }
 })
+
+test('SERIAL_TORCH_THREADS raises serial dispatches; chunked scope still wins', async () => {
+  // SERIAL_THREADS is captured at module load, so set the env and import a
+  // fresh module instance. The cache-busting query is only on pythonWorker —
+  // threadingContext is imported plainly so its AsyncLocalStorage instance is
+  // shared with the worker module's internal import (so withThreadLimit reaches
+  // getThreadLimit). Same reasoning as the withThreadLimit test above.
+  const prevSerial = process.env.SERIAL_TORCH_THREADS
+  const prevPool   = process.env.PYTHON_WORKER_POOL_SIZE
+  process.env.SERIAL_TORCH_THREADS    = '5'
+  process.env.PYTHON_WORKER_POOL_SIZE = '1'
+
+  const mod = await import(`../pipeline/pythonWorker.js?serial=${Date.now()}`)
+  const { withThreadLimit } = await import('../pipeline/threadingContext.js')
+  try {
+    // Serial dispatch (no chunked scope) now carries the SERIAL hint instead
+    // of falling back to the worker's spawn env-default.
+    const serial = await mod.runPython('__ping__', [], 'ping-serial')
+    assert.equal(serial.last_threads_hint, 5,
+      `serial call should send SERIAL_TORCH_THREADS=5; got ${serial.last_threads_hint}`)
+
+    // A chunked scope still takes priority over the serial default.
+    const chunked = await withThreadLimit(2, () => mod.runPython('__ping__', [], 'ping-chunked'))
+    assert.equal(chunked.last_threads_hint, 2,
+      `chunked scope should override the serial default; got ${chunked.last_threads_hint}`)
+  } finally {
+    await mod.stopWorker()
+    if (prevSerial === undefined) delete process.env.SERIAL_TORCH_THREADS
+    else process.env.SERIAL_TORCH_THREADS = prevSerial
+    if (prevPool === undefined) delete process.env.PYTHON_WORKER_POOL_SIZE
+    else process.env.PYTHON_WORKER_POOL_SIZE = prevPool
+  }
+})

--- a/server/test/pythonWorkerPool.test.js
+++ b/server/test/pythonWorkerPool.test.js
@@ -149,13 +149,16 @@ test('SERIAL_TORCH_THREADS raises serial dispatches; chunked scope still wins', 
   // threadingContext is imported plainly so its AsyncLocalStorage instance is
   // shared with the worker module's internal import (so withThreadLimit reaches
   // getThreadLimit). Same reasoning as the withThreadLimit test above.
+  // Ensure we don't keep a prior cached pool alive while spinning up a second
+  // pythonWorker module instance for this env-dependent test.
+  if (loadedModule) {
+    await loadedModule.stopWorker()
+    loadedModule = null
+    loadedPoolSize = null
+  }
+
   const prevSerial = process.env.SERIAL_TORCH_THREADS
   const prevPool   = process.env.PYTHON_WORKER_POOL_SIZE
-  process.env.SERIAL_TORCH_THREADS    = '5'
-  process.env.PYTHON_WORKER_POOL_SIZE = '1'
-
-  const mod = await import(`../pipeline/pythonWorker.js?serial=${Date.now()}`)
-  const { withThreadLimit } = await import('../pipeline/threadingContext.js')
   try {
     // Serial dispatch (no chunked scope) now carries the SERIAL hint instead
     // of falling back to the worker's spawn env-default.


### PR DESCRIPTION
## Summary

Adds runtime thread-count control for serial (non-chunked) Python dispatches, decoupling them from the spawn-time DF3 budget. This allows serial NumPy/scipy/torch stages to run with more threads than the conservative DF3 limit without oversubscribing the chunked block.

## Key Changes

- **New environment variable `SERIAL_TORCH_THREADS`**: Per-call thread hint for serial dispatches, applied at runtime. NumPy/scipy/torch honor the raise; DF3 is unaffected since it only runs in the chunked block and pins to spawn-time `TORCH_NUM_THREADS`.

- **Thread priority hierarchy in `runPython()`**: 
  1. Chunked scope hint (AsyncLocalStorage) — keeps concurrent chunks lean
  2. `SERIAL_TORCH_THREADS` — raises serial stages above DF3 budget
  3. Worker spawn-time env-default — fallback

- **New environment variable `RAYON_NUM_THREADS`**: Explicit control over libdf's (DeepFilterNet's Rust core) Rayon pool size. Since Rayon reads this once at first use and ignores runtime changes, it must be set at worker spawn. Defaults to `TORCH_NUM_THREADS` (the DF3/chunked budget).

- **Updated documentation**: Clarified threading model in comments and `.env.example`. The recommended production setup is now:
  ```
  TORCH_NUM_THREADS=2        # spawn env → DF3 + chunked (concurrency × 2)
  SERIAL_TORCH_THREADS=6     # runtime raise → serial NumPy/scipy stages
  ```

- **New test**: `SERIAL_TORCH_THREADS raises serial dispatches; chunked scope still wins` validates that serial dispatches receive the serial hint and that chunked scope still takes priority.

## Implementation Details

- `SERIAL_THREADS` is captured at module load (like `CHUNKED_THREADS`) to avoid repeated env reads.
- The per-call thread hint is passed to the worker and applied by `_worker.py` via environment variable at dispatch time.
- `RAYON_NUM_THREADS` is set in the worker spawn environment alongside other thread-pool variables (`OMP_NUM_THREADS`, `MKL_NUM_THREADS`, `TORCH_NUM_THREADS`).
- Unset `SERIAL_TORCH_THREADS` → `null` → serial calls send no hint → identical to prior behaviour (backward compatible).

https://claude.ai/code/session_01W9Jscy2VAaGM8JKRBrTbQD