### PR TITLE
Add auto makeup gain to the LA-2A

### DIFF
--- a/src/audio/la2aProcessor.js
+++ b/src/audio/la2aProcessor.js
@@ -329,6 +329,59 @@ export function processLA2ABuffer(channelData, sampleRate, params = {}) {
   }
 }
 
+/** RMS across every sample of every channel. */
+function rmsOfChannels(channels) {
+  let sumSq = 0
+  let count = 0
+  for (const ch of channels) {
+    for (let i = 0; i < ch.length; i++) sumSq += ch[i] * ch[i]
+    count += ch.length
+  }
+  return count > 0 ? Math.sqrt(sumSq / count) : 0
+}
+
+/**
+ * Compute the makeup gain (dB) that restores the processed signal to the
+ * input's RMS level — i.e. what makes engaging the compressor level-neutral
+ * so bypass A/B comparisons aren't decided by loudness bias.
+ *
+ * Measured, not derived from the curve: the kernel is run over the actual
+ * audio and the output RMS compared to the input's. RMS rather than peak,
+ * because reducing peaks is the point — peak matching would over-boost.
+ *
+ * Iterated because makeup is applied *before* the tube stage (as on the
+ * hardware, where the Gain knob drives the output amplifier). Raising
+ * makeup therefore drives the tubes slightly harder, which shifts the
+ * output level a little, so each pass re-measures at the corrected
+ * operating point. The loop stops as soon as a correction lands under
+ * `toleranceDb`, which for most settings means two passes; only extreme
+ * ones (max peak reduction into max tube drive) need three or four.
+ *
+ * The caller's manual Gain trim is deliberately excluded — this returns the
+ * unity-restoring offset, and any trim is a deliberate deviation added on
+ * top of it.
+ */
+export function computeAutoMakeupDb(channelData, sampleRate, params = {}, options = {}) {
+  const { maxIterations = 4, toleranceDb = 0.05 } = options
+
+  const inputRms = rmsOfChannels(channelData)
+  if (inputRms <= 0) return 0
+
+  let makeupDb = 0
+  for (let i = 0; i < maxIterations; i++) {
+    const { channelData: out } = processLA2ABuffer(channelData, sampleRate, {
+      ...params,
+      gainDb: makeupDb,
+    })
+    const outRms = rmsOfChannels(out)
+    if (outRms <= 0) break
+    const correctionDb = 20 * Math.log10(inputRms / outRms)
+    makeupDb = clamp(makeupDb + correctionDb, -24, 24)
+    if (Math.abs(correctionDb) < toleranceDb) break
+  }
+  return makeupDb
+}
+
 // ── AudioWorklet registration (worklet scope only) ──────────────────────────
 
 // `registerProcessor` and the `sampleRate` global exist only inside an

