### PR TITLE
Auto makeup drives the Gain knob instead of offsetting it

### DIFF
--- a/src/components/knobs/Knob.vue
+++ b/src/components/knobs/Knob.vue
@@ -10,6 +10,10 @@ const props = defineProps({
   accent: { type: String, default: '#f5a623' },
   formatValue: { type: Function, default: (v) => String(Math.round(v)) },
   disabled: { type: Boolean, default: false },
+  // Driven by the plugin rather than the user (e.g. auto makeup owning the
+  // Gain knob): not draggable, but stays fully lit because the value it is
+  // showing is live and meaningful — unlike `disabled`, which dims.
+  readonly: { type: Boolean, default: false },
   valueFontPx: { type: Number, default: 19 },
 })
 
@@ -61,7 +65,7 @@ function quantize(v) {
 }
 
 function onPointerDown(e) {
-  if (props.disabled) return
+  if (props.disabled || props.readonly) return
   dragging.value = true
   dragStartY = e.clientY
   dragStartValue = props.modelValue
@@ -82,7 +86,7 @@ function onPointerUp(e) {
 }
 
 function onWheel(e) {
-  if (props.disabled) return
+  if (props.disabled || props.readonly) return
   e.preventDefault()
   const delta = e.deltaY < 0 ? props.step : -props.step
   emit('update:modelValue', quantize(props.modelValue + delta))
@@ -94,7 +98,7 @@ function onWheel(e) {
        :style="{ fontFamily: `'Inter',system-ui,sans-serif`, opacity: disabled ? 0.4 : 1 }">
     <div
       class="relative w-full touch-none"
-      :class="disabled ? 'cursor-default' : 'cursor-ns-resize'"
+      :class="disabled || readonly ? 'cursor-default' : 'cursor-ns-resize'"
       style="aspect-ratio:1"
       @pointerdown="onPointerDown"
       @pointermove="onPointerMove"

--- a/src/components/panels/LA2AModal.vue
+++ b/src/components/panels/LA2AModal.vue
@@ -6,7 +6,7 @@ import Knob from '../knobs/Knob.vue'
 
 const {
   la2aMode, la2aPeakReduction, la2aGain, la2aTubeDrive, la2aEmphasis,
-  la2aAutoMakeup, la2aAutoMakeupDb, la2aAutoMakeupBusy,
+  la2aAutoMakeup, la2aAutoMakeupBusy,
   la2aPreview, la2aReduction, la2aInputDb, la2aOutputDb, hasSelection,
   togglePreview, syncMode, syncPeakReduction, syncGain, syncTubeDrive,
   syncEmphasis, toggleAutoMakeup, refreshAutoMakeup, apply, teardown, closeModal,
@@ -23,12 +23,9 @@ onMounted(() => {
 // a fresh measurement.
 watch(() => state.selection, () => refreshAutoMakeup(), { deep: true })
 
-const autoMakeupLabel = computed(() => {
-  if (!la2aAutoMakeup.value) return 'AUTO'
-  if (la2aAutoMakeupBusy.value) return 'AUTO ···'
-  const v = la2aAutoMakeupDb.value
-  return `AUTO ${v > 0 ? '+' : ''}${v.toFixed(1)}`
-})
+const autoMakeupLabel = computed(() =>
+  la2aAutoMakeup.value && la2aAutoMakeupBusy.value ? 'AUTO ···' : 'AUTO'
+)
 
 const ACCENT = '#f5a623'
 const PANEL_WIDTH = 640
@@ -239,13 +236,14 @@ function selectMockPreset(name) {
                 :model-value="la2aGain"
                 @update:model-value="syncGain"
                 :min="-12" :max="24" :step="0.1"
-                :label="la2aAutoMakeup ? 'Gain (trim)' : 'Gain'"
-                :accent="ACCENT" :format-value="formatGain"
+                label="Gain" :accent="ACCENT" :format-value="formatGain"
                 :disabled="!la2aPreview"
+                :readonly="la2aAutoMakeup"
               />
-              <!-- Auto makeup: measured offset that keeps engaging the
-                   compressor level-neutral, so bypass A/B isn't decided by
-                   loudness. The knob above stays live as a trim on top. -->
+              <!-- Auto makeup drives the Gain knob above to whatever keeps
+                   the output level-matched to the input, so bypass A/B isn't
+                   decided by loudness. Switching it off leaves the knob where
+                   it stands and hands control back to the user. -->
               <button
                 class="mt-[7px] px-2.5 py-[4px] rounded-full cursor-pointer transition-all disabled:cursor-default"
                 :style="{
@@ -258,8 +256,8 @@ function selectMockPreset(name) {
                 }"
                 :disabled="!la2aPreview"
                 :title="la2aAutoMakeup
-                  ? 'Auto makeup on — output level matched to input so you hear the compression, not the loudness'
-                  : 'Auto makeup off — set makeup manually with the Gain knob'"
+                  ? 'Auto makeup on — the plugin sets Gain to level-match the output, so you hear the compression rather than the loudness. Click to take manual control.'
+                  : 'Auto makeup off — Gain is yours to set. Click to let the plugin level-match it.'"
                 @click="toggleAutoMakeup"
               >{{ autoMakeupLabel }}</button>
             </div>

--- a/src/composables/useLA2A.js
+++ b/src/composables/useLA2A.js
@@ -13,9 +13,15 @@ const la2aEmphasis = ref(LA2A_DEFAULTS.emphasis)
 // Auto makeup: on by default so spot compression is level-neutral — an
 // unmatched makeup on a selection leaves an audible step at the selection
 // boundary and perturbs the levels the mastering chain later measures.
+// While on, the plugin owns the Gain knob: measurements are written into
+// la2aGain itself, so the knob always shows the gain actually in effect.
 const la2aAutoMakeup = ref(true)
-const la2aAutoMakeupDb = ref(0)
 const la2aAutoMakeupBusy = ref(false)
+
+// Gain knob travel — measured makeup is clamped to it so the knob position
+// can never disagree with the value in effect.
+const GAIN_MIN_DB = -12
+const GAIN_MAX_DB = 24
 const la2aPreview = ref(false)
 const la2aReduction = ref(0)
 const la2aInputDb = ref(-Infinity)
@@ -28,16 +34,11 @@ const AUTO_MAKEUP_DEBOUNCE_MS = 120
 let makeupTimer = null
 let makeupSeq = 0
 
-/** Total gain sent to the kernel: measured makeup plus the manual trim. */
-function effectiveGainDb() {
-  return (la2aAutoMakeup.value ? la2aAutoMakeupDb.value : 0) + la2aGain.value
-}
-
 function currentParams() {
   return {
     mode: la2aMode.value,
     peakReduction: la2aPeakReduction.value,
-    gain: effectiveGainDb(),
+    gain: la2aGain.value,
     tubeDrive: la2aTubeDrive.value,
     emphasis: la2aEmphasis.value,
   }
@@ -116,15 +117,15 @@ export function useLA2A() {
     chain.updateParam(la2aEffect.id, name, value)
   }
 
-  /** Push the combined makeup + trim to the running effect. */
   function pushGain() {
-    pushParam('gain', effectiveGainDb())
+    pushParam('gain', la2aGain.value)
   }
 
   /**
-   * Re-measure the auto-makeup for the current selection and settings.
-   * Superseded calls are discarded by sequence number so a fast knob drag
-   * can't have an older measurement land after a newer one.
+   * Re-measure the auto-makeup for the current selection and settings and
+   * drive the Gain knob to it. Superseded calls are discarded by sequence
+   * number so a fast knob drag can't have an older measurement land after
+   * a newer one.
    */
   async function refreshAutoMakeup() {
     if (!la2aAutoMakeup.value || !state.selection || !state.currentFile) return
@@ -139,7 +140,7 @@ export function useLA2A() {
         state.currentFile.sampleRate, state.currentFile.channels
       )
       if (seq !== makeupSeq) return // a newer measurement is already in flight
-      la2aAutoMakeupDb.value = makeupDb
+      la2aGain.value = Math.max(GAIN_MIN_DB, Math.min(GAIN_MAX_DB, makeupDb))
       pushGain()
     } catch (err) {
       console.error('LA-2A auto makeup measurement failed:', err)
@@ -171,6 +172,7 @@ export function useLA2A() {
   const syncEmphasis = (v) => syncCompressionParam('emphasis', la2aEmphasis, v)
 
   function syncGain(v) {
+    if (la2aAutoMakeup.value) return // the plugin owns the gain in auto mode
     la2aGain.value = v
     pushGain()
   }
@@ -180,10 +182,10 @@ export function useLA2A() {
     if (la2aAutoMakeup.value) {
       refreshAutoMakeup()
     } else {
+      // Hand the knob back where it stands, so switching to manual is a
+      // seamless takeover rather than a jump back to 0 dB.
       makeupSeq++ // discard any in-flight measurement
-      la2aAutoMakeupDb.value = 0
       la2aAutoMakeupBusy.value = false
-      pushGain()
     }
   }
 
@@ -238,7 +240,6 @@ export function useLA2A() {
     la2aTubeDrive,
     la2aEmphasis,
     la2aAutoMakeup,
-    la2aAutoMakeupDb,
     la2aAutoMakeupBusy,
     la2aPreview,
     la2aReduction,


### PR DESCRIPTION
The previous design applied the measured makeup as a hidden offset added to the Gain knob, so the knob could read 0 while +4 dB was actually in effect — the value shown was not the value in use. Auto mode now does what auto mode conventionally does: the plugin takes ownership of the Gain control and drives it, so the knob always shows the gain actually applied.

- la2aGain is now the single source of truth for output gain. The measurement writes into it directly (clamped to the knob's travel) and the separate offset ref is gone.
- While auto is on the knob is readonly rather than disabled — not draggable, but fully lit, since the value it displays is live and meaningful. Added a `readonly` prop to Knob for this; `disabled` keeps its dimmed appearance for the bypassed case.
- Switching auto off leaves the knob where it stands, so taking manual control is a seamless handoff rather than a jump back to 0 dB.
- The AUTO pill is now just a state toggle (it showed the offset value before, which the knob itself now reports).


Claude-Session: https://claude.ai/code/session_01QiWq1oHvUbXSdYph3rGQPh