### PR TITLE
humEQ: anchor on 120 Hz + F0 veto to stop notching vocal fundamentals

### DIFF
--- a/server/pipeline/humEQ.js
+++ b/server/pipeline/humEQ.js
@@ -103,13 +103,46 @@ export async function humEQ(inputPath, outputPath, options = {}) {
 }
 
 /**
+ * Build the FFmpeg equalizer filter string for a set of notch frequencies.
+ * Exported so the pipeline stage can rebuild the filter after F0-based veto
+ * trims the candidate set returned by analyzeHum().
+ */
+export function buildHumNotchFilter(frequencies, notchQ, notchDepth) {
+  if (!frequencies?.length) return null
+  return frequencies
+    .map(f => `equalizer=f=${f}:width_type=q:width=${notchQ}:g=-${notchDepth}`)
+    .join(',')
+}
+
+/**
  * Analyze audio for hum — detection only, no file I/O side effects.
  * The returned ffmpegFilter is built when triggered so the caller can apply it
  * directly (used by the pipeline stage to avoid a second analysis pass).
  *
+ * Detection model (June 2026): instead of evaluating each harmonic in
+ * isolation, the detector anchors on the 2nd harmonic (120 Hz for 60 Hz mains,
+ * 100 Hz for 50 Hz mains). The 2nd harmonic is a more reliable anchor than the
+ * fundamental because user-applied HPFs commonly suppress 60 Hz but leave
+ * 120 Hz essentially untouched — and 120 Hz hum (transformer core, magnetic
+ * coupling) is in practice more common than pure 60 Hz hum on modern gear.
+ *
+ * Coherence rules (with anchorDelta = anchor peak − floor):
+ *   • Nothing is flagged unless anchorDelta ≥ anchorMinDeltaDb (default 6).
+ *   • For k ≥ 3 (180 Hz+): Δₖ ≤ anchorDelta + slackForK. The default slack is
+ *     3 dB; 180 Hz uses 1 dB because it's a very common male F0 and the cost of
+ *     a false positive there is high.
+ *   • For k = 1 (60 Hz fundamental): no upper bound vs. anchor — real hum's
+ *     fundamental can be louder than the 2nd harmonic, and HPFs can push it
+ *     arbitrarily low. Standard detectionThreshold and minAbsoluteLevel apply.
+ *
+ * This is the first line of defense against misclassifying vocal fundamentals
+ * (typical F0 range 80–300 Hz) as hum. The pipeline stage adds a second line
+ * by vetoing any surviving candidate that overlaps the speaker's voiced F0
+ * histogram.
+ *
  * @param {string} inputPath
  * @param {object} options
- * @returns {Promise<{ triggered, flaggedHarmonics, detectionDetail, ffmpegFilter }>}
+ * @returns {Promise<{ triggered, flaggedHarmonics, detectionDetail, ffmpegFilter, anchorFrequency, anchorDeltaDb }>}
  */
 export async function analyzeHum(inputPath, options = {}) {
   const {
@@ -121,7 +154,18 @@ export async function analyzeHum(inputPath, options = {}) {
     notchQ                 = 30,
     analysisWindow         = 50,
     minAbsoluteLevel       = -80,
+    anchorMultiplier       = 2,
+    anchorMinDeltaDb       = 6,
+    coherenceSlackDb       = 3,
+    strictSlackDb          = { 3: 1 },
   } = options
+
+  const anchorFrequency = fundamental * anchorMultiplier
+  if (!harmonics.includes(anchorMultiplier)) {
+    throw new Error(
+      `[hum-detect] anchorMultiplier (${anchorMultiplier}) must be in harmonics list`
+    )
+  }
 
   // Decode audio to raw float32 PCM samples (mono, 44.1 kHz, ≤10 s)
   const maxSamples = MAX_ANALYSIS_SECONDS * SAMPLE_RATE
@@ -130,23 +174,62 @@ export async function analyzeHum(inputPath, options = {}) {
   // Compute magnitude spectrum (dBFS) via windowed FFT
   const magnitudeDb = computeMagnitudeSpectrum(samples, FFT_SIZE, SAMPLE_RATE)
 
-  // Evaluate each harmonic
-  const detectionDetail  = []
-  const flaggedHarmonics = []
-
-  for (const multiplier of harmonics) {
+  // First pass: per-harmonic peak / floor / delta, no flagging yet.
+  const measurements = harmonics.map(multiplier => {
     const frequency = fundamental * multiplier
     const peakDb    = getPeakInBand(magnitudeDb, frequency, 2, SAMPLE_RATE, FFT_SIZE)
     const floorDb   = getMedianFloor(magnitudeDb, frequency, analysisWindow, 5, SAMPLE_RATE, FFT_SIZE)
-    const deltaDb   = peakDb - floorDb
-    const flagged   = deltaDb >= detectionThreshold && peakDb >= minAbsoluteLevel
+    return {
+      multiplier,
+      frequency,
+      peakDb,
+      floorDb,
+      deltaDb: peakDb - floorDb,
+    }
+  })
+
+  const anchor      = measurements.find(m => m.multiplier === anchorMultiplier)
+  const anchorDelta = anchor.deltaDb
+  const anchorPasses = anchorDelta >= anchorMinDeltaDb
+
+  // Second pass: apply coherence rules.
+  const detectionDetail  = []
+  const flaggedHarmonics = []
+
+  for (const m of measurements) {
+    const { multiplier, frequency, peakDb, floorDb, deltaDb } = m
+
+    let flagged          = false
+    let rejectionReason  = null
+
+    if (!anchorPasses) {
+      rejectionReason = 'anchor-failed'
+    } else if (peakDb < minAbsoluteLevel) {
+      rejectionReason = 'below-absolute-floor'
+    } else if (deltaDb < detectionThreshold) {
+      rejectionReason = 'below-threshold'
+    } else if (multiplier === anchorMultiplier) {
+      flagged = true
+    } else if (multiplier === 1) {
+      // Fundamental: no upper-bound coherence check (HPFs commonly suppress it
+      // far below the anchor, and an unfiltered fundamental can sit above).
+      flagged = true
+    } else {
+      const slack = strictSlackDb[multiplier] ?? coherenceSlackDb
+      if (deltaDb <= anchorDelta + slack) {
+        flagged = true
+      } else {
+        rejectionReason = 'anchor-coherence'
+      }
+    }
 
     detectionDetail.push({
       frequency,
-      peakDb:  round2(peakDb),
-      floorDb: round2(floorDb),
-      deltaDb: round2(deltaDb),
+      peakDb:           round2(peakDb),
+      floorDb:          round2(floorDb),
+      deltaDb:          round2(deltaDb),
       flagged,
+      rejectionReason,
     })
 
     if (flagged) flaggedHarmonics.push(frequency)
@@ -164,15 +247,18 @@ export async function analyzeHum(inputPath, options = {}) {
 
   const triggered = flaggedHarmonics.length >= minHarmonicsToTrigger
 
-  // Build filter string now (even if not applying) so the stage can reuse it
-  // without a second analysis pass; null when not triggered.
   const ffmpegFilter = triggered
-    ? flaggedHarmonics
-        .map(f => `equalizer=f=${f}:width_type=q:width=${notchQ}:g=-${notchDepth}`)
-        .join(',')
+    ? buildHumNotchFilter(flaggedHarmonics, notchQ, notchDepth)
     : null
 
-  return { triggered, flaggedHarmonics, detectionDetail, ffmpegFilter }
+  return {
+    triggered,
+    flaggedHarmonics,
+    detectionDetail,
+    ffmpegFilter,
+    anchorFrequency,
+    anchorDeltaDb: round2(anchorDelta),
+  }
 }
 
 // ── Audio decoding ─────────────────────────────────────────────────────────────

--- a/server/pipeline/humEQ.js
+++ b/server/pipeline/humEQ.js
@@ -206,10 +206,14 @@ export async function analyzeHum(inputPath, options = {}) {
       rejectionReason = 'anchor-failed'
     } else if (peakDb < minAbsoluteLevel) {
       rejectionReason = 'below-absolute-floor'
+    } else if (multiplier === anchorMultiplier) {
+      // Anchor coherence (anchorMinDeltaDb) IS the detection bar for the anchor
+      // itself — bypass detectionThreshold so that anchor deltas between
+      // anchorMinDeltaDb and detectionThreshold still count toward
+      // minHarmonicsToTrigger.
+      flagged = true
     } else if (deltaDb < detectionThreshold) {
       rejectionReason = 'below-threshold'
-    } else if (multiplier === anchorMultiplier) {
-      flagged = true
     } else if (multiplier === 1) {
       // Fundamental: no upper-bound coherence check (HPFs commonly suppress it
       // far below the anchor, and an unfiltered fundamental can sit above).

--- a/server/pipeline/stages.js
+++ b/server/pipeline/stages.js
@@ -488,27 +488,51 @@ async function applyF0Veto(ctx, candidates) {
     return { surviving: candidates.slice(), vetoed: [] }
   }
 
-  const perFrame = contour?.perFrame ?? []
-  if (perFrame.length === 0) {
+  const perFrame  = contour?.perFrame ?? []
+  const hopLength = contour?.hopLength
+  const vadFrames = ctx.results.metrics?.frames
+  if (perFrame.length === 0 || !hopLength || !vadFrames?.length) {
     return { surviving: candidates.slice(), vetoed: [] }
   }
 
+  // Build a voiced-frame mask aligned to the F0 contour. estimate_f0_contour.py
+  // forward-fills unvoiced gaps so perFrame is always > 0 — we cannot infer
+  // voiced/silence from perFrame alone. Instead, map each STFT frame's center
+  // sample to the Silero VAD frame that contains it.
+  const lastVadFrame = vadFrames[vadFrames.length - 1]
+  const vadEndSample = lastVadFrame.offsetSamples + lastVadFrame.lengthSamples
+  const vadFrameLen  = vadFrames[0].lengthSamples
+
   const surviving = []
   const vetoed    = []
-  const total     = perFrame.length
 
   for (const freq of candidates) {
     let overlapCount = 0
-    for (let i = 0; i < total; i++) {
+    let voicedTotal  = 0
+    for (let i = 0; i < perFrame.length; i++) {
+      const centerSample = i * hopLength + (hopLength >> 1)
+      if (centerSample >= vadEndSample) break
+      const vadIdx = Math.min(
+        vadFrames.length - 1,
+        Math.floor(centerSample / vadFrameLen)
+      )
+      if (vadFrames[vadIdx].isSilence) continue
+      voicedTotal++
       const f0 = perFrame[i]
       if (f0 > 0 && Math.abs(f0 - freq) <= F0_VETO_HALF_WIDTH_HZ) overlapCount++
     }
-    const fraction = overlapCount / total
+
+    if (voicedTotal === 0) {
+      surviving.push(freq)
+      continue
+    }
+
+    const fraction = overlapCount / voicedTotal
     if (overlapCount >= F0_VETO_MIN_FRAMES && fraction >= F0_VETO_MIN_FRACTION) {
       vetoed.push({
         frequency:    freq,
         overlapFrames: overlapCount,
-        totalFrames:   total,
+        voicedFrames:  voicedTotal,
         fraction:      round2(fraction * 100) / 100,
       })
     } else {

--- a/server/pipeline/stages.js
+++ b/server/pipeline/stages.js
@@ -61,7 +61,7 @@ import { analyzeAutoLeveler, renderAutoLeveler } from './autoLeveler.js'
 import { applyParallelCompression } from './parallelCompression.js'
 import { applyVocalExpander } from './vocalExpander.js'
 import { applyVadGate }       from './vadGate.js'
-import { analyzeHum } from './humEQ.js'
+import { analyzeHum, buildHumNotchFilter } from './humEQ.js'
 import { computeAirBoostParams, applyAirBoostBands, applyAirBoostMask } from './airBoost.js'
 import { getReferenceCurvePath, runReferenceEQPass } from './referenceEQ.js'
 import { getF0Contour } from './f0Analysis.js'
@@ -389,26 +389,73 @@ export async function throatClickAttenuate(ctx) {
 // filters (Q=30, −18 dB) at each flagged harmonic. When not triggered the
 // current path is left unchanged (no temp file is created).
 
+// F0-overlap veto parameters. A surviving hum candidate is rejected if the
+// speaker's voiced F0 sits within ±F0_VETO_HALF_WIDTH_HZ of it for at least
+// F0_VETO_MIN_FRAMES voiced frames AND that fraction exceeds
+// F0_VETO_MIN_FRACTION of all voiced frames. The dual gate (absolute count +
+// fraction) guards both against spurious one-off F0 estimates and against
+// very short voiced segments dominating the histogram.
+const F0_VETO_HALF_WIDTH_HZ = 15
+const F0_VETO_MIN_FRAMES    = 10
+const F0_VETO_MIN_FRACTION  = 0.05
+const HUM_NOTCH_Q           = 30
+const HUM_NOTCH_DEPTH_DB    = 18
+
 export async function humDetect(ctx) {
-  const detection = await analyzeHum(ctx.currentPath)
+  const detection = await analyzeHum(ctx.currentPath, {
+    notchQ:     HUM_NOTCH_Q,
+    notchDepth: HUM_NOTCH_DEPTH_DB,
+  })
+
+  const baseReport = {
+    detectionDetail:  detection.detectionDetail,
+    anchorFrequency:  detection.anchorFrequency,
+    anchorDeltaDb:    detection.anchorDeltaDb,
+  }
 
   if (!detection.triggered) {
     ctx.results.humEQ = {
+      ...baseReport,
       triggered:        false,
       flaggedHarmonics: [],
       notchesApplied:   [],
-      detectionDetail:  detection.detectionDetail,
       ffmpegFilter:     null,
+      f0VetoApplied:    [],
     }
-    ctx.log('[hum-detect] No hum detected — passing through unmodified')
+    ctx.log(
+      `[hum-detect] No hum detected — anchor ${detection.anchorFrequency} Hz ` +
+      `Δ=${detection.anchorDeltaDb} dB`
+    )
     return
   }
 
-  // Apply the pre-computed notch filter string
-  const outPath = ctx.tmp('.wav')
+  // Second-line defense: veto any candidate that overlaps the speaker's voiced
+  // F0 histogram. We only fetch the F0 contour here — once analyzeHum has
+  // already proposed at least one notch — so the typical no-hum case skips
+  // this work entirely.
+  const { surviving, vetoed } = await applyF0Veto(ctx, detection.flaggedHarmonics)
+
+  if (surviving.length === 0) {
+    ctx.results.humEQ = {
+      ...baseReport,
+      triggered:        false,
+      flaggedHarmonics: detection.flaggedHarmonics,
+      notchesApplied:   [],
+      ffmpegFilter:     null,
+      f0VetoApplied:    vetoed,
+    }
+    ctx.log(
+      `[hum-detect] All candidates vetoed by F0 overlap ` +
+      `(${vetoed.map(v => `${v.frequency}Hz`).join(', ')}) — passing through unmodified`
+    )
+    return
+  }
+
+  const ffmpegFilter = buildHumNotchFilter(surviving, HUM_NOTCH_Q, HUM_NOTCH_DEPTH_DB)
+  const outPath     = ctx.tmp('.wav')
   await runFfmpeg([
     '-i', ctx.currentPath,
-    '-af', detection.ffmpegFilter,
+    '-af', ffmpegFilter,
     '-map_metadata', '0',
     '-acodec', 'pcm_f32le',
     '-f', 'wav',
@@ -417,13 +464,59 @@ export async function humDetect(ctx) {
 
   ctx.currentPath = outPath
   ctx.results.humEQ = {
+    ...baseReport,
     triggered:        true,
     flaggedHarmonics: detection.flaggedHarmonics,
-    notchesApplied:   detection.flaggedHarmonics,
-    detectionDetail:  detection.detectionDetail,
-    ffmpegFilter:     detection.ffmpegFilter,
+    notchesApplied:   surviving,
+    ffmpegFilter,
+    f0VetoApplied:    vetoed,
   }
-  ctx.log(`[hum-detect] Notches applied at ${detection.flaggedHarmonics.join(', ')} Hz`)
+  const vetoNote = vetoed.length > 0
+    ? ` (vetoed by F0: ${vetoed.map(v => `${v.frequency}Hz`).join(', ')})`
+    : ''
+  ctx.log(`[hum-detect] Notches applied at ${surviving.join(', ')} Hz${vetoNote}`)
+}
+
+async function applyF0Veto(ctx, candidates) {
+  if (!candidates?.length) return { surviving: [], vetoed: [] }
+
+  let contour
+  try {
+    contour = await getF0Contour(ctx)
+  } catch (err) {
+    ctx.log(`[hum-detect] F0 veto skipped — getF0Contour failed: ${err.message}`)
+    return { surviving: candidates.slice(), vetoed: [] }
+  }
+
+  const perFrame = contour?.perFrame ?? []
+  if (perFrame.length === 0) {
+    return { surviving: candidates.slice(), vetoed: [] }
+  }
+
+  const surviving = []
+  const vetoed    = []
+  const total     = perFrame.length
+
+  for (const freq of candidates) {
+    let overlapCount = 0
+    for (let i = 0; i < total; i++) {
+      const f0 = perFrame[i]
+      if (f0 > 0 && Math.abs(f0 - freq) <= F0_VETO_HALF_WIDTH_HZ) overlapCount++
+    }
+    const fraction = overlapCount / total
+    if (overlapCount >= F0_VETO_MIN_FRAMES && fraction >= F0_VETO_MIN_FRACTION) {
+      vetoed.push({
+        frequency:    freq,
+        overlapFrames: overlapCount,
+        totalFrames:   total,
+        fraction:      round2(fraction * 100) / 100,
+      })
+    } else {
+      surviving.push(freq)
+    }
+  }
+
+  return { surviving, vetoed }
 }
 
 // ── Stage: High-pass filter ───────────────────────────────────────────────────


### PR DESCRIPTION
The detector was evaluating each 60 Hz harmonic in isolation, so any narrow
tonal energy landing on a 60 Hz multiple was fair game — including the
speaker's voiced F0. The Q=30, -18 dB notches that resulted carved an
~8 Hz pit into the strongest harmonic of those vowels, gutting words
whose F0 happened to sit at 180 / 300 Hz.

Two-line defense:

1. Coherence anchor on the 2nd harmonic (120 Hz for 60 Hz mains).
   Nothing is flagged unless the anchor itself is ≥6 dB above floor, and
   higher harmonics must satisfy Δk ≤ anchorDelta + slack (slack=3 dB,
   tightened to 1 dB at 180 Hz where male F0 collisions are common).
   Anchoring on 120 Hz instead of 60 Hz handles the common case where
   the user has already applied an HPF that suppresses 60 Hz but leaves
   120 Hz intact. The fundamental keeps no upper-bound check for the
   same reason.

2. F0 histogram veto in the stage. After analyzeHum proposes candidates,
   getF0Contour is consulted (only when there is something to veto — the
   typical no-hum case skips this entirely) and any harmonic the speaker
   sustains at for ≥10 voiced frames AND ≥5% of voiced frames is dropped.

Report payload gains anchorFrequency, anchorDeltaDb, f0VetoApplied, and
a rejectionReason per harmonic so the decision is auditable.