--- a/src/audio/processing.js
+++ b/src/audio/processing.js
@@ -193,6 +193,60 @@ export function adjustVolumeRegion(segments, start, end, gainDb, audioContext, s
 }
 
 /**
+ * Measure the LA-2A auto-makeup gain (dB) for a region.
+ *
+ * Because this is a spot effect on a finite selection (not a live input),
+ * the makeup can be measured once and applied as a static offset — the
+ * real-time preview and the offline apply then use the identical constant,
+ * so they stay sample-identical and there's no estimator drift baked into
+ * the head of the region.
+ *
+ * Long regions are measured over a centered window rather than end to end:
+ * the RMS ratio is stable across a representative stretch, and this keeps
+ * the re-measure fast enough to sit behind a knob drag. The window only
+ * affects how the number is derived — preview and apply still share it.
+ */
+const AUTO_MAKEUP_MAX_ANALYSIS_S = 30
+
+export function computeLA2AAutoMakeup(segments, start, end, kernelParams, sampleRate, channels) {
+  let aStart = start
+  let aEnd = end
+  if (end - start > AUTO_MAKEUP_MAX_ANALYSIS_S) {
+    const mid = (start + end) / 2
+    aStart = mid - AUTO_MAKEUP_MAX_ANALYSIS_S / 2
+    aEnd = mid + AUTO_MAKEUP_MAX_ANALYSIS_S / 2
+  }
+
+  return new Promise((resolve, reject) => {
+    const channelData = renderRegionToBuffer(segments, aStart, aEnd, sampleRate, channels)
+
+    const worker = new Worker(
+      new URL('../workers/processWorker.js', import.meta.url),
+      { type: 'module' }
+    )
+
+    worker.onmessage = (e) => {
+      worker.terminate()
+      if (e.data.type === 'done') {
+        resolve(e.data.makeupDb)
+      } else if (e.data.type === 'error') {
+        reject(new Error(e.data.message))
+      }
+    }
+
+    worker.onerror = (err) => {
+      worker.terminate()
+      reject(err)
+    }
+
+    worker.postMessage(
+      { type: 'la2aAutoMakeup', channelData, sampleRate, params: kernelParams },
+      channelData.map(c => c.buffer)
+    )
+  })
+}
+
+/**
  * Apply LA-2A compression via OfflineAudioContext running the same
  * AudioWorklet as the real-time preview (src/audio/la2aProcessor.js), so
  * the applied result is sample-identical to what the user heard.

--- a/src/components/panels/LA2AModal.vue
+++ b/src/components/panels/LA2AModal.vue
@@ -1,18 +1,33 @@
 <script setup>
-import { computed, ref, onMounted } from 'vue'
+import { computed, ref, onMounted, watch } from 'vue'
 import { useLA2A } from '../../composables/useLA2A.js'
+import { useEditorState } from '../../composables/useEditorState.js'
 import Knob from '../knobs/Knob.vue'
 
 const {
   la2aMode, la2aPeakReduction, la2aGain, la2aTubeDrive, la2aEmphasis,
+  la2aAutoMakeup, la2aAutoMakeupDb, la2aAutoMakeupBusy,
   la2aPreview, la2aReduction, la2aInputDb, la2aOutputDb, hasSelection,
   togglePreview, syncMode, syncPeakReduction, syncGain, syncTubeDrive,
-  syncEmphasis, apply, teardown, closeModal,
+  syncEmphasis, toggleAutoMakeup, refreshAutoMakeup, apply, teardown, closeModal,
 } = useLA2A()
+
+const { state } = useEditorState()
 
 // Default to engaged when the panel opens
 onMounted(() => {
   if (!la2aPreview.value) togglePreview()
+})
+
+// The makeup is measured from the selected region, so a new selection needs
+// a fresh measurement.
+watch(() => state.selection, () => refreshAutoMakeup(), { deep: true })
+
+const autoMakeupLabel = computed(() => {
+  if (!la2aAutoMakeup.value) return 'AUTO'
+  if (la2aAutoMakeupBusy.value) return 'AUTO ···'
+  const v = la2aAutoMakeupDb.value
+  return `AUTO ${v > 0 ? '+' : ''}${v.toFixed(1)}`
 })
 
 const ACCENT = '#f5a623'
@@ -219,14 +234,34 @@ function selectMockPreset(name) {
                 :disabled="!la2aPreview"
               />
             </div>
-            <div class="w-[130px]">
+            <div class="w-[130px] flex flex-col items-center">
               <Knob
                 :model-value="la2aGain"
                 @update:model-value="syncGain"
                 :min="-12" :max="24" :step="0.1"
-                label="Gain" :accent="ACCENT" :format-value="formatGain"
+                :label="la2aAutoMakeup ? 'Gain (trim)' : 'Gain'"
+                :accent="ACCENT" :format-value="formatGain"
                 :disabled="!la2aPreview"
               />
+              <!-- Auto makeup: measured offset that keeps engaging the
+                   compressor level-neutral, so bypass A/B isn't decided by
+                   loudness. The knob above stays live as a trim on top. -->
+              <button
+                class="mt-[7px] px-2.5 py-[4px] rounded-full cursor-pointer transition-all disabled:cursor-default"
+                :style="{
+                  background: la2aAutoMakeup ? 'rgba(245,166,35,.16)' : 'rgba(255,255,255,.05)',
+                  border: `1px solid ${la2aAutoMakeup ? 'rgba(245,166,35,.42)' : 'rgba(255,255,255,.09)'}`,
+                  color: la2aAutoMakeup ? '#f7c877' : 'rgba(255,255,255,.4)',
+                  font: `700 8.5px 'JetBrains Mono',monospace`,
+                  letterSpacing: '.1em',
+                  opacity: la2aPreview ? 1 : 0.4,
+                }"
+                :disabled="!la2aPreview"
+                :title="la2aAutoMakeup
+                  ? 'Auto makeup on — output level matched to input so you hear the compression, not the loudness'
+                  : 'Auto makeup off — set makeup manually with the Gain knob'"
+                @click="toggleAutoMakeup"
+              >{{ autoMakeupLabel }}</button>
             </div>
           </div>
 

--- a/src/composables/useLA2A.js
+++ b/src/composables/useLA2A.js
@@ -1,6 +1,6 @@
 import { ref } from 'vue'
 import { useEditorState } from './useEditorState.js'
-import { applyLA2ARegion, computePeakCache } from '../audio/processing.js'
+import { applyLA2ARegion, computeLA2AAutoMakeup, computePeakCache } from '../audio/processing.js'
 import { getEffectChain } from '../audio/effectChain.js'
 import { la2aEffect, LA2A_DEFAULTS } from '../audio/effects/la2aCompressor.js'
 
@@ -10,17 +10,45 @@ const la2aPeakReduction = ref(LA2A_DEFAULTS.peakReduction)
 const la2aGain = ref(LA2A_DEFAULTS.gain)
 const la2aTubeDrive = ref(LA2A_DEFAULTS.tubeDrive)
 const la2aEmphasis = ref(LA2A_DEFAULTS.emphasis)
+// Auto makeup: on by default so spot compression is level-neutral — an
+// unmatched makeup on a selection leaves an audible step at the selection
+// boundary and perturbs the levels the mastering chain later measures.
+const la2aAutoMakeup = ref(true)
+const la2aAutoMakeupDb = ref(0)
+const la2aAutoMakeupBusy = ref(false)
 const la2aPreview = ref(false)
 const la2aReduction = ref(0)
 const la2aInputDb = ref(-Infinity)
 const la2aOutputDb = ref(-Infinity)
 let meterId = null
 
+// Debounce + supersede state for the auto-makeup measurement, shared across
+// every useLA2A() caller so knob drags coalesce into one measurement.
+const AUTO_MAKEUP_DEBOUNCE_MS = 120
+let makeupTimer = null
+let makeupSeq = 0
+
+/** Total gain sent to the kernel: measured makeup plus the manual trim. */
+function effectiveGainDb() {
+  return (la2aAutoMakeup.value ? la2aAutoMakeupDb.value : 0) + la2aGain.value
+}
+
 function currentParams() {
   return {
     mode: la2aMode.value,
     peakReduction: la2aPeakReduction.value,
-    gain: la2aGain.value,
+    gain: effectiveGainDb(),
+    tubeDrive: la2aTubeDrive.value,
+    emphasis: la2aEmphasis.value,
+  }
+}
+
+/** Params for the measurement pass — makeup is what we're solving for. */
+function measurementParams() {
+  return {
+    mode: la2aMode.value,
+    peakReduction: la2aPeakReduction.value,
+    gainDb: 0,
     tubeDrive: la2aTubeDrive.value,
     emphasis: la2aEmphasis.value,
   }
@@ -76,24 +104,88 @@ export function useLA2A() {
     if (la2aPreview.value) {
       pushAllParams(chain)
       startMeters(chain)
+      refreshAutoMakeup()
     } else {
       stopMeters()
     }
   }
 
-  function syncParam(name, refVar, value) {
-    refVar.value = value
+  function pushParam(name, value) {
     if (!la2aPreview.value) return
-    const ctx = getAudioContext()
-    const chain = getEffectChain(ctx)
+    const chain = getEffectChain(getAudioContext())
     chain.updateParam(la2aEffect.id, name, value)
   }
 
-  const syncMode = (v) => syncParam('mode', la2aMode, v)
-  const syncPeakReduction = (v) => syncParam('peakReduction', la2aPeakReduction, v)
-  const syncGain = (v) => syncParam('gain', la2aGain, v)
-  const syncTubeDrive = (v) => syncParam('tubeDrive', la2aTubeDrive, v)
-  const syncEmphasis = (v) => syncParam('emphasis', la2aEmphasis, v)
+  /** Push the combined makeup + trim to the running effect. */
+  function pushGain() {
+    pushParam('gain', effectiveGainDb())
+  }
+
+  /**
+   * Re-measure the auto-makeup for the current selection and settings.
+   * Superseded calls are discarded by sequence number so a fast knob drag
+   * can't have an older measurement land after a newer one.
+   */
+  async function refreshAutoMakeup() {
+    if (!la2aAutoMakeup.value || !state.selection || !state.currentFile) return
+
+    const { start, end } = state.selection
+    const seq = ++makeupSeq
+    la2aAutoMakeupBusy.value = true
+    try {
+      const makeupDb = await computeLA2AAutoMakeup(
+        state.segments, start, end,
+        measurementParams(),
+        state.currentFile.sampleRate, state.currentFile.channels
+      )
+      if (seq !== makeupSeq) return // a newer measurement is already in flight
+      la2aAutoMakeupDb.value = makeupDb
+      pushGain()
+    } catch (err) {
+      console.error('LA-2A auto makeup measurement failed:', err)
+    } finally {
+      if (seq === makeupSeq) la2aAutoMakeupBusy.value = false
+    }
+  }
+
+  function scheduleAutoMakeup() {
+    if (!la2aAutoMakeup.value) return
+    if (makeupTimer !== null) clearTimeout(makeupTimer)
+    makeupTimer = setTimeout(() => {
+      makeupTimer = null
+      refreshAutoMakeup()
+    }, AUTO_MAKEUP_DEBOUNCE_MS)
+  }
+
+  // Params that change how much the compressor reduces (and so how much
+  // makeup is needed) trigger a re-measure; the manual trim does not.
+  function syncCompressionParam(name, refVar, value) {
+    refVar.value = value
+    pushParam(name, value)
+    scheduleAutoMakeup()
+  }
+
+  const syncMode = (v) => syncCompressionParam('mode', la2aMode, v)
+  const syncPeakReduction = (v) => syncCompressionParam('peakReduction', la2aPeakReduction, v)
+  const syncTubeDrive = (v) => syncCompressionParam('tubeDrive', la2aTubeDrive, v)
+  const syncEmphasis = (v) => syncCompressionParam('emphasis', la2aEmphasis, v)
+
+  function syncGain(v) {
+    la2aGain.value = v
+    pushGain()
+  }
+
+  function toggleAutoMakeup() {
+    la2aAutoMakeup.value = !la2aAutoMakeup.value
+    if (la2aAutoMakeup.value) {
+      refreshAutoMakeup()
+    } else {
+      makeupSeq++ // discard any in-flight measurement
+      la2aAutoMakeupDb.value = 0
+      la2aAutoMakeupBusy.value = false
+      pushGain()
+    }
+  }
 
   async function apply() {
     if (!state.selection) return
@@ -145,6 +237,9 @@ export function useLA2A() {
     la2aGain,
     la2aTubeDrive,
     la2aEmphasis,
+    la2aAutoMakeup,
+    la2aAutoMakeupDb,
+    la2aAutoMakeupBusy,
     la2aPreview,
     la2aReduction,
     la2aInputDb,
@@ -156,6 +251,8 @@ export function useLA2A() {
     syncGain,
     syncTubeDrive,
     syncEmphasis,
+    toggleAutoMakeup,
+    refreshAutoMakeup,
     apply,
     teardown,
     openModal,

--- a/src/workers/processWorker.js
+++ b/src/workers/processWorker.js
@@ -2,10 +2,12 @@
  * Audio Processing Web Worker
  *
  * Handles CPU-intensive audio processing tasks off the main thread.
- * Supports: normalize, adjustVolume
+ * Supports: normalize, adjustVolume, la2aAutoMakeup
  */
+import { computeAutoMakeupDb } from '../audio/la2aProcessor.js'
+
 self.onmessage = function (e) {
-  const { type, channelData, params } = e.data
+  const { type, channelData, sampleRate, params } = e.data
 
   switch (type) {
     case 'normalize':
@@ -14,8 +16,22 @@ self.onmessage = function (e) {
     case 'adjustVolume':
       adjustVolume(channelData, params)
       break
+    case 'la2aAutoMakeup':
+      la2aAutoMakeup(channelData, sampleRate, params)
+      break
     default:
       self.postMessage({ type: 'error', message: `Unknown operation: ${type}` })
+  }
+}
+
+// Runs the LA-2A kernel over the region purely to measure it — this is why
+// it lives in the worker rather than on the main thread, so knob drags
+// don't jank the UI while the measurement re-runs.
+function la2aAutoMakeup(channelData, sampleRate, params) {
+  try {
+    self.postMessage({ type: 'done', makeupDb: computeAutoMakeupDb(channelData, sampleRate, params) })
+  } catch (err) {
+    self.postMessage({ type: 'error', message: err.message })
   }
 }
 


### PR DESCRIPTION
Level-matches the compressor's output to its input so engaging it (or toggling BYPASS) doesn't change loudness — you hear what the compression is doing rather than the level change it comes with. Also keeps spot compression level-neutral, which avoids an audible step at the selection boundary and preserves the level relationships the mastering chain later measures against.

Measured rather than derived from the curve, and measured once: because this is a spot effect on a finite selection, the kernel is run over the region up front and the resulting offset applied as a static value. The preview and the offline apply therefore use the identical constant, so they stay sample-identical and no estimator drift is baked into the head of the region.

- computeAutoMakeupDb (la2aProcessor.js): compares output RMS to input RMS (not peak — reducing peaks is the point). Iterates because makeup is applied pre-tube, so raising it drives the tube stage harder; the loop stops once a correction lands under 0.05 dB, which is two passes for typical settings and up to four at the extremes.
- Measurement runs in processWorker so knob drags don't jank the UI, debounced at 120 ms and superseded by sequence number. Regions longer than 30 s are measured over a centered window.
- useLA2A: auto offset and the manual Gain knob are summed, so the knob stays live as a trim and toggling AUTO never discards a manual setting. Re-measures when compression settings or the selection change.
- LA2AModal: AUTO pill under the Gain knob showing the measured offset; knob relabels to "Gain (trim)" while auto is on. Default on.

Verified in Node: output matches input RMS within 0.007 dB across compress/limit and the full tube-drive and R37 range, with silent and stereo regions handled; existing 13 DSP checks still pass.


Claude-Session: https://claude.ai/code/session_01QiWq1oHvUbXSdYph3rGQPh