### PR TITLE
Add FET Punch, an 1176-style companion to the OptoSmooth

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,7 +52,7 @@ Processing is split between client and server based on operation type. This is n
 |---|---|---|
 | Trim, cut, delete, silence, split | Client | Pure segment manipulation — no audio data touched |
 | Normalize | Client | Linear operation, expected to feel instant. Quality gap vs. server is acceptable for spot work |
-| Compression | Client | Interactive parameter tweaking expects immediacy. OfflineAudioContext + DynamicsCompressorNode |
+| Compression | Client | Interactive parameter tweaking expects immediacy. Two emulations — OptoSmooth (LA-2A opto) and FET Punch (1176 FET) — each a dependency-free kernel run in an AudioWorklet for preview and in an OfflineAudioContext for apply, so the two are sample-identical |
 | Noise reduction | Server (DeepFilterNet3) | Quality gap vs. RNNoise is significant and user-visible. Modal wait is normal for this operation |
 | Full preset chain | Server | Always server-side |
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -5,6 +5,7 @@ import EditorScreen from './components/EditorScreen.vue'
 import ProcessingOverlay from './components/ProcessingOverlay.vue'
 import ToastNotification from './components/ToastNotification.vue'
 import LA2AModal from './components/panels/LA2AModal.vue'
+import FET1176Modal from './components/panels/FET1176Modal.vue'
 
 const { hasFile, state } = useEditorState()
 </script>
@@ -14,5 +15,6 @@ const { hasFile, state } = useEditorState()
   <EditorScreen v-else />
   <ProcessingOverlay v-if="state.isProcessing" />
   <LA2AModal v-if="state.la2aModalOpen" />
+  <FET1176Modal v-if="state.fet1176ModalOpen" />
   <ToastNotification />
 </template>

--- a/src/audio/effects/fet1176Compressor.js
+++ b/src/audio/effects/fet1176Compressor.js
@@ -1,40 +1,46 @@
 /**
- * LA-2A optical compressor — real-time effect chain wrapper.
+ * FET Punch (1176-style) compressor — real-time effect chain wrapper.
  *
- * The DSP itself lives in ../la2aProcessor.js (T4 optical cell with
- * dual-stage memory-dependent release, program-dependent compress/limit
- * ratios, R37 sidechain emphasis, tube saturation) and runs in an
- * AudioWorklet. The offline apply path renders through the same worklet in
- * an OfflineAudioContext, so the preview is sample-identical to what gets
- * written to the timeline.
+ * The DSP itself lives in ../fet1176Processor.js (FET gain cell with
+ * user-set microsecond attack, program-dependent release, four ratio
+ * settings plus all-buttons-in, optional sidechain high-pass, FET/class-A
+ * saturation) and runs in an AudioWorklet. The offline apply path renders
+ * through the same worklet in an OfflineAudioContext, so the preview is
+ * sample-identical to what gets written to the timeline.
  *
  * The worklet module loads asynchronously; until it's ready the effect
  * passes audio through unprocessed, then splices the worklet node in.
  */
 
-import { ensureLA2AWorklet } from '../la2aWorkletLoader.js'
+import { ensureFET1176Worklet } from '../fet1176WorkletLoader.js'
 import { createLevelTap } from './levelTap.js'
 
-export const LA2A_DEFAULTS = {
-  mode: 'compress', // 'compress' | 'limit'
-  peakReduction: 50,
-  gain: 0, // makeup gain dB
-  tubeDrive: 0.3,
-  emphasis: 0, // R37 HF sidechain emphasis, 0 = flat (stock)
+export const FET1176_DEFAULTS = {
+  inputDrive: 50, // 0-100, drives the fixed internal threshold
+  output: 0, // makeup gain dB
+  attack: 4, // dial 1-7, 7 = fastest (20 us)
+  release: 4, // dial 1-7, 7 = fastest (50 ms)
+  ratio: '4', // '4' | '8' | '12' | '20' | 'all'
+  fetDrive: 0.35, // FET / output-amp saturation
+  scHpf: 0, // sidechain high-pass corner in Hz, 0 = off (stock)
+  mix: 1, // wet/dry blend for parallel compression
 }
 
 /** Map UI param names to kernel param names. */
 export function toKernelParams(params) {
   return {
-    mode: params.mode,
-    peakReduction: params.peakReduction,
-    gainDb: params.gain,
-    tubeDrive: params.tubeDrive,
-    emphasis: params.emphasis,
+    inputDrive: params.inputDrive,
+    outputGainDb: params.output,
+    attack: params.attack,
+    release: params.release,
+    ratio: params.ratio,
+    fetDrive: params.fetDrive,
+    scHpfHz: params.scHpf,
+    mix: params.mix,
   }
 }
 
-export function createLA2ACompressor(audioContext) {
+export function createFET1176Compressor(audioContext) {
   const input = audioContext.createGain()
   // preOutput is a stable internal hand-off: the chain calls .disconnect()
   // on `output` during rebuilds (wiping ALL its outgoing connections), so
@@ -43,7 +49,7 @@ export function createLA2ACompressor(audioContext) {
   const preOutput = audioContext.createGain()
   const output = audioContext.createGain()
 
-  let params = { ...LA2A_DEFAULTS }
+  let params = { ...FET1176_DEFAULTS }
   let worklet = null
   let destroyed = false
   let grDb = 0
@@ -52,10 +58,10 @@ export function createLA2ACompressor(audioContext) {
   input.connect(preOutput)
   preOutput.connect(output)
 
-  ensureLA2AWorklet(audioContext)
+  ensureFET1176Worklet(audioContext)
     .then(() => {
       if (destroyed) return
-      worklet = new AudioWorkletNode(audioContext, 'la2a-processor', {
+      worklet = new AudioWorkletNode(audioContext, 'fet1176-processor', {
         processorOptions: { params: toKernelParams(params) },
       })
       worklet.port.onmessage = (e) => {
@@ -66,7 +72,7 @@ export function createLA2ACompressor(audioContext) {
       worklet.connect(preOutput)
     })
     .catch((err) => {
-      console.error('LA-2A worklet failed to load, running bypassed:', err)
+      console.error('FET Punch worklet failed to load, running bypassed:', err)
     })
 
   // Level meter taps on dedicated monitor nodes fed from stable internal
@@ -121,10 +127,10 @@ export function createLA2ACompressor(audioContext) {
   }
 }
 
-export const la2aEffect = {
-  id: 'la2a-compressor',
-  name: 'LA-2A Compressor',
+export const fet1176Effect = {
+  id: 'fet1176-compressor',
+  name: 'FET Punch Compressor',
   createNodes(audioContext) {
-    return createLA2ACompressor(audioContext)
+    return createFET1176Compressor(audioContext)
   },
 }

--- a/src/audio/effects/levelTap.js
+++ b/src/audio/effects/levelTap.js
@@ -1,0 +1,37 @@
+/**
+ * RMS level meter tap, shared by the real-time effect wrappers.
+ *
+ * An AnalyserNode only gets pulled for processing if it's part of a graph
+ * that's reachable from the destination — a tap with no downstream connection
+ * can silently stop updating. Route it through a silent sink so it's always
+ * actively processed regardless of engine optimizations.
+ */
+export function createLevelTap(audioContext, node) {
+  const analyser = audioContext.createAnalyser()
+  analyser.fftSize = 1024
+  analyser.smoothingTimeConstant = 0.6
+  node.connect(analyser)
+
+  const silentSink = audioContext.createGain()
+  silentSink.gain.value = 0
+  analyser.connect(silentSink)
+  silentSink.connect(audioContext.destination)
+
+  const data = new Float32Array(analyser.fftSize)
+
+  return {
+    analyser,
+    getLevelDb() {
+      analyser.getFloatTimeDomainData(data)
+      let sumSquares = 0
+      for (let i = 0; i < data.length; i++) sumSquares += data[i] * data[i]
+      const rms = Math.sqrt(sumSquares / data.length)
+      if (rms <= 0) return -Infinity
+      return 20 * Math.log10(rms)
+    },
+    destroy() {
+      analyser.disconnect()
+      silentSink.disconnect()
+    },
+  }
+}

--- a/src/audio/fet1176Processor.js
+++ b/src/audio/fet1176Processor.js
@@ -1,0 +1,496 @@
+/**
+ * 1176-style FET limiting amplifier emulation ("FET Punch") — worklet kernel.
+ *
+ * Companion to la2aProcessor.js (OptoSmooth). Same contract: this file is
+ * BOTH a normal ES module (exports FET1176Kernel and processFET1176Buffer for
+ * offline use and Node-based verification) AND an AudioWorklet module
+ * (registers 'fet1176-processor' when loaded into an AudioWorkletGlobalScope).
+ * It must stay dependency-free: the worklet loads it as a raw asset via
+ * `new URL(...)`, so imports would not resolve there.
+ *
+ * The same kernel therefore runs in three places with identical results:
+ * real-time preview (AudioContext), offline apply (OfflineAudioContext), and
+ * Node verification scripts.
+ *
+ * Where the LA-2A is slow, optical and self-effacing, this one is the
+ * opposite, and the model is built around the differences that matter:
+ *
+ * 1. FET gain element, not a light bulb
+ *    - Attack is user-set from 800 us (dial 1) down to 20 us (dial 7), which
+ *      is short enough that the gain cell tracks individual waveform peaks
+ *      rather than an envelope. That is where the "grab" comes from.
+ *    - Release runs 1.1 s (dial 1) to 50 ms (dial 7).
+ *    - Both dials are REVERSED on the hardware: 7 is the fastest position,
+ *      not the slowest. Modeled the same way so the UI can print the dial
+ *      number the way the panel does.
+ *
+ * 2. Program-dependent release
+ *    - The control-voltage network does not discharge on a single time
+ *      constant. A minority share of the reduction hangs on a slower tail,
+ *      so dense program recovers more slowly than isolated peaks.
+ *
+ * 3. Input as the only threshold control
+ *    - Like the LA-2A there is no threshold knob. Input is an attenuator
+ *      ahead of a fixed internal threshold, and it feeds the audio path as
+ *      well as the detector, so turning it up raises level AND compression
+ *      together. Output then brings it back down. That interaction is the
+ *      whole gain-staging feel of the unit and is modeled directly.
+ *    - The threshold is referenced to nominal analog operating level
+ *      (0 VU = -18 dBFS), matching the LA-2A model's NOMINAL_DBFS.
+ *
+ * 4. Ratio buttons, including all-buttons-in
+ *    - 4:1, 8:1, 12:1 and 20:1 select progressively tighter knees.
+ *    - Pressing every button at once ("British mode") is not a ratio at all:
+ *      it drops the effective threshold, bends the curve so the ratio climbs
+ *      with level, lags the attack, lengthens the release tail and pushes the
+ *      FET much harder. Modeled as its own mode rather than as a number.
+ *
+ * 5. Detector and output stage
+ *    - Broadband detector (the hardware has no sidechain filter); an optional
+ *      one-pole sidechain high-pass is offered as a modern extension so
+ *      plosives and rumble don't duck a narration track.
+ *    - Asymmetric tanh waveshaper standing in for the FET plus class-A output
+ *      amp, followed by a DC blocker.
+ */
+
+// ── Level reference ─────────────────────────────────────────────────────────
+
+// Nominal operating level (0 VU = +4 dBu). The internal threshold sits at
+// line level on the hardware, so Input is referenced to that rather than to
+// digital full scale — see the same constant in la2aProcessor.js.
+const NOMINAL_DBFS = -18
+const THRESHOLD_DBFS = NOMINAL_DBFS
+
+// Input knob 0-100 -> drive into the fixed threshold, spanning 40 dB
+// (-24 dB at knob 0, +16 dB at knob 100). IN_TAPER < 1 models the hardware's
+// stepped audio-taper attenuator: level rises quickly off zero and flattens
+// toward the top.
+const IN_DRIVE_MIN_DB = -24
+const IN_DRIVE_SPAN_DB = 40
+const IN_TAPER = 0.8
+
+// ── Ballistics ──────────────────────────────────────────────────────────────
+
+// Dial 1 (slowest) and dial 7 (fastest) endpoints; positions in between are
+// interpolated geometrically, as the hardware's switched resistor ladder does.
+const ATTACK_SLOWEST_S = 0.0008
+const ATTACK_FASTEST_S = 0.00002
+const RELEASE_SLOWEST_S = 1.1
+const RELEASE_FASTEST_S = 0.05
+
+// Program-dependent release: this share of the reduction recovers on a tail
+// this many times slower than the dial setting.
+const TAIL_FRACTION = 0.22
+const TAIL_MULT = 4
+
+// All-buttons-in holds far more of the reduction on the slow tail, which is
+// what makes it pump and breathe instead of releasing cleanly.
+const ALL_TAIL_FRACTION = 0.45
+const ALL_TAIL_MULT = 6
+
+// ── Gain computer ───────────────────────────────────────────────────────────
+
+// Tighter knees as the ratio climbs — 4:1 is a comparatively gentle curve,
+// 20:1 is nearly a corner.
+const RATIO_VALUES = { 4: 4, 8: 8, 12: 12, 20: 20 }
+const RATIO_KNEE_DB = { 4: 10, 8: 8, 12: 6, 20: 3 }
+
+// All-buttons-in: a wide, badly-behaved knee whose effective ratio climbs
+// with overshoot, over a threshold pulled down by ALL_THRESHOLD_DROP_DB.
+const ALL_KNEE_DB = 16
+const ALL_THRESHOLD_DROP_DB = 6
+const ALL_RATIO_MIN = 6
+const ALL_RATIO_SPAN = 14
+const ALL_RATIO_HALF_DB = 12 // overshoot at which the ratio sits mid-range
+// The famously late attack: the dial still sets the rate, but everything
+// arrives slower than the number says.
+const ALL_ATTACK_LAG = 2.5
+// ...and the FET is driven much harder, which is most of the "sound".
+const ALL_FET_BOOST = 1.6
+
+const LN10_OVER_20 = Math.LN10 / 20
+
+export const FET1176_KERNEL_DEFAULTS = {
+  inputDrive: 50, // 0-100, drive into the fixed threshold (hardware Input knob)
+  outputGainDb: 0, // makeup (hardware Output knob)
+  attack: 4, // dial 1-7, 7 = fastest (hardware markings)
+  release: 4, // dial 1-7, 7 = fastest (hardware markings)
+  ratio: '4', // '4' | '8' | '12' | '20' | 'all'
+  fetDrive: 0.35, // 0-1 FET / output-amp saturation amount
+  scHpfHz: 0, // 0 = off (stock), or sidechain high-pass corner in Hz
+  mix: 1, // wet/dry blend — parallel compression
+}
+
+function clamp(v, lo, hi) {
+  return v < lo ? lo : v > hi ? hi : v
+}
+
+/** Geometric interpolation between the dial-1 and dial-7 endpoints. */
+function dialToSeconds(dial, slowestS, fastestS) {
+  const t = (clamp(dial, 1, 7) - 1) / 6
+  return slowestS * Math.pow(fastestS / slowestS, t)
+}
+
+/**
+ * Attack/release time actually modeled at a given dial position. Exported so
+ * the panel can print the real number under the knob instead of carrying a
+ * second, drift-prone copy of the table.
+ */
+export function attackSecondsForDial(dial) {
+  return dialToSeconds(dial, ATTACK_SLOWEST_S, ATTACK_FASTEST_S)
+}
+
+export function releaseSecondsForDial(dial) {
+  return dialToSeconds(dial, RELEASE_SLOWEST_S, RELEASE_FASTEST_S)
+}
+
+/**
+ * Stateful block processor. Feed it consecutive blocks of any length and it
+ * behaves identically to processing the concatenation in one pass (block size
+ * affects nothing — every coefficient is fixed at setParams time).
+ */
+export class FET1176Kernel {
+  constructor(sampleRate) {
+    this.sampleRate = sampleRate
+
+    // DC blocker pole (~5 Hz) — the asymmetric shaper shifts the operating point
+    this.dcR = 1 - 2 * Math.PI * 5 / sampleRate
+
+    // Sidechain / detector state
+    this.hpfLp1 = 0
+    this.hpfLp2 = 0
+    this.grMain = 0
+    this.grTail = 0
+
+    // Per-channel DC blocker state (grown on demand)
+    this.dcX = []
+    this.dcY = []
+
+    // Metering
+    this.grDb = 0
+    this.maxGrDb = 0
+    this.grSum = 0
+    this.grActive = 0
+
+    this.gainScratch = new Float32Array(128)
+
+    this.params = { ...FET1176_KERNEL_DEFAULTS }
+    this.setParams({})
+  }
+
+  /** Merge a partial param update and recompute derived coefficients. */
+  setParams(partial) {
+    const p = { ...this.params, ...partial }
+    this.params = p
+
+    const sr = this.sampleRate
+
+    this.isAllButtons = String(p.ratio) === 'all'
+    if (this.isAllButtons) {
+      this.kneeDb = ALL_KNEE_DB
+      this.thresholdDb = THRESHOLD_DBFS - ALL_THRESHOLD_DROP_DB
+      this.tailFraction = ALL_TAIL_FRACTION
+      this.tailMult = ALL_TAIL_MULT
+    } else {
+      const ratioKey = RATIO_VALUES[p.ratio] ? p.ratio : '4'
+      this.ratio = RATIO_VALUES[ratioKey]
+      this.slope = 1 - 1 / this.ratio
+      this.kneeDb = RATIO_KNEE_DB[ratioKey]
+      this.thresholdDb = THRESHOLD_DBFS
+      this.tailFraction = TAIL_FRACTION
+      this.tailMult = TAIL_MULT
+    }
+    this.halfKnee = this.kneeDb / 2
+    this.mainFraction = 1 - this.tailFraction
+
+    // Ballistics. Attack is applied to the whole reduction; release splits
+    // across a main stage and a slower tail.
+    let attackS = dialToSeconds(p.attack, ATTACK_SLOWEST_S, ATTACK_FASTEST_S)
+    if (this.isAllButtons) attackS *= ALL_ATTACK_LAG
+    const releaseS = dialToSeconds(p.release, RELEASE_SLOWEST_S, RELEASE_FASTEST_S)
+
+    this.attackCoef = 1 - Math.exp(-1 / (sr * attackS))
+    this.releaseCoef = 1 - Math.exp(-1 / (sr * releaseS))
+    this.tailCoef = 1 - Math.exp(-1 / (sr * releaseS * this.tailMult))
+
+    // Input attenuator: audio path and detector both, as on the hardware.
+    const knob = clamp(p.inputDrive, 0, 100) / 100
+    this.inputDriveDb = IN_DRIVE_MIN_DB + IN_DRIVE_SPAN_DB * Math.pow(knob, IN_TAPER)
+    this.inputLin = Math.exp(this.inputDriveDb * LN10_OVER_20)
+    this.outputLin = Math.exp(p.outputGainDb * LN10_OVER_20)
+
+    // Optional sidechain high-pass (0 = off, the stock broadband detector).
+    // Two cascaded one-poles: a single pole leaves too much of a 60-80 Hz
+    // plosive in the detector to be worth switching on.
+    this.scHpfOn = p.scHpfHz > 0
+    this.hpfLpCoef = this.scHpfOn
+      ? 1 - Math.exp(-2 * Math.PI * p.scHpfHz / sr)
+      : 0
+
+    // FET + class-A output amp. Drive can go sub-unity (the slope is
+    // normalized back to 1 below), so `fetDrive` sets harmonic content
+    // without changing level.
+    const amount = clamp(p.fetDrive, 0, 1)
+    this.applyFet = amount > 0
+    this.fetDriveLin = (0.3 + 2.2 * amount) * (this.isAllButtons ? ALL_FET_BOOST : 1)
+    this.fetBias = 0.15 * amount
+    this.tanhBias = Math.tanh(this.fetBias)
+    // Normalize so the shaper has unity small-signal gain
+    this.fetNorm = this.fetDriveLin * (1 - this.tanhBias * this.tanhBias)
+
+    this.wetMix = clamp(p.mix, 0, 1)
+    this.dryMix = 1 - this.wetMix
+  }
+
+  /** Static curve: overshoot in dB -> gain reduction in dB. */
+  _grForOvershoot(over) {
+    if (over <= -this.halfKnee) return 0
+    const slope = this.isAllButtons
+      ? 1 - 1 / (ALL_RATIO_MIN + ALL_RATIO_SPAN * (over > 0 ? over / (over + ALL_RATIO_HALF_DB) : 0))
+      : this.slope
+    if (over >= this.halfKnee) return slope * over
+    const t = over + this.halfKnee
+    return slope * t * t / (2 * this.kneeDb)
+  }
+
+  /**
+   * Process one block.
+   *
+   * @param {Float32Array[]} inputChannels  - per-channel input (any count)
+   * @param {Float32Array[]} outputChannels - per-channel output to fill
+   * @param {number} n                      - samples in this block
+   */
+  process(inputChannels, outputChannels, n) {
+    const nIn = inputChannels.length
+    const nOut = outputChannels.length
+    if (nIn === 0 || n === 0) {
+      for (let ch = 0; ch < nOut; ch++) outputChannels[ch].fill(0, 0, n)
+      return
+    }
+
+    if (this.gainScratch.length < n) this.gainScratch = new Float32Array(n)
+    const gain = this.gainScratch
+    const chScale = 1 / nIn
+
+    let { hpfLp1, hpfLp2, grMain, grTail } = this
+
+    for (let i = 0; i < n; i++) {
+      // Mono sidechain tap, taken after the input attenuator
+      let x = inputChannels[0][i]
+      for (let ch = 1; ch < nIn; ch++) x += inputChannels[ch][i]
+      x *= chScale * this.inputLin
+
+      let sc = x
+      if (this.scHpfOn) {
+        hpfLp1 += (x - hpfLp1) * this.hpfLpCoef
+        const hp1 = x - hpfLp1
+        hpfLp2 += (hp1 - hpfLp2) * this.hpfLpCoef
+        sc = hp1 - hpfLp2
+      }
+
+      // Full-wave rectified peak detector. There is deliberately no envelope
+      // smoothing here: at the fast attack settings the gain cell is meant to
+      // track the waveform itself, and the release network supplies the only
+      // meaningful time constant on the way back down.
+      const rect = sc < 0 ? -sc : sc
+      const levelDb = rect > 1e-6 ? 20 * Math.log10(rect) : -120
+      const grTarget = this._grForOvershoot(levelDb - this.thresholdDb)
+
+      // Attack pulls both stages toward their share of the target together;
+      // release lets each stage decay at its own rate, which is what makes
+      // recovery depend on how dense the program was.
+      const gr = grMain + grTail
+      if (grTarget > gr) {
+        const delta = (grTarget - gr) * this.attackCoef
+        grMain += delta * this.mainFraction
+        grTail += delta * this.tailFraction
+      } else {
+        grMain += (grTarget * this.mainFraction - grMain) * this.releaseCoef
+        grTail += (grTarget * this.tailFraction - grTail) * this.tailCoef
+      }
+
+      const grNow = grMain + grTail
+      if (grNow > this.maxGrDb) this.maxGrDb = grNow
+      if (grNow > 0.05) {
+        this.grSum += grNow
+        this.grActive++
+      }
+      // Input attenuator and gain cell fold into one per-sample coefficient;
+      // Output is applied after the saturator, where the hardware's output
+      // control sits.
+      gain[i] = this.inputLin * Math.exp(-grNow * LN10_OVER_20)
+    }
+
+    this.hpfLp1 = hpfLp1
+    this.hpfLp2 = hpfLp2
+    this.grMain = grMain
+    this.grTail = grTail
+    this.grDb = grMain + grTail
+
+    while (this.dcX.length < nOut) {
+      this.dcX.push(0)
+      this.dcY.push(0)
+    }
+
+    for (let ch = 0; ch < nOut; ch++) {
+      const input = inputChannels[ch < nIn ? ch : nIn - 1]
+      const out = outputChannels[ch]
+      let dcX = this.dcX[ch]
+      let dcY = this.dcY[ch]
+      for (let i = 0; i < n; i++) {
+        const dry = input[i]
+        let wet = dry * gain[i]
+        if (this.applyFet) {
+          const shaped = (Math.tanh(this.fetDriveLin * wet + this.fetBias) - this.tanhBias) / this.fetNorm
+          dcY = shaped - dcX + this.dcR * dcY
+          dcX = shaped
+          wet = dcY
+        }
+        wet *= this.outputLin
+        // The dry side of the blend is the untouched input, so a parallel
+        // setting stays level-sane and bypass A/B compares like for like.
+        out[i] = dry * this.dryMix + wet * this.wetMix
+      }
+      this.dcX[ch] = dcX
+      this.dcY[ch] = dcY
+    }
+  }
+
+  getMetering() {
+    return {
+      grDb: this.grDb,
+      maxGainReductionDb: this.maxGrDb,
+      avgGainReductionDb: this.grActive > 0 ? this.grSum / this.grActive : 0,
+    }
+  }
+}
+
+/**
+ * One-shot offline convenience: process a whole buffer through a fresh
+ * kernel. Used by the auto-makeup measurement worker and by Node verification
+ * scripts; the app itself renders through an OfflineAudioContext running the
+ * worklet so preview and apply share the exact same code path.
+ */
+export function processFET1176Buffer(channelData, sampleRate, params = {}) {
+  const kernel = new FET1176Kernel(sampleRate)
+  kernel.setParams(params)
+
+  const n = channelData[0].length
+  const output = channelData.map(() => new Float32Array(n))
+  const BLOCK = 128
+  for (let off = 0; off < n; off += BLOCK) {
+    const len = Math.min(BLOCK, n - off)
+    kernel.process(
+      channelData.map(c => c.subarray(off, off + len)),
+      output.map(c => c.subarray(off, off + len)),
+      len,
+    )
+  }
+
+  const m = kernel.getMetering()
+  return {
+    channelData: output,
+    metering: {
+      maxGainReductionDb: m.maxGainReductionDb,
+      avgGainReductionDb: m.avgGainReductionDb,
+    },
+  }
+}
+
+/** RMS across every sample of every channel. */
+function rmsOfChannels(channels) {
+  let sumSq = 0
+  let count = 0
+  for (const ch of channels) {
+    for (let i = 0; i < ch.length; i++) sumSq += ch[i] * ch[i]
+    count += ch.length
+  }
+  return count > 0 ? Math.sqrt(sumSq / count) : 0
+}
+
+/**
+ * Compute the Output setting (dB) that restores the processed signal to the
+ * input's RMS level — i.e. what makes engaging the compressor level-neutral
+ * so bypass A/B comparisons aren't decided by loudness bias.
+ *
+ * This matters more here than on the OptoSmooth: Input drives the audio path
+ * as well as the detector, so moving it swings the output level by tens of dB
+ * and the user would otherwise be re-trimming Output after every touch.
+ *
+ * Measured, not derived from the curve: the kernel is run over the actual
+ * audio and the output RMS compared to the input's. RMS rather than peak,
+ * because reducing peaks is the point — peak matching would over-boost.
+ *
+ * Output is applied after the saturator (as on the hardware), so unlike the
+ * LA-2A's makeup it does not change the operating point of the nonlinearity
+ * and the first correction is normally exact. The loop is kept for the same
+ * shape as its counterpart and simply exits early.
+ */
+export function computeFET1176AutoMakeupDb(channelData, sampleRate, params = {}, options = {}) {
+  const { maxIterations = 3, toleranceDb = 0.05 } = options
+
+  const inputRms = rmsOfChannels(channelData)
+  if (inputRms <= 0) return 0
+
+  let makeupDb = 0
+  for (let i = 0; i < maxIterations; i++) {
+    const { channelData: out } = processFET1176Buffer(channelData, sampleRate, {
+      ...params,
+      outputGainDb: makeupDb,
+    })
+    const outRms = rmsOfChannels(out)
+    if (outRms <= 0) break
+    const correctionDb = 20 * Math.log10(inputRms / outRms)
+    makeupDb = clamp(makeupDb + correctionDb, -36, 36)
+    if (Math.abs(correctionDb) < toleranceDb) break
+  }
+  return makeupDb
+}
+
+// ── AudioWorklet registration (worklet scope only) ──────────────────────────
+
+// `registerProcessor` and the `sampleRate` global exist only inside an
+// AudioWorkletGlobalScope. When this file is imported as a normal module
+// (main bundle, Node), this block is skipped.
+if (typeof registerProcessor === 'function') {
+  // Post gain-reduction metering every ~21 ms at 44.1 kHz — enough for a
+  // smooth needle without flooding the message port.
+  const METER_INTERVAL_SAMPLES = 1024
+
+  class FET1176WorkletProcessor extends AudioWorkletProcessor {
+    constructor(options) {
+      super()
+      this.kernel = new FET1176Kernel(sampleRate)
+      if (options?.processorOptions?.params) {
+        this.kernel.setParams(options.processorOptions.params)
+      }
+      this.sinceMeter = 0
+      this.port.onmessage = (e) => {
+        if (e.data?.type === 'params') this.kernel.setParams(e.data.params)
+      }
+    }
+
+    process(inputs, outputs) {
+      const input = inputs[0]
+      const output = outputs[0]
+      if (!output || output.length === 0) return true
+
+      const n = output[0].length
+      if (!input || input.length === 0) {
+        for (const ch of output) ch.fill(0)
+        return true
+      }
+
+      this.kernel.process(input, output, n)
+
+      this.sinceMeter += n
+      if (this.sinceMeter >= METER_INTERVAL_SAMPLES) {
+        this.sinceMeter = 0
+        this.port.postMessage({ type: 'gr', grDb: this.kernel.grDb })
+      }
+      return true
+    }
+  }
+
+  registerProcessor('fet1176-processor', FET1176WorkletProcessor)
+}

--- a/src/audio/fet1176WorkletLoader.js
+++ b/src/audio/fet1176WorkletLoader.js
@@ -1,0 +1,18 @@
+/**
+ * Load the FET Punch worklet module into an AudioContext or
+ * OfflineAudioContext, once per context. fet1176Processor.js is referenced as
+ * a raw asset URL (it is deliberately dependency-free so it works unbundled in
+ * the worklet scope).
+ */
+const loadPromises = new WeakMap()
+
+export function ensureFET1176Worklet(context) {
+  let promise = loadPromises.get(context)
+  if (!promise) {
+    promise = context.audioWorklet.addModule(
+      new URL('./fet1176Processor.js', import.meta.url)
+    )
+    loadPromises.set(context, promise)
+  }
+  return promise
+}

--- a/src/audio/processing.js
+++ b/src/audio/processing.js
@@ -1,6 +1,11 @@
 import { getSegmentDuration } from './operations.js'
 import { ensureLA2AWorklet } from './la2aWorkletLoader.js'
 import { LA2A_DEFAULTS, toKernelParams } from './effects/la2aCompressor.js'
+import { ensureFET1176Worklet } from './fet1176WorkletLoader.js'
+import {
+  FET1176_DEFAULTS,
+  toKernelParams as toFET1176KernelParams,
+} from './effects/fet1176Compressor.js'
 
 /**
  * Render a region of the timeline to a flat PCM buffer.
@@ -208,7 +213,7 @@ export function adjustVolumeRegion(segments, start, end, gainDb, audioContext, s
  */
 const AUTO_MAKEUP_MAX_ANALYSIS_S = 30
 
-export function computeLA2AAutoMakeup(segments, start, end, kernelParams, sampleRate, channels) {
+function computeAutoMakeup(workerType, segments, start, end, kernelParams, sampleRate, channels) {
   let aStart = start
   let aEnd = end
   if (end - start > AUTO_MAKEUP_MAX_ANALYSIS_S) {
@@ -240,24 +245,38 @@ export function computeLA2AAutoMakeup(segments, start, end, kernelParams, sample
     }
 
     worker.postMessage(
-      { type: 'la2aAutoMakeup', channelData, sampleRate, params: kernelParams },
+      { type: workerType, channelData, sampleRate, params: kernelParams },
       channelData.map(c => c.buffer)
     )
   })
 }
 
+export function computeLA2AAutoMakeup(segments, start, end, kernelParams, sampleRate, channels) {
+  return computeAutoMakeup('la2aAutoMakeup', segments, start, end, kernelParams, sampleRate, channels)
+}
+
+/** Measure the FET Punch auto-makeup (Output) for a region — see above. */
+export function computeFET1176AutoMakeup(segments, start, end, kernelParams, sampleRate, channels) {
+  return computeAutoMakeup('fet1176AutoMakeup', segments, start, end, kernelParams, sampleRate, channels)
+}
+
 /**
- * Apply LA-2A compression via OfflineAudioContext running the same
- * AudioWorklet as the real-time preview (src/audio/la2aProcessor.js), so
- * the applied result is sample-identical to what the user heard.
+ * Render a region through a compressor worklet in an OfflineAudioContext.
+ *
+ * Both compressors apply this way, running the exact same worklet module as
+ * the real-time preview, so the applied result is sample-identical to what
+ * the user heard.
  */
-export async function applyLA2ARegion(segments, start, end, params, sampleRate, channels) {
+async function applyWorkletRegion(
+  segments, start, end, sampleRate, channels,
+  { ensureWorklet, processorName, kernelParams },
+) {
   const channelData = renderRegionToBuffer(segments, start, end, sampleRate, channels)
   const duration = end - start
   const numSamples = Math.ceil(duration * sampleRate)
 
   const offlineCtx = new OfflineAudioContext(channels, numSamples, sampleRate)
-  await ensureLA2AWorklet(offlineCtx)
+  await ensureWorklet(offlineCtx)
 
   const inputBuffer = offlineCtx.createBuffer(channels, numSamples, sampleRate)
   for (let ch = 0; ch < channels; ch++) {
@@ -267,18 +286,36 @@ export async function applyLA2ARegion(segments, start, end, params, sampleRate, 
   const source = offlineCtx.createBufferSource()
   source.buffer = inputBuffer
 
-  const la2aNode = new AudioWorkletNode(offlineCtx, 'la2a-processor', {
+  const node = new AudioWorkletNode(offlineCtx, processorName, {
     channelCount: channels,
     channelCountMode: 'explicit',
     outputChannelCount: [channels],
-    processorOptions: { params: toKernelParams({ ...LA2A_DEFAULTS, ...params }) },
+    processorOptions: { params: kernelParams },
   })
 
-  source.connect(la2aNode)
-  la2aNode.connect(offlineCtx.destination)
+  source.connect(node)
+  node.connect(offlineCtx.destination)
   source.start(0)
 
   return await offlineCtx.startRendering()
+}
+
+/** Apply OptoSmooth (LA-2A) compression to a region. */
+export function applyLA2ARegion(segments, start, end, params, sampleRate, channels) {
+  return applyWorkletRegion(segments, start, end, sampleRate, channels, {
+    ensureWorklet: ensureLA2AWorklet,
+    processorName: 'la2a-processor',
+    kernelParams: toKernelParams({ ...LA2A_DEFAULTS, ...params }),
+  })
+}
+
+/** Apply FET Punch (1176) compression to a region. */
+export function applyFET1176Region(segments, start, end, params, sampleRate, channels) {
+  return applyWorkletRegion(segments, start, end, sampleRate, channels, {
+    ensureWorklet: ensureFET1176Worklet,
+    processorName: 'fet1176-processor',
+    kernelParams: toFET1176KernelParams({ ...FET1176_DEFAULTS, ...params }),
+  })
 }
 
 /**

--- a/src/components/knobs/SegmentedSwitch.vue
+++ b/src/components/knobs/SegmentedSwitch.vue
@@ -1,0 +1,50 @@
+<script setup>
+/**
+ * Hardware-style switch bank — the panel equivalent of a row of latching
+ * push-buttons (COMP/LIMIT, the 1176's ratio buttons, sidechain filter).
+ *
+ * Values are compared with String() so numeric and string option values can
+ * be mixed freely with whatever the caller keeps in state.
+ */
+defineProps({
+  modelValue: { type: [String, Number], required: true },
+  // [{ value, label, title? }]
+  options: { type: Array, required: true },
+  accent: { type: String, default: '#f5a623' },
+  disabled: { type: Boolean, default: false },
+  // Caption under the bank, e.g. the selected setting's plain-English effect.
+  caption: { type: String, default: '' },
+  paddingX: { type: Number, default: 14 },
+})
+
+const emit = defineEmits(['update:modelValue'])
+</script>
+
+<template>
+  <div class="flex flex-col gap-[7px]">
+    <div class="flex rounded-full overflow-hidden" style="border:1px solid rgba(255,255,255,.1)">
+      <button
+        v-for="opt in options" :key="String(opt.value)"
+        class="cursor-pointer border-none py-[7px] transition-colors disabled:cursor-default"
+        :style="{
+          paddingLeft: paddingX + 'px',
+          paddingRight: paddingX + 'px',
+          background: String(modelValue) === String(opt.value)
+            ? `color-mix(in srgb, ${accent} 18%, transparent)`
+            : 'transparent',
+          color: String(modelValue) === String(opt.value)
+            ? `color-mix(in srgb, ${accent} 65%, #ffffff)`
+            : 'rgba(255,255,255,.4)',
+          font: `700 9px 'JetBrains Mono',monospace`,
+          letterSpacing: '.12em',
+        }"
+        :disabled="disabled"
+        :title="opt.title"
+        @click="emit('update:modelValue', opt.value)"
+      >{{ opt.label }}</button>
+    </div>
+    <span v-if="caption" class="text-center" style="font:600 8.5px 'Inter',system-ui;letter-spacing:.08em;color:rgba(255,255,255,.35)">
+      {{ caption }}
+    </span>
+  </div>
+</template>

--- a/src/components/meters/GainReductionBar.vue
+++ b/src/components/meters/GainReductionBar.vue
@@ -1,0 +1,45 @@
+<script setup>
+import { computed } from 'vue'
+
+/**
+ * Horizontal gain-reduction bar with a labelled scale.
+ * Shared by the plugin panels.
+ */
+const props = defineProps({
+  // Negative dB, matching DynamicsCompressorNode.reduction conventions.
+  reductionDb: { type: Number, required: true },
+  accent: { type: String, default: '#f5a623' },
+  // Reduction (in dB) that fills the bar end to end.
+  fullScaleDb: { type: Number, default: 40 },
+  scale: { type: Array, default: () => ['0', '-3', '-6', '-12', '-24'] },
+  title: { type: String, default: 'GAIN REDUCTION' },
+})
+
+const amount = computed(() => Math.abs(props.reductionDb))
+const fillPct = computed(() => Math.min(100, (amount.value / props.fullScaleDb) * 100))
+</script>
+
+<template>
+  <div>
+    <div class="flex items-center justify-between mb-1.5">
+      <span style="font:700 9.5px 'JetBrains Mono',monospace;letter-spacing:.18em;color:rgba(255,255,255,.5)">{{ title }}</span>
+      <span :style="{
+              font: `700 12px 'JetBrains Mono',monospace`,
+              color: `color-mix(in srgb, ${accent} 65%, #ffffff)`,
+              textShadow: `0 0 8px color-mix(in srgb, ${accent} 55%, transparent)`,
+            }">{{ amount.toFixed(1) }} dB</span>
+    </div>
+    <div class="relative h-[18px] rounded-[9px]" style="background:#0a0806;box-shadow:inset 0 0 0 1px rgba(255,255,255,.05),inset 0 2px 6px rgba(0,0,0,.8)">
+      <div class="absolute top-0 bottom-0 left-0 rounded-[9px] transition-all duration-75"
+           :style="{
+             width: fillPct + '%',
+             background: `linear-gradient(90deg, color-mix(in srgb, ${accent} 35%, #ffffff), ${accent})`,
+             boxShadow: `0 0 16px color-mix(in srgb, ${accent} 70%, transparent)`,
+           }"></div>
+      <div class="absolute inset-0 rounded-[9px]" style="background:repeating-linear-gradient(90deg,#0000 0 9px,rgba(10,8,6,.85) 9px 11px)"></div>
+    </div>
+    <div class="flex justify-between mt-[5px]" style="font:600 8px 'JetBrains Mono',monospace;color:rgba(255,255,255,.3)">
+      <span v-for="(mark, i) in scale" :key="i">{{ mark }}</span>
+    </div>
+  </div>
+</template>

--- a/src/components/meters/LevelMeter.vue
+++ b/src/components/meters/LevelMeter.vue
@@ -1,0 +1,40 @@
+<script setup>
+import { computed } from 'vue'
+
+/**
+ * Vertical segmented level meter — a column per channel plus a caption.
+ * Shared by the plugin panels for their IN and OUT readouts.
+ */
+const props = defineProps({
+  db: { type: Number, required: true },
+  label: { type: String, default: '' },
+  channels: { type: Number, default: 2 },
+  height: { type: Number, default: 150 },
+  // Bottom of the scale. The top is always 0 dBFS.
+  floorDb: { type: Number, default: -60 },
+})
+
+const fillPct = computed(() => {
+  if (!Number.isFinite(props.db)) return 0
+  const span = -props.floorDb
+  return Math.max(0, Math.min(100, ((props.db - props.floorDb) / span) * 100))
+})
+</script>
+
+<template>
+  <div class="flex flex-col items-center gap-[9px]">
+    <div class="flex gap-[3px]">
+      <div
+        v-for="ch in channels" :key="ch"
+        class="relative w-[9px] rounded-[3px]"
+        :style="{ height: height + 'px' }"
+        style="background:#07090c;box-shadow:inset 0 0 0 1px rgba(255,255,255,.05)"
+      >
+        <div class="absolute bottom-0 left-0 right-0 rounded-[3px] transition-all duration-100"
+             :style="{ height: fillPct + '%', background: 'linear-gradient(to top,#2ec96b 0 62%,#e9c63b 62% 84%,#e35d4f 84%)' }"></div>
+        <div class="absolute inset-0" style="background:repeating-linear-gradient(to top,#0000 0 4px,#07090c 4px 6px)"></div>
+      </div>
+    </div>
+    <span v-if="label" style="font:700 9px 'JetBrains Mono',monospace;letter-spacing:.16em;color:rgba(255,255,255,.45)">{{ label }}</span>
+  </div>
+</template>

--- a/src/components/meters/VuMeter.vue
+++ b/src/components/meters/VuMeter.vue
@@ -1,0 +1,168 @@
+<script setup>
+import { computed } from 'vue'
+
+/**
+ * Backlit analog VU meter with a swinging needle.
+ *
+ * Modeled on the meter of the hardware it fronts: one movement, switchable
+ * between gain reduction and output level. Both scales are laid out the way a
+ * real moving-coil meter behaves — deflection is linear in voltage, so the dB
+ * markings crowd together toward the end of their travel on their own rather
+ * than being placed by hand.
+ *
+ *  - `gr`: rest position is hard right (no reduction); the needle swings left
+ *    as the compressor works.
+ *  - `vu`: conventional VU scale, 0 VU referenced to whatever dBFS the
+ *    caller nominates (the hardware's +4 / +8 meter buttons).
+ */
+const props = defineProps({
+  mode: { type: String, default: 'gr' }, // 'gr' | 'vu'
+  // Gain reduction as a positive magnitude in dB.
+  reductionDb: { type: Number, default: 0 },
+  // Output level in dBFS, for the VU scale.
+  levelDb: { type: Number, default: -Infinity },
+  // dBFS that reads as 0 VU.
+  referenceDbfs: { type: Number, default: -18 },
+  accent: { type: String, default: '#79b8ff' },
+})
+
+// Needle sweep, degrees either side of vertical.
+const SWEEP = 52
+
+// Deflection is linear in voltage, so the dB markings bunch up on their own
+// at the crowded end of the travel. Only the numerals that stay legible get
+// printed; the rest are drawn as bare ticks, the way a real face is engraved.
+const GR_MARKS = [0, 1, 2, 3, 4, 5, 7, 10, 20]
+const GR_LABELLED = new Set([0, 1, 3, 5, 10, 20])
+const GR_MIN_FRACTION = 0.1 // voltage fraction at the 20 dB end of the scale
+
+const VU_MARKS = [-20, -10, -7, -5, -3, -1, 0, 1, 2, 3]
+const VU_LABELLED = new Set([-20, -10, -5, -3, 0, 3])
+const VU_TOP_DB = 3 // right-hand end of the scale
+
+/** Voltage fraction (0-1 across the face) for a gain-reduction reading. */
+function grFraction(db) {
+  const v = Math.pow(10, -Math.max(0, db) / 20)
+  return (v - GR_MIN_FRACTION) / (1 - GR_MIN_FRACTION)
+}
+
+/** Voltage fraction (0-1 across the face) for a VU reading. */
+function vuFraction(vu) {
+  return Math.pow(10, (vu - VU_TOP_DB) / 20)
+}
+
+function clamp01(v) {
+  return v < 0 ? 0 : v > 1 ? 1 : v
+}
+
+function fractionToAngle(f) {
+  return -SWEEP + clamp01(f) * SWEEP * 2
+}
+
+const isGr = computed(() => props.mode === 'gr')
+
+const marks = computed(() =>
+  isGr.value
+    ? GR_MARKS.map(db => ({
+        label: GR_LABELLED.has(db) ? String(db) : '',
+        angle: fractionToAngle(grFraction(db)),
+        major: GR_LABELLED.has(db),
+      }))
+    : VU_MARKS.map(db => ({
+        label: VU_LABELLED.has(db) ? (db > 0 ? `+${db}` : String(db)) : '',
+        angle: fractionToAngle(vuFraction(db)),
+        major: VU_LABELLED.has(db),
+        hot: db >= 0,
+      }))
+)
+
+const needleAngle = computed(() => {
+  if (isGr.value) return fractionToAngle(grFraction(props.reductionDb))
+  const vu = Number.isFinite(props.levelDb) ? props.levelDb - props.referenceDbfs : -60
+  return fractionToAngle(vuFraction(vu))
+})
+
+// The red arc: 0 VU and above on the level scale; the GR scale has none.
+const redArc = computed(() => {
+  if (isGr.value) return null
+  return { from: fractionToAngle(vuFraction(0)), to: SWEEP }
+})
+
+const PIVOT_X = 100
+const PIVOT_Y = 104
+const FACE_R = 86
+
+function polar(angleDeg, radius) {
+  const rad = (angleDeg - 90) * Math.PI / 180
+  return {
+    x: PIVOT_X + radius * Math.cos(rad),
+    y: PIVOT_Y + radius * Math.sin(rad),
+  }
+}
+
+/** SVG arc path along the scale radius. */
+function arcPath(fromDeg, toDeg, radius) {
+  const a = polar(fromDeg, radius)
+  const b = polar(toDeg, radius)
+  return `M ${a.x.toFixed(2)} ${a.y.toFixed(2)} A ${radius} ${radius} 0 0 1 ${b.x.toFixed(2)} ${b.y.toFixed(2)}`
+}
+
+const scaleArc = computed(() => arcPath(-SWEEP, SWEEP, FACE_R))
+const redArcPath = computed(() => (redArc.value ? arcPath(redArc.value.from, redArc.value.to, FACE_R) : ''))
+
+const tickLines = computed(() =>
+  marks.value.map(m => {
+    const outer = polar(m.angle, FACE_R)
+    const inner = polar(m.angle, FACE_R - (m.major ? 11 : 8))
+    const text = polar(m.angle, FACE_R - 22)
+    return { ...m, x1: outer.x, y1: outer.y, x2: inner.x, y2: inner.y, tx: text.x, ty: text.y }
+  })
+)
+
+const caption = computed(() => (isGr.value ? 'GAIN REDUCTION' : 'VU'))
+</script>
+
+<template>
+  <div class="relative rounded-[10px] overflow-hidden"
+       :style="{
+         background: 'linear-gradient(175deg,#f3ead4,#dfd2b4 62%,#cfc09e)',
+         boxShadow: `inset 0 0 22px rgba(120,96,54,.35), inset 0 0 0 1px rgba(0,0,0,.45), 0 0 18px color-mix(in srgb, ${accent} 18%, transparent)`,
+       }">
+    <svg viewBox="0 0 200 118" class="block w-full">
+      <!-- Scale arc -->
+      <path :d="scaleArc" fill="none" stroke="#3a3226" stroke-width="1.6" />
+      <path v-if="redArcPath" :d="redArcPath" fill="none" stroke="#c0392b" stroke-width="3.2" />
+
+      <!-- Ticks + numerals -->
+      <g v-for="(t, i) in tickLines" :key="i">
+        <line :x1="t.x1" :y1="t.y1" :x2="t.x2" :y2="t.y2"
+              :stroke="t.hot ? '#b03225' : '#3a3226'" :stroke-width="t.major ? 1.7 : 1.1" stroke-linecap="round" />
+        <text v-if="t.label" :x="t.tx" :y="t.ty" text-anchor="middle" dominant-baseline="middle"
+              :fill="t.hot ? '#a82f22' : '#3a3226'"
+              style="font:700 9px 'JetBrains Mono',monospace">{{ t.label }}</text>
+      </g>
+
+      <!-- Caption -->
+      <text :x="PIVOT_X" :y="PIVOT_Y - 21" text-anchor="middle"
+            fill="rgba(58,50,38,.72)"
+            style="font:700 7.5px 'Inter',system-ui;letter-spacing:.22em">{{ caption }}</text>
+
+      <!-- Needle -->
+      <g :style="{
+           transform: `rotate(${needleAngle}deg)`,
+           transformBox: 'view-box',
+           transformOrigin: `${PIVOT_X}px ${PIVOT_Y}px`,
+           transition: 'transform 130ms cubic-bezier(.22,.9,.3,1.08)',
+         }">
+        <line :x1="PIVOT_X" :y1="PIVOT_Y + 6" :x2="PIVOT_X" :y2="PIVOT_Y - FACE_R + 4"
+              stroke="#14100a" stroke-width="1.9" stroke-linecap="round" />
+      </g>
+      <circle :cx="PIVOT_X" :cy="PIVOT_Y" r="7" fill="#1b1710" />
+      <circle :cx="PIVOT_X" :cy="PIVOT_Y" r="4" fill="#3d3527" />
+    </svg>
+
+    <!-- Glass: a soft top-left highlight over the whole face -->
+    <div class="absolute inset-0 pointer-events-none"
+         style="background:linear-gradient(150deg,rgba(255,255,255,.42),rgba(255,255,255,0) 46%)"></div>
+  </div>
+</template>

--- a/src/components/panels/EffectsPanel.vue
+++ b/src/components/panels/EffectsPanel.vue
@@ -5,6 +5,7 @@ import { normalizeRegion, computePeakCache } from '../../audio/processing.js'
 import { getTimelineDuration } from '../../audio/operations.js'
 import { applyVocalSaturation } from '../../api/spotEffects.js'
 import { useLA2A } from '../../composables/useLA2A.js'
+import { useFET1176 } from '../../composables/useFET1176.js'
 
 const {
   state, hasSelection, getAudioContext, replaceRegion, setPeakCache,
@@ -31,6 +32,7 @@ const satMidDriveMult  = ref(0.1)
 const satHighDriveMult = ref(0.1)
 
 const { openModal: openLA2AModal } = useLA2A()
+const { openModal: openFET1176Modal } = useFET1176()
 
 const openSection = ref('normalize')
 
@@ -171,6 +173,23 @@ async function applySaturation() {
           <div class="flex-1">
             <div class="font-heading text-[13px] font-extrabold text-ink">Opto Smooth</div>
             <div class="text-[11px] text-ink-lt font-semibold mt-[1px]">Subtle, transparent leveler/compressor</div>
+          </div>
+          <svg viewBox="0 0 24 24" class="w-4 h-4 fill-none stroke-ink-lt shrink-0" stroke-width="2.5"><polyline points="9 18 15 12 9 6"/></svg>
+        </button>
+      </div>
+
+      <!-- FET Punch Compressor -->
+      <div class="border-2 border-border rounded-[var(--radius-md)] overflow-hidden transition-all">
+        <button
+          class="w-full flex items-center gap-2.5 px-[13px] py-3 bg-transparent border-none cursor-pointer text-left select-none"
+          @click="openFET1176Modal"
+        >
+          <div class="w-[34px] h-[34px] rounded-[var(--radius-sm)] flex items-center justify-center shrink-0 bg-bg">
+            <svg viewBox="0 0 24 24" class="w-4 h-4 fill-none stroke-ink-mid" stroke-width="2"><polyline points="13 2 4 14 11 14 10 22 20 10 13 10 13 2"/></svg>
+          </div>
+          <div class="flex-1">
+            <div class="font-heading text-[13px] font-extrabold text-ink">FET Punch</div>
+            <div class="text-[11px] text-ink-lt font-semibold mt-[1px]">Fast, forward, in-your-face compression</div>
           </div>
           <svg viewBox="0 0 24 24" class="w-4 h-4 fill-none stroke-ink-lt shrink-0" stroke-width="2.5"><polyline points="9 18 15 12 9 6"/></svg>
         </button>

--- a/src/components/panels/FET1176Modal.vue
+++ b/src/components/panels/FET1176Modal.vue
@@ -1,0 +1,290 @@
+<script setup>
+import { computed, ref, onMounted, watch } from 'vue'
+import { useFET1176 } from '../../composables/useFET1176.js'
+import { useEditorState } from '../../composables/useEditorState.js'
+import { attackSecondsForDial, releaseSecondsForDial } from '../../audio/fet1176Processor.js'
+import Knob from '../knobs/Knob.vue'
+import SegmentedSwitch from '../knobs/SegmentedSwitch.vue'
+import LevelMeter from '../meters/LevelMeter.vue'
+import VuMeter from '../meters/VuMeter.vue'
+import FloatingPluginPanel from './FloatingPluginPanel.vue'
+
+const {
+  fetInput, fetOutput, fetAttack, fetRelease, fetRatio, fetDrive, fetScHpf, fetMix,
+  fetAutoMakeup, fetPreview, fetReduction, fetInputDb, fetOutputDb, hasSelection,
+  togglePreview, syncInput, syncOutput, syncAttack, syncRelease, syncRatio,
+  syncDrive, syncScHpf, syncMix, toggleAutoMakeup, refreshAutoMakeup,
+  apply, teardown, closeModal,
+} = useFET1176()
+
+const { state } = useEditorState()
+
+// Default to engaged when the panel opens
+onMounted(() => {
+  if (!fetPreview.value) togglePreview()
+})
+
+// The makeup is measured from the selected region, so a new selection needs
+// a fresh measurement.
+watch(() => state.selection, () => refreshAutoMakeup(), { deep: true })
+
+// Steel blue rather than the OptoSmooth's amber — at a glance you can tell
+// which of the two is on screen.
+const ACCENT = '#79b8ff'
+
+const RATIO_OPTIONS = [
+  { value: '4', label: '4:1', title: 'Gentle enough to leave on a whole take' },
+  { value: '8', label: '8:1', title: 'Firm control' },
+  { value: '12', label: '12:1', title: 'Peak taming' },
+  { value: '20', label: '20:1', title: 'Effectively limiting' },
+  { value: 'all', label: 'ALL', title: 'All buttons in — the "British mode" trick' },
+]
+
+const RATIO_CAPTIONS = {
+  4: 'gentle — safe on a whole take',
+  8: 'firm control',
+  12: 'peak taming',
+  20: 'effectively limiting',
+  all: 'all buttons in — crushed, lagging, loud',
+}
+
+const SC_HPF_OPTIONS = [
+  { value: 0, label: 'OFF', title: 'Stock broadband detector' },
+  { value: 90, label: '90', title: 'Stops plosives and rumble from ducking the take' },
+  { value: 150, label: '150', title: 'Keeps chest weight out of the detector entirely' },
+]
+
+const METER_OPTIONS = [
+  { value: 'gr', label: 'GR', title: 'Gain reduction' },
+  { value: 'vu4', label: '+4', title: 'Output level, 0 VU = -18 dBFS' },
+  { value: 'vu8', label: '+8', title: 'Output level, 0 VU = -14 dBFS' },
+]
+
+const meterMode = ref('gr')
+const vuReference = computed(() => (meterMode.value === 'vu8' ? -14 : -18))
+
+const ratioCaption = computed(() => RATIO_CAPTIONS[fetRatio.value] ?? '')
+
+function close() {
+  teardown()
+  closeModal()
+}
+
+async function applyAndClose() {
+  await apply()
+  closeModal()
+}
+
+function formatInteger(v) {
+  return String(Math.round(v))
+}
+function formatGain(v) {
+  return `${v > 0 ? '+' : ''}${v.toFixed(1)}`
+}
+function formatPercent(v) {
+  return String(Math.round(v * 100))
+}
+
+function formatMs(seconds) {
+  const ms = seconds * 1000
+  if (ms < 1) return `${Math.round(ms * 1000)} µs`
+  if (ms < 100) return `${ms.toFixed(ms < 10 ? 1 : 0)} ms`
+  return `${(ms / 1000).toFixed(2)} s`
+}
+
+const attackTime = computed(() => formatMs(attackSecondsForDial(fetAttack.value)))
+const releaseTime = computed(() => formatMs(releaseSecondsForDial(fetRelease.value)))
+</script>
+
+<template>
+  <FloatingPluginPanel
+    :width="700"
+    :top="130"
+    :accent="ACCENT"
+    brand-lead="FET"
+    brand-tail="PUNCH"
+    background="linear-gradient(155deg,#171a1f,#0b0d10 60%)"
+    header-background="linear-gradient(#1e2229,#13161a)"
+    :engaged="fetPreview"
+    @toggle-engaged="togglePreview"
+    @close="close"
+  >
+    <template #header-center>
+      <span style="font:600 9.5px 'JetBrains Mono',monospace;letter-spacing:.16em;color:rgba(255,255,255,.32)">
+        FET LIMITING AMPLIFIER
+      </span>
+    </template>
+
+    <div class="px-[26px] pt-[20px] pb-[26px]">
+      <!-- Meter bay: VU movement on the left, gain staging on the right -->
+      <div class="flex items-start gap-[26px]">
+        <div class="w-[248px] shrink-0 flex flex-col items-center gap-[10px]">
+          <VuMeter
+            class="w-full"
+            :mode="meterMode === 'gr' ? 'gr' : 'vu'"
+            :reduction-db="Math.abs(fetReduction)"
+            :level-db="fetOutputDb"
+            :reference-dbfs="vuReference"
+            :accent="ACCENT"
+          />
+          <SegmentedSwitch
+            v-model="meterMode"
+            :options="METER_OPTIONS"
+            :accent="ACCENT"
+            :padding-x="16"
+          />
+        </div>
+
+        <div class="flex-1 flex items-center justify-between gap-[14px]">
+          <LevelMeter :db="fetInputDb" label="IN" :height="132" />
+
+          <div class="flex-1 flex justify-center gap-[26px]">
+            <div class="w-[118px]">
+              <!-- Input is the only threshold control there is: it drives the
+                   audio path and the detector together, exactly as the
+                   hardware attenuator does. -->
+              <Knob
+                :model-value="fetInput"
+                @update:model-value="syncInput"
+                :min="0" :max="100" :step="1"
+                label="Input" :accent="ACCENT" :format-value="formatInteger"
+                :disabled="!fetPreview"
+              />
+            </div>
+            <div class="w-[118px] flex flex-col items-center">
+              <div class="relative w-full" :style="{ opacity: fetAutoMakeup ? 0.78 : 1 }">
+                <Knob
+                  :model-value="fetOutput"
+                  @update:model-value="syncOutput"
+                  :min="-36" :max="24" :step="0.1"
+                  label="Output" :accent="ACCENT" :format-value="formatGain"
+                  :disabled="!fetPreview"
+                  :readonly="fetAutoMakeup"
+                />
+                <span
+                  v-if="fetAutoMakeup"
+                  class="absolute top-[2px] right-[4px] px-1.5 py-[2px] rounded-full pointer-events-none"
+                  :style="{
+                    background: `color-mix(in srgb, ${ACCENT} 20%, transparent)`,
+                    border: `1px solid color-mix(in srgb, ${ACCENT} 40%, transparent)`,
+                    font: `700 7px/1 'JetBrains Mono',monospace`,
+                    letterSpacing: '.09em',
+                    color: `color-mix(in srgb, ${ACCENT} 65%, #ffffff)`,
+                  }"
+                >AUTO</span>
+              </div>
+              <!-- Auto makeup matters more here than on the OptoSmooth:
+                   Input feeds the audio path too, so driving the unit harder
+                   swings the output level by tens of dB. With AUTO on, the
+                   plugin keeps Output level-matched to the input so pushing
+                   Input is a change of character, not of loudness. -->
+              <button
+                class="mt-[7px] px-2.5 py-[4px] rounded-full cursor-pointer transition-all disabled:cursor-default"
+                :style="{
+                  background: fetAutoMakeup ? `color-mix(in srgb, ${ACCENT} 16%, transparent)` : 'rgba(255,255,255,.05)',
+                  border: `1px solid ${fetAutoMakeup ? `color-mix(in srgb, ${ACCENT} 42%, transparent)` : 'rgba(255,255,255,.09)'}`,
+                  color: fetAutoMakeup ? `color-mix(in srgb, ${ACCENT} 65%, #ffffff)` : 'rgba(255,255,255,.4)',
+                  font: `700 8.5px 'JetBrains Mono',monospace`,
+                  letterSpacing: '.1em',
+                  opacity: fetPreview ? 1 : 0.4,
+                }"
+                :disabled="!fetPreview"
+                :title="fetAutoMakeup
+                  ? 'Auto makeup on. Click to take manual control of Output.'
+                  : 'Auto makeup off. Click to let the plugin match Output to the input level.'"
+              @click="toggleAutoMakeup"
+              >AUTO</button>
+            </div>
+          </div>
+
+          <LevelMeter :db="fetOutputDb" label="OUT" :height="132" />
+        </div>
+      </div>
+
+      <!-- Ratio buttons + sidechain filter, and the ballistics -->
+      <div class="flex items-start justify-between gap-[20px] mt-[18px] pt-[16px]" style="border-top:1px solid rgba(255,255,255,.06)">
+        <div class="flex flex-col gap-[12px] pt-[6px]">
+          <div class="flex items-center gap-[10px]">
+            <span class="w-[46px]" style="font:700 8.5px 'JetBrains Mono',monospace;letter-spacing:.16em;color:rgba(255,255,255,.4)">RATIO</span>
+            <SegmentedSwitch
+              :model-value="fetRatio"
+              @update:model-value="syncRatio"
+              :options="RATIO_OPTIONS"
+              :accent="ACCENT"
+              :disabled="!fetPreview"
+              :padding-x="11"
+              :caption="ratioCaption"
+            />
+          </div>
+          <div class="flex items-center gap-[10px]">
+            <span class="w-[46px]" style="font:700 8.5px 'JetBrains Mono',monospace;letter-spacing:.16em;color:rgba(255,255,255,.4)">SC HPF</span>
+            <!-- Not on the original: the 1176's detector is broadband, which
+                 lets plosives duck a whole phrase. Off is the stock path. -->
+            <SegmentedSwitch
+              :model-value="fetScHpf"
+              @update:model-value="syncScHpf"
+              :options="SC_HPF_OPTIONS"
+              :accent="ACCENT"
+              :disabled="!fetPreview"
+              :padding-x="13"
+            />
+          </div>
+        </div>
+
+        <div class="flex gap-[18px]">
+          <div class="w-[72px] flex flex-col items-center">
+            <!-- Dial numbering follows the panel: 7 is the FASTEST position,
+                 not the slowest. -->
+            <Knob
+              :model-value="fetAttack"
+              @update:model-value="syncAttack"
+              :min="1" :max="7" :step="1" :value-font-px="13"
+              label="Attack" :accent="ACCENT" :format-value="formatInteger"
+              :disabled="!fetPreview"
+            />
+            <span class="mt-[3px]" style="font:600 8px 'JetBrains Mono',monospace;color:rgba(255,255,255,.32)">{{ attackTime }}</span>
+          </div>
+          <div class="w-[72px] flex flex-col items-center">
+            <Knob
+              :model-value="fetRelease"
+              @update:model-value="syncRelease"
+              :min="1" :max="7" :step="1" :value-font-px="13"
+              label="Release" :accent="ACCENT" :format-value="formatInteger"
+              :disabled="!fetPreview"
+            />
+            <span class="mt-[3px]" style="font:600 8px 'JetBrains Mono',monospace;color:rgba(255,255,255,.32)">{{ releaseTime }}</span>
+          </div>
+          <div class="w-[72px]">
+            <Knob
+              :model-value="fetDrive"
+              @update:model-value="syncDrive"
+              :min="0" :max="1" :step="0.01" :value-font-px="13"
+              label="FET Drive" :accent="ACCENT" :format-value="formatPercent"
+              :disabled="!fetPreview"
+            />
+          </div>
+          <div class="w-[72px]">
+            <!-- Blends the untouched input back in — parallel compression
+                 without a second track. -->
+            <Knob
+              :model-value="fetMix"
+              @update:model-value="syncMix"
+              :min="0" :max="1" :step="0.01" :value-font-px="13"
+              label="Mix" :accent="ACCENT" :format-value="formatPercent"
+              :disabled="!fetPreview"
+            />
+          </div>
+        </div>
+      </div>
+
+      <button
+        class="w-full flex items-center justify-center gap-1.5 mt-4 py-2.5 rounded-full border-none cursor-pointer transition-opacity disabled:opacity-60 disabled:cursor-default"
+        style="background:linear-gradient(90deg,#79b8ff,#4f8fd6);color:#0c1218;font:800 13px 'Inter';letter-spacing:.02em"
+        :disabled="!hasSelection || !fetPreview"
+        @click="applyAndClose"
+      >
+        {{ !fetPreview ? 'Turn on FET Punch to apply' : hasSelection ? 'Apply compression' : 'Make a selection on the waveform to apply' }}
+      </button>
+    </div>
+  </FloatingPluginPanel>
+</template>

--- a/src/components/panels/FloatingPluginPanel.vue
+++ b/src/components/panels/FloatingPluginPanel.vue
@@ -1,0 +1,138 @@
+<script setup>
+import { ref, onMounted } from 'vue'
+
+/**
+ * Shared shell for the outboard-gear plugin panels (OptoSmooth, FET Punch).
+ *
+ * Owns the chrome every plugin needs and nothing about any one of them: the
+ * floating draggable frame, the header with brand mark, the engage/bypass
+ * pill and the close button. Everything gear-specific — knobs, meters,
+ * switches — arrives through the default slot.
+ */
+const props = defineProps({
+  width: { type: Number, default: 640 },
+  // Vertical offset of the panel's initial resting place.
+  top: { type: Number, default: 90 },
+  accent: { type: String, default: '#f5a623' },
+  // Two-part brand mark, e.g. "OPTO" + "SMOOTH": the first word is set solid,
+  // the second in a lighter weight.
+  brandLead: { type: String, required: true },
+  brandTail: { type: String, default: '' },
+  // Faceplate gradients — each plugin gets its own colour.
+  background: { type: String, default: 'linear-gradient(155deg,#1a1815,#100e0b 60%)' },
+  headerBackground: { type: String, default: 'linear-gradient(#221f1a,#171410)' },
+  engaged: { type: Boolean, default: false },
+})
+
+const emit = defineEmits(['toggle-engaged', 'close'])
+
+// Floating, draggable position — starts near the top-right so it doesn't
+// cover the waveform, and stays wherever the user drags it.
+const pos = ref({ x: 0, y: props.top })
+const dragging = ref(false)
+let dragOffsetX = 0
+let dragOffsetY = 0
+
+onMounted(() => {
+  pos.value.x = Math.max(16, window.innerWidth - props.width - 40)
+})
+
+function clampToViewport() {
+  const maxX = window.innerWidth - 120
+  const maxY = window.innerHeight - 60
+  pos.value.x = Math.min(Math.max(-props.width + 120, pos.value.x), maxX)
+  pos.value.y = Math.min(Math.max(0, pos.value.y), maxY)
+}
+
+function onDragStart(e) {
+  dragging.value = true
+  dragOffsetX = e.clientX - pos.value.x
+  dragOffsetY = e.clientY - pos.value.y
+  e.currentTarget.setPointerCapture(e.pointerId)
+}
+
+function onDragMove(e) {
+  if (!dragging.value) return
+  pos.value.x = e.clientX - dragOffsetX
+  pos.value.y = e.clientY - dragOffsetY
+}
+
+function onDragEnd(e) {
+  if (!dragging.value) return
+  dragging.value = false
+  // On pointercancel the capture is already implicitly released
+  try { e.currentTarget.releasePointerCapture(e.pointerId) } catch { /* not captured */ }
+  clampToViewport()
+}
+</script>
+
+<template>
+  <div
+    class="fixed z-[500] rounded-2xl overflow-hidden"
+    :style="{
+      left: pos.x + 'px', top: pos.y + 'px', width: width + 'px',
+      background,
+      boxShadow: '0 24px 60px rgba(0,0,0,.55),inset 0 0 0 1px rgba(255,255,255,.05)',
+      fontFamily: `'Inter',system-ui,sans-serif`,
+      animation: dragging ? 'none' : 'pluginBounceIn 0.3s cubic-bezier(0.34,1.56,0.64,1) both',
+      userSelect: dragging ? 'none' : 'auto',
+    }"
+  >
+    <!-- Header (drag handle) -->
+    <div
+      class="flex items-center justify-between px-[18px] h-12 touch-none"
+      :class="dragging ? 'cursor-grabbing' : 'cursor-grab'"
+      style="border-bottom:1px solid rgba(255,255,255,.06)"
+      :style="{ background: headerBackground }"
+      @pointerdown="onDragStart"
+      @pointermove="onDragMove"
+      @pointerup="onDragEnd"
+      @pointercancel="onDragEnd"
+    >
+      <div class="flex items-center gap-2.5">
+        <div class="w-3.5 h-3.5 rounded-full"
+             :style="{
+               background: `linear-gradient(135deg, color-mix(in srgb, ${accent} 45%, #ffffff), ${accent})`,
+               boxShadow: `0 0 10px color-mix(in srgb, ${accent} 65%, transparent)`,
+             }"></div>
+        <span style="font:800 13px/1 'Inter';letter-spacing:.22em;color:#f6ecdd">{{ brandLead }}&nbsp;<span style="font-weight:500;color:rgba(255,255,255,.4)">{{ brandTail }}</span></span>
+      </div>
+
+      <!-- Optional middle slot (preset selector and the like) -->
+      <slot name="header-center" />
+
+      <div class="flex items-center gap-2">
+        <button
+          class="flex items-center gap-2 px-3 py-1.5 rounded-full border cursor-pointer transition-opacity"
+          :style="{
+            background: `color-mix(in srgb, ${accent} 14%, transparent)`,
+            borderColor: `color-mix(in srgb, ${accent} 40%, transparent)`,
+            opacity: engaged ? 1 : 0.55,
+          }"
+          @pointerdown.stop
+          @click="emit('toggle-engaged')"
+        >
+          <span class="w-[7px] h-[7px] rounded-full" :style="{ background: accent, boxShadow: `0 0 7px ${accent}` }"></span>
+          <span :style="{ font: `700 9px 'JetBrains Mono',monospace`, letterSpacing: '.14em', color: `color-mix(in srgb, ${accent} 65%, #ffffff)` }">{{ engaged ? 'ON' : 'BYPASS' }}</span>
+        </button>
+        <button
+          class="flex items-center justify-center w-7 h-7 rounded-full border-none cursor-pointer"
+          style="background:rgba(255,255,255,.06);color:rgba(255,255,255,.55)"
+          @pointerdown.stop
+          @click="emit('close')"
+        >
+          <svg viewBox="0 0 24 24" class="w-3.5 h-3.5 fill-none stroke-current" stroke-width="2.5"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
+        </button>
+      </div>
+    </div>
+
+    <slot />
+  </div>
+</template>
+
+<style scoped>
+@keyframes pluginBounceIn {
+  0% { opacity: 0; transform: scale(0.94) translateY(8px); }
+  100% { opacity: 1; transform: scale(1) translateY(0); }
+}
+</style>

--- a/src/components/panels/LA2AModal.vue
+++ b/src/components/panels/LA2AModal.vue
@@ -3,6 +3,10 @@ import { computed, ref, onMounted, watch } from 'vue'
 import { useLA2A } from '../../composables/useLA2A.js'
 import { useEditorState } from '../../composables/useEditorState.js'
 import Knob from '../knobs/Knob.vue'
+import SegmentedSwitch from '../knobs/SegmentedSwitch.vue'
+import LevelMeter from '../meters/LevelMeter.vue'
+import GainReductionBar from '../meters/GainReductionBar.vue'
+import FloatingPluginPanel from './FloatingPluginPanel.vue'
 
 const {
   la2aMode, la2aPeakReduction, la2aGain, la2aTubeDrive, la2aEmphasis,
@@ -28,53 +32,11 @@ const autoMakeupLabel = computed(() =>
 )
 
 const ACCENT = '#f5a623'
-const PANEL_WIDTH = 640
 
-// Floating, draggable position — starts near the top-right so it doesn't
-// cover the waveform, and stays wherever the user drags it.
-const pos = ref({ x: 0, y: 90 })
-const dragging = ref(false)
-let dragOffsetX = 0
-let dragOffsetY = 0
-
-onMounted(() => {
-  pos.value.x = Math.max(16, window.innerWidth - PANEL_WIDTH - 40)
-})
-
-function clampToViewport() {
-  const maxX = window.innerWidth - 120
-  const maxY = window.innerHeight - 60
-  pos.value.x = Math.min(Math.max(-PANEL_WIDTH + 120, pos.value.x), maxX)
-  pos.value.y = Math.min(Math.max(0, pos.value.y), maxY)
-}
-
-function onDragStart(e) {
-  dragging.value = true
-  dragOffsetX = e.clientX - pos.value.x
-  dragOffsetY = e.clientY - pos.value.y
-  e.currentTarget.setPointerCapture(e.pointerId)
-}
-
-function onDragMove(e) {
-  if (!dragging.value) return
-  pos.value.x = e.clientX - dragOffsetX
-  pos.value.y = e.clientY - dragOffsetY
-}
-
-function onDragEnd(e) {
-  if (!dragging.value) return
-  dragging.value = false
-  // On pointercancel the capture is already implicitly released
-  try { e.currentTarget.releasePointerCapture(e.pointerId) } catch { /* not captured */ }
-  clampToViewport()
-}
-
-const grPct = computed(() => Math.min(100, Math.abs(la2aReduction.value) * 2.5))
-
-function dbToPct(db) {
-  if (!Number.isFinite(db)) return 0
-  return Math.max(0, Math.min(100, ((db + 60) / 60) * 100))
-}
+const MODE_OPTIONS = [
+  { value: 'compress', label: 'COMP' },
+  { value: 'limit', label: 'LIMIT' },
+]
 
 function close() {
   teardown()
@@ -113,33 +75,17 @@ function selectMockPreset(name) {
 </script>
 
 <template>
-  <div
-    class="fixed z-[500] rounded-2xl overflow-hidden"
-    :style="{
-      left: pos.x + 'px', top: pos.y + 'px', width: PANEL_WIDTH + 'px',
-      background: 'linear-gradient(155deg,#1a1815,#100e0b 60%)',
-      boxShadow: '0 24px 60px rgba(0,0,0,.55),inset 0 0 0 1px rgba(255,255,255,.05)',
-      fontFamily: `'Inter',system-ui,sans-serif`,
-      animation: dragging ? 'none' : 'la2aBounceIn 0.3s cubic-bezier(0.34,1.56,0.64,1) both',
-      userSelect: dragging ? 'none' : 'auto',
-    }"
+  <FloatingPluginPanel
+    :width="640"
+    :accent="ACCENT"
+    brand-lead="OPTO"
+    brand-tail="SMOOTH"
+    :engaged="la2aPreview"
+    @toggle-engaged="togglePreview"
+    @close="close"
   >
-    <!-- Header (drag handle) -->
-    <div
-      class="flex items-center justify-between px-[18px] h-12 touch-none"
-      :class="dragging ? 'cursor-grabbing' : 'cursor-grab'"
-      style="background:linear-gradient(#221f1a,#171410);border-bottom:1px solid rgba(255,255,255,.06)"
-      @pointerdown="onDragStart"
-      @pointermove="onDragMove"
-      @pointerup="onDragEnd"
-      @pointercancel="onDragEnd"
-    >
-      <div class="flex items-center gap-2.5">
-        <div class="w-3.5 h-3.5 rounded-full" style="background:linear-gradient(135deg,#ffd88a,#f5a623);box-shadow:0 0 10px rgba(245,166,35,.65)"></div>
-        <span style="font:800 13px/1 'Inter';letter-spacing:.22em;color:#f6ecdd">OPTO&nbsp;<span style="font-weight:500;color:rgba(255,255,255,.4)">SMOOTH</span></span>
-      </div>
-
-      <!-- Preset selector — visual mockup only, not yet wired to real presets -->
+    <!-- Preset selector — visual mockup only, not yet wired to real presets -->
+    <template #header-center>
       <div class="relative" @pointerdown.stop>
         <button
           class="cursor-pointer"
@@ -163,199 +109,109 @@ function selectMockPreset(name) {
           </button>
         </div>
       </div>
-
-      <div class="flex items-center gap-2">
-        <button
-          class="flex items-center gap-2 px-3 py-1.5 rounded-full border cursor-pointer transition-opacity"
-          style="background:rgba(245,166,35,.14);border-color:rgba(245,166,35,.4)"
-          :style="{ opacity: la2aPreview ? 1 : 0.55 }"
-          @pointerdown.stop
-          @click="togglePreview"
-        >
-          <span class="w-[7px] h-[7px] rounded-full" style="background:#f5a623;box-shadow:0 0 7px #f5a623"></span>
-          <span style="font:700 9px 'JetBrains Mono',monospace;letter-spacing:.14em;color:#f7c877">{{ la2aPreview ? 'ON' : 'BYPASS' }}</span>
-        </button>
-        <button
-          class="flex items-center justify-center w-7 h-7 rounded-full border-none cursor-pointer"
-          style="background:rgba(255,255,255,.06);color:rgba(255,255,255,.55)"
-          @pointerdown.stop
-          @click="close"
-        >
-          <svg viewBox="0 0 24 24" class="w-3.5 h-3.5 fill-none stroke-current" stroke-width="2.5"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
-        </button>
-      </div>
-    </div>
+    </template>
 
     <div class="px-[26px] pt-[22px] pb-[28px]">
-        <!-- Gain reduction bar -->
-        <div class="flex items-center justify-between mb-1.5">
-          <span style="font:700 9.5px 'JetBrains Mono',monospace;letter-spacing:.18em;color:rgba(255,255,255,.5)">GAIN REDUCTION</span>
-          <span style="font:700 12px 'JetBrains Mono',monospace;color:#f7c877;text-shadow:0 0 8px rgba(245,166,35,.55)">{{ Math.abs(la2aReduction).toFixed(1) }} dB</span>
-        </div>
-        <div class="relative h-[18px] rounded-[9px]" style="background:#0a0806;box-shadow:inset 0 0 0 1px rgba(255,255,255,.05),inset 0 2px 6px rgba(0,0,0,.8)">
-          <div class="absolute top-0 bottom-0 left-0 rounded-[9px] transition-all duration-75"
-               :style="{ width: grPct + '%', background: 'linear-gradient(90deg,#ffe0a0,#f5a623)', boxShadow: '0 0 16px rgba(245,166,35,.7)' }"></div>
-          <div class="absolute inset-0 rounded-[9px]" style="background:repeating-linear-gradient(90deg,#0000 0 9px,rgba(10,8,6,.85) 9px 11px)"></div>
-        </div>
-        <div class="flex justify-between mt-[5px]" style="font:600 8px 'JetBrains Mono',monospace;color:rgba(255,255,255,.3)">
-          <span>0</span><span>-3</span><span>-6</span><span>-12</span><span>-24</span>
-        </div>
+      <GainReductionBar :reduction-db="la2aReduction" :accent="ACCENT" />
 
-        <!-- IN meter · knobs · OUT meter -->
-        <div class="flex items-center justify-between gap-[22px] mt-[24px]">
-          <!-- IN -->
-          <div class="flex flex-col items-center gap-[9px]">
-            <div class="flex gap-[3px]">
-              <div class="relative w-[9px] h-[150px] rounded-[3px]" style="background:#07090c;box-shadow:inset 0 0 0 1px rgba(255,255,255,.05)">
-                <div class="absolute bottom-0 left-0 right-0 rounded-[3px] transition-all duration-100"
-                     :style="{ height: dbToPct(la2aInputDb) + '%', background: 'linear-gradient(to top,#2ec96b 0 62%,#e9c63b 62% 84%,#e35d4f 84%)' }"></div>
-                <div class="absolute inset-0" style="background:repeating-linear-gradient(to top,#0000 0 4px,#07090c 4px 6px)"></div>
-              </div>
-              <div class="relative w-[9px] h-[150px] rounded-[3px]" style="background:#07090c;box-shadow:inset 0 0 0 1px rgba(255,255,255,.05)">
-                <div class="absolute bottom-0 left-0 right-0 rounded-[3px] transition-all duration-100"
-                     :style="{ height: dbToPct(la2aInputDb) + '%', background: 'linear-gradient(to top,#2ec96b 0 62%,#e9c63b 62% 84%,#e35d4f 84%)' }"></div>
-                <div class="absolute inset-0" style="background:repeating-linear-gradient(to top,#0000 0 4px,#07090c 4px 6px)"></div>
-              </div>
-            </div>
-            <span style="font:700 9px 'JetBrains Mono',monospace;letter-spacing:.16em;color:rgba(255,255,255,.45)">IN</span>
+      <!-- IN meter · knobs · OUT meter -->
+      <div class="flex items-center justify-between gap-[22px] mt-[24px]">
+        <LevelMeter :db="la2aInputDb" label="IN" />
+
+        <div class="flex-1 flex justify-center gap-[40px]">
+          <div class="w-[130px]">
+            <Knob
+              :model-value="la2aPeakReduction"
+              @update:model-value="syncPeakReduction"
+              :min="0" :max="100" :step="1"
+              label="Peak Reduction" :accent="ACCENT" :format-value="formatPeakReduction"
+              :disabled="!la2aPreview"
+            />
           </div>
-
-          <!-- Knobs -->
-          <div class="flex-1 flex justify-center gap-[40px]">
-            <div class="w-[130px]">
+          <div class="w-[130px] flex flex-col items-center">
+            <div class="relative w-full" :style="{ opacity: la2aAutoMakeup ? 0.78 : 1 }">
               <Knob
-                :model-value="la2aPeakReduction"
-                @update:model-value="syncPeakReduction"
-                :min="0" :max="100" :step="1"
-                label="Peak Reduction" :accent="ACCENT" :format-value="formatPeakReduction"
+                :model-value="la2aGain"
+                @update:model-value="syncGain"
+                :min="-12" :max="24" :step="0.1"
+                label="Gain" :accent="ACCENT" :format-value="formatGain"
                 :disabled="!la2aPreview"
+                :readonly="la2aAutoMakeup"
               />
+              <span
+                v-if="la2aAutoMakeup"
+                class="absolute top-[2px] right-[4px] px-1.5 py-[2px] rounded-full pointer-events-none"
+                style="background:rgba(245,166,35,.2);border:1px solid rgba(245,166,35,.4);font:700 7px/1 'JetBrains Mono',monospace;letter-spacing:.09em;color:#f7c877"
+              >AUTO</span>
             </div>
-            <div class="w-[130px] flex flex-col items-center">
-              <div class="relative w-full" :style="{ opacity: la2aAutoMakeup ? 0.78 : 1 }">
-                <Knob
-                  :model-value="la2aGain"
-                  @update:model-value="syncGain"
-                  :min="-12" :max="24" :step="0.1"
-                  label="Gain" :accent="ACCENT" :format-value="formatGain"
-                  :disabled="!la2aPreview"
-                  :readonly="la2aAutoMakeup"
-                />
-                <span
-                  v-if="la2aAutoMakeup"
-                  class="absolute top-[2px] right-[4px] px-1.5 py-[2px] rounded-full pointer-events-none"
-                  style="background:rgba(245,166,35,.2);border:1px solid rgba(245,166,35,.4);font:700 7px/1 'JetBrains Mono',monospace;letter-spacing:.09em;color:#f7c877"
-                >AUTO</span>
-              </div>
-              <!-- Auto makeup drives the Gain knob above to whatever keeps
-                   the output level-matched to the input, so bypass A/B isn't
-                   decided by loudness. Switching it off leaves the knob where
-                   it stands and hands control back to the user. -->
-              <button
-                class="mt-[7px] px-2.5 py-[4px] rounded-full cursor-pointer transition-all disabled:cursor-default"
-                :style="{
-                  background: la2aAutoMakeup ? 'rgba(245,166,35,.16)' : 'rgba(255,255,255,.05)',
-                  border: `1px solid ${la2aAutoMakeup ? 'rgba(245,166,35,.42)' : 'rgba(255,255,255,.09)'}`,
-                  color: la2aAutoMakeup ? '#f7c877' : 'rgba(255,255,255,.4)',
-                  font: `700 8.5px 'JetBrains Mono',monospace`,
-                  letterSpacing: '.1em',
-                  opacity: la2aPreview ? 1 : 0.4,
-                }"
-                :disabled="!la2aPreview"
-                :title="la2aAutoMakeup
-                  ? 'Auto makeup on. Click to take manual control.'
-                  : 'Auto makeup off. Click to let the plugin automatically set the output gain.'"
-                @click="toggleAutoMakeup"
-              >{{ autoMakeupLabel }}</button>
-            </div>
-          </div>
-
-          <!-- OUT -->
-          <div class="flex flex-col items-center gap-[9px]">
-            <div class="flex gap-[3px]">
-              <div class="relative w-[9px] h-[150px] rounded-[3px]" style="background:#07090c;box-shadow:inset 0 0 0 1px rgba(255,255,255,.05)">
-                <div class="absolute bottom-0 left-0 right-0 rounded-[3px] transition-all duration-100"
-                     :style="{ height: dbToPct(la2aOutputDb) + '%', background: 'linear-gradient(to top,#2ec96b 0 62%,#e9c63b 62% 84%,#e35d4f 84%)' }"></div>
-                <div class="absolute inset-0" style="background:repeating-linear-gradient(to top,#0000 0 4px,#07090c 4px 6px)"></div>
-              </div>
-              <div class="relative w-[9px] h-[150px] rounded-[3px]" style="background:#07090c;box-shadow:inset 0 0 0 1px rgba(255,255,255,.05)">
-                <div class="absolute bottom-0 left-0 right-0 rounded-[3px] transition-all duration-100"
-                     :style="{ height: dbToPct(la2aOutputDb) + '%', background: 'linear-gradient(to top,#2ec96b 0 62%,#e9c63b 62% 84%,#e35d4f 84%)' }"></div>
-                <div class="absolute inset-0" style="background:repeating-linear-gradient(to top,#0000 0 4px,#07090c 4px 6px)"></div>
-              </div>
-            </div>
-            <span style="font:700 9px 'JetBrains Mono',monospace;letter-spacing:.16em;color:rgba(255,255,255,.45)">OUT</span>
+            <!-- Auto makeup drives the Gain knob above to whatever keeps
+                 the output level-matched to the input, so bypass A/B isn't
+                 decided by loudness. Switching it off leaves the knob where
+                 it stands and hands control back to the user. -->
+            <button
+              class="mt-[7px] px-2.5 py-[4px] rounded-full cursor-pointer transition-all disabled:cursor-default"
+              :style="{
+                background: la2aAutoMakeup ? 'rgba(245,166,35,.16)' : 'rgba(255,255,255,.05)',
+                border: `1px solid ${la2aAutoMakeup ? 'rgba(245,166,35,.42)' : 'rgba(255,255,255,.09)'}`,
+                color: la2aAutoMakeup ? '#f7c877' : 'rgba(255,255,255,.4)',
+                font: `700 8.5px 'JetBrains Mono',monospace`,
+                letterSpacing: '.1em',
+                opacity: la2aPreview ? 1 : 0.4,
+              }"
+              :disabled="!la2aPreview"
+              :title="la2aAutoMakeup
+                ? 'Auto makeup on. Click to take manual control.'
+                : 'Auto makeup off. Click to let the plugin automatically set the output gain.'"
+              @click="toggleAutoMakeup"
+            >{{ autoMakeupLabel }}</button>
           </div>
         </div>
 
-        <!-- Secondary row: Comp/Limit mode + small knobs (tube drive, R37 emphasis) -->
-        <div class="flex items-center justify-between mt-[20px] pt-[16px]" style="border-top:1px solid rgba(255,255,255,.06)">
-          <!-- Compress / Limit — the hardware's rear-panel switch -->
-          <div class="flex flex-col gap-[7px]">
-            <div class="flex rounded-full overflow-hidden" style="border:1px solid rgba(255,255,255,.1)">
-              <button
-                class="cursor-pointer border-none px-3.5 py-[7px] transition-colors"
-                :style="{
-                  background: la2aMode === 'compress' ? 'rgba(245,166,35,.18)' : 'transparent',
-                  color: la2aMode === 'compress' ? '#f7c877' : 'rgba(255,255,255,.4)',
-                  font: `700 9px 'JetBrains Mono',monospace`, letterSpacing: '.12em',
-                }"
-                :disabled="!la2aPreview"
-                @click="syncMode('compress')"
-              >COMP</button>
-              <button
-                class="cursor-pointer border-none px-3.5 py-[7px] transition-colors"
-                :style="{
-                  background: la2aMode === 'limit' ? 'rgba(245,166,35,.18)' : 'transparent',
-                  color: la2aMode === 'limit' ? '#f7c877' : 'rgba(255,255,255,.4)',
-                  font: `700 9px 'JetBrains Mono',monospace`, letterSpacing: '.12em',
-                }"
-                :disabled="!la2aPreview"
-                @click="syncMode('limit')"
-              >LIMIT</button>
-            </div>
-            <span class="text-center" style="font:600 8.5px 'Inter',system-ui;letter-spacing:.08em;color:rgba(255,255,255,.35)">
-              {{ la2aMode === 'compress' ? '~3:1 leveling' : 'hard ceiling' }}
-            </span>
-          </div>
-
-          <div class="flex gap-[26px]">
-            <div class="w-[78px]">
-              <Knob
-                :model-value="la2aTubeDrive"
-                @update:model-value="syncTubeDrive"
-                :min="0" :max="1" :step="0.01" :value-font-px="13"
-                label="Tube Drive" :accent="ACCENT" :format-value="formatPercent"
-                :disabled="!la2aPreview"
-              />
-            </div>
-            <div class="w-[78px]">
-              <Knob
-                :model-value="la2aEmphasis"
-                @update:model-value="syncEmphasis"
-                :min="0" :max="1" :step="0.01" :value-font-px="13"
-                label="R37 Emphasis" :accent="ACCENT" :format-value="formatPercent"
-                :disabled="!la2aPreview"
-              />
-            </div>
-          </div>
-        </div>
-
-        <button
-          class="w-full flex items-center justify-center gap-1.5 mt-3 py-2.5 rounded-full border-none cursor-pointer transition-opacity disabled:opacity-60 disabled:cursor-default"
-          style="background:linear-gradient(90deg,#f5a623,#e0921a);color:#1a1310;font:800 13px 'Inter';letter-spacing:.02em"
-          :disabled="!hasSelection || !la2aPreview"
-          @click="applyAndClose"
-        >
-          {{ !la2aPreview ? 'Turn on LA-2A to apply' : hasSelection ? 'Apply compression' : 'Make a selection on the waveform to apply' }}
-        </button>
+        <LevelMeter :db="la2aOutputDb" label="OUT" />
       </div>
-  </div>
-</template>
 
-<style scoped>
-@keyframes la2aBounceIn {
-  0% { opacity: 0; transform: scale(0.94) translateY(8px); }
-  100% { opacity: 1; transform: scale(1) translateY(0); }
-}
-</style>
+      <!-- Secondary row: Comp/Limit mode + small knobs (tube drive, R37 emphasis) -->
+      <div class="flex items-center justify-between mt-[20px] pt-[16px]" style="border-top:1px solid rgba(255,255,255,.06)">
+        <!-- Compress / Limit — the hardware's rear-panel switch -->
+        <SegmentedSwitch
+          :model-value="la2aMode"
+          @update:model-value="syncMode"
+          :options="MODE_OPTIONS"
+          :accent="ACCENT"
+          :disabled="!la2aPreview"
+          :caption="la2aMode === 'compress' ? '~3:1 leveling' : 'hard ceiling'"
+        />
+
+        <div class="flex gap-[26px]">
+          <div class="w-[78px]">
+            <Knob
+              :model-value="la2aTubeDrive"
+              @update:model-value="syncTubeDrive"
+              :min="0" :max="1" :step="0.01" :value-font-px="13"
+              label="Tube Drive" :accent="ACCENT" :format-value="formatPercent"
+              :disabled="!la2aPreview"
+            />
+          </div>
+          <div class="w-[78px]">
+            <Knob
+              :model-value="la2aEmphasis"
+              @update:model-value="syncEmphasis"
+              :min="0" :max="1" :step="0.01" :value-font-px="13"
+              label="R37 Emphasis" :accent="ACCENT" :format-value="formatPercent"
+              :disabled="!la2aPreview"
+            />
+          </div>
+        </div>
+      </div>
+
+      <button
+        class="w-full flex items-center justify-center gap-1.5 mt-3 py-2.5 rounded-full border-none cursor-pointer transition-opacity disabled:opacity-60 disabled:cursor-default"
+        style="background:linear-gradient(90deg,#f5a623,#e0921a);color:#1a1310;font:800 13px 'Inter';letter-spacing:.02em"
+        :disabled="!hasSelection || !la2aPreview"
+        @click="applyAndClose"
+      >
+        {{ !la2aPreview ? 'Turn on OptoSmooth to apply' : hasSelection ? 'Apply compression' : 'Make a selection on the waveform to apply' }}
+      </button>
+    </div>
+  </FloatingPluginPanel>
+</template>

--- a/src/composables/useEditorState.js
+++ b/src/composables/useEditorState.js
@@ -47,6 +47,7 @@ const state = reactive({
   processingProgress: 0,
   contextPanelOpen: false,
   la2aModalOpen: false,
+  fet1176ModalOpen: false,
   toasts: [],
 })
 

--- a/src/composables/useFET1176.js
+++ b/src/composables/useFET1176.js
@@ -1,0 +1,306 @@
+import { ref } from 'vue'
+import { useEditorState } from './useEditorState.js'
+import { applyFET1176Region, computeFET1176AutoMakeup, computePeakCache } from '../audio/processing.js'
+import { getEffectChain } from '../audio/effectChain.js'
+import { fet1176Effect, FET1176_DEFAULTS } from '../audio/effects/fet1176Compressor.js'
+
+// Singleton reactive state shared between the sidebar trigger and the modal
+const fetInput = ref(FET1176_DEFAULTS.inputDrive)
+const fetOutput = ref(FET1176_DEFAULTS.output)
+const fetAttack = ref(FET1176_DEFAULTS.attack)
+const fetRelease = ref(FET1176_DEFAULTS.release)
+const fetRatio = ref(FET1176_DEFAULTS.ratio)
+const fetDrive = ref(FET1176_DEFAULTS.fetDrive)
+const fetScHpf = ref(FET1176_DEFAULTS.scHpf)
+const fetMix = ref(FET1176_DEFAULTS.mix)
+
+// Auto makeup: on by default, and load-bearing here in a way it isn't on the
+// OptoSmooth — Input drives the audio path as well as the detector, so a
+// 20-point move on that knob swings the output by tens of dB. While auto is
+// on the plugin owns the Output knob: measurements are written into fetOutput
+// itself, so the knob always shows the gain actually in effect.
+const fetAutoMakeup = ref(true)
+const fetAutoMakeupBusy = ref(false)
+
+// Output knob travel — measured makeup is clamped to it so the knob position
+// can never disagree with the value in effect.
+const OUTPUT_MIN_DB = -36
+const OUTPUT_MAX_DB = 24
+
+const fetPreview = ref(false)
+const fetReduction = ref(0)
+const fetInputDb = ref(-Infinity)
+const fetOutputDb = ref(-Infinity)
+let meterId = null
+
+// Debounce + supersede state for the auto-makeup measurement, shared across
+// every useFET1176() caller so knob drags coalesce into one measurement.
+const AUTO_MAKEUP_DEBOUNCE_MS = 45
+let makeupTimer = null
+let makeupSeq = 0
+let makeupBurstActive = false
+let makeupBurstDirty = false
+
+function currentParams() {
+  return {
+    inputDrive: fetInput.value,
+    output: fetOutput.value,
+    attack: fetAttack.value,
+    release: fetRelease.value,
+    ratio: fetRatio.value,
+    fetDrive: fetDrive.value,
+    scHpf: fetScHpf.value,
+    mix: fetMix.value,
+  }
+}
+
+/** Params for the measurement pass — makeup is what we're solving for. */
+function measurementParams() {
+  return {
+    inputDrive: fetInput.value,
+    outputGainDb: 0,
+    attack: fetAttack.value,
+    release: fetRelease.value,
+    ratio: fetRatio.value,
+    fetDrive: fetDrive.value,
+    scHpfHz: fetScHpf.value,
+    mix: fetMix.value,
+  }
+}
+
+export function useFET1176() {
+  const { state, getAudioContext, hasSelection, replaceRegion, setPeakCache, startProcessing, endProcessing, showToast } = useEditorState()
+
+  function initChain() {
+    const ctx = getAudioContext()
+    const chain = getEffectChain(ctx)
+    if (!chain.effects.find(e => e.id === fet1176Effect.id)) {
+      chain.addEffect(fet1176Effect)
+    }
+    return chain
+  }
+
+  function startMeters(chain) {
+    stopMeters()
+    function tick() {
+      const nodes = chain.effects.find(e => e.id === fet1176Effect.id)?.nodes
+      if (nodes) {
+        fetReduction.value = nodes.getReduction()
+        fetInputDb.value = nodes.getInputLevelDb()
+        fetOutputDb.value = nodes.getOutputLevelDb()
+      }
+      meterId = requestAnimationFrame(tick)
+    }
+    meterId = requestAnimationFrame(tick)
+  }
+
+  function stopMeters() {
+    if (meterId !== null) {
+      cancelAnimationFrame(meterId)
+      meterId = null
+    }
+    fetReduction.value = 0
+    fetInputDb.value = -Infinity
+    fetOutputDb.value = -Infinity
+  }
+
+  function pushAllParams(chain) {
+    for (const [name, value] of Object.entries(currentParams())) {
+      chain.updateParam(fet1176Effect.id, name, value)
+    }
+  }
+
+  function togglePreview() {
+    const chain = initChain()
+    fetPreview.value = !fetPreview.value
+    chain.setEnabled(fet1176Effect.id, fetPreview.value)
+
+    if (fetPreview.value) {
+      pushAllParams(chain)
+      startMeters(chain)
+      refreshAutoMakeup()
+    } else {
+      stopMeters()
+    }
+  }
+
+  function pushParam(name, value) {
+    if (!fetPreview.value) return
+    const chain = getEffectChain(getAudioContext())
+    chain.updateParam(fet1176Effect.id, name, value)
+  }
+
+  function pushOutput() {
+    pushParam('output', fetOutput.value)
+  }
+
+  /**
+   * Re-measure the auto-makeup for the current selection and settings and
+   * drive the Output knob to it. Superseded calls are discarded by sequence
+   * number so a fast knob drag can't have an older measurement land after
+   * a newer one.
+   */
+  async function refreshAutoMakeup() {
+    if (!fetAutoMakeup.value || !state.selection || !state.currentFile) return
+
+    const { start, end } = state.selection
+    const seq = ++makeupSeq
+    fetAutoMakeupBusy.value = true
+    try {
+      const makeupDb = await computeFET1176AutoMakeup(
+        state.segments, start, end,
+        measurementParams(),
+        state.currentFile.sampleRate, state.currentFile.channels
+      )
+      if (seq !== makeupSeq) return // a newer measurement is already in flight
+      fetOutput.value = Math.max(OUTPUT_MIN_DB, Math.min(OUTPUT_MAX_DB, makeupDb))
+      pushOutput()
+    } catch (err) {
+      console.error('FET Punch auto makeup measurement failed:', err)
+    } finally {
+      if (seq === makeupSeq) fetAutoMakeupBusy.value = false
+    }
+  }
+
+  function scheduleAutoMakeup() {
+    if (!fetAutoMakeup.value) return
+
+    // Leading edge: first move in a burst measures immediately so the Output
+    // knob responds right away.
+    if (!makeupBurstActive) {
+      makeupBurstActive = true
+      makeupBurstDirty = false
+      refreshAutoMakeup()
+    } else {
+      // Additional moves during the debounce window request one trailing pass
+      // with the final knob value.
+      makeupBurstDirty = true
+    }
+
+    if (makeupTimer !== null) clearTimeout(makeupTimer)
+    makeupTimer = setTimeout(() => {
+      makeupTimer = null
+      const shouldRunTrailing = makeupBurstDirty
+      makeupBurstActive = false
+      makeupBurstDirty = false
+      if (shouldRunTrailing) refreshAutoMakeup()
+    }, AUTO_MAKEUP_DEBOUNCE_MS)
+  }
+
+  // Params that change how much the compressor reduces (and so how much
+  // makeup is needed) trigger a re-measure; the manual trim does not.
+  function syncCompressionParam(name, refVar, value) {
+    refVar.value = value
+    pushParam(name, value)
+    scheduleAutoMakeup()
+  }
+
+  const syncInput = (v) => syncCompressionParam('inputDrive', fetInput, v)
+  const syncAttack = (v) => syncCompressionParam('attack', fetAttack, v)
+  const syncRelease = (v) => syncCompressionParam('release', fetRelease, v)
+  const syncRatio = (v) => syncCompressionParam('ratio', fetRatio, v)
+  const syncDrive = (v) => syncCompressionParam('fetDrive', fetDrive, v)
+  const syncScHpf = (v) => syncCompressionParam('scHpf', fetScHpf, v)
+  const syncMix = (v) => syncCompressionParam('mix', fetMix, v)
+
+  function syncOutput(v) {
+    if (fetAutoMakeup.value) return // the plugin owns the output in auto mode
+    fetOutput.value = v
+    pushOutput()
+  }
+
+  function toggleAutoMakeup() {
+    fetAutoMakeup.value = !fetAutoMakeup.value
+    if (fetAutoMakeup.value) {
+      refreshAutoMakeup()
+    } else {
+      // Hand the knob back where it stands, so switching to manual is a
+      // seamless takeover rather than a jump back to 0 dB.
+      if (makeupTimer !== null) {
+        clearTimeout(makeupTimer)
+        makeupTimer = null
+      }
+      makeupBurstActive = false
+      makeupBurstDirty = false
+      makeupSeq++ // discard any in-flight measurement
+      fetAutoMakeupBusy.value = false
+    }
+  }
+
+  async function apply() {
+    if (!state.selection) return
+    const { start, end } = state.selection
+
+    const wasPreviewing = fetPreview.value
+    if (wasPreviewing) togglePreview()
+
+    startProcessing('Applying FET Punch...')
+    try {
+      const buffer = await applyFET1176Region(
+        state.segments, start, end,
+        currentParams(),
+        state.currentFile.sampleRate, state.currentFile.channels
+      )
+      const bufferId = replaceRegion(start, end, buffer)
+      const cache = await computePeakCache(buffer, 256)
+      setPeakCache(bufferId, cache)
+      showToast('FET Punch compression applied')
+    } catch (err) {
+      console.error('FET Punch failed:', err)
+      showToast('FET Punch compression failed')
+    } finally {
+      endProcessing()
+    }
+  }
+
+  function teardown() {
+    stopMeters()
+    if (fetPreview.value) {
+      const ctx = getAudioContext()
+      const chain = getEffectChain(ctx)
+      chain.setEnabled(fet1176Effect.id, false)
+      fetPreview.value = false
+    }
+  }
+
+  function openModal() {
+    state.fet1176ModalOpen = true
+  }
+
+  function closeModal() {
+    state.fet1176ModalOpen = false
+  }
+
+  return {
+    fetInput,
+    fetOutput,
+    fetAttack,
+    fetRelease,
+    fetRatio,
+    fetDrive,
+    fetScHpf,
+    fetMix,
+    fetAutoMakeup,
+    fetAutoMakeupBusy,
+    fetPreview,
+    fetReduction,
+    fetInputDb,
+    fetOutputDb,
+    hasSelection,
+    togglePreview,
+    syncInput,
+    syncOutput,
+    syncAttack,
+    syncRelease,
+    syncRatio,
+    syncDrive,
+    syncScHpf,
+    syncMix,
+    toggleAutoMakeup,
+    refreshAutoMakeup,
+    apply,
+    teardown,
+    openModal,
+    closeModal,
+  }
+}

--- a/src/workers/processWorker.js
+++ b/src/workers/processWorker.js
@@ -2,9 +2,10 @@
  * Audio Processing Web Worker
  *
  * Handles CPU-intensive audio processing tasks off the main thread.
- * Supports: normalize, adjustVolume, la2aAutoMakeup
+ * Supports: normalize, adjustVolume, la2aAutoMakeup, fet1176AutoMakeup
  */
 import { computeAutoMakeupDb } from '../audio/la2aProcessor.js'
+import { computeFET1176AutoMakeupDb } from '../audio/fet1176Processor.js'
 
 self.onmessage = function (e) {
   const { type, channelData, sampleRate, params } = e.data
@@ -17,19 +18,22 @@ self.onmessage = function (e) {
       adjustVolume(channelData, params)
       break
     case 'la2aAutoMakeup':
-      la2aAutoMakeup(channelData, sampleRate, params)
+      autoMakeup(computeAutoMakeupDb, channelData, sampleRate, params)
+      break
+    case 'fet1176AutoMakeup':
+      autoMakeup(computeFET1176AutoMakeupDb, channelData, sampleRate, params)
       break
     default:
       self.postMessage({ type: 'error', message: `Unknown operation: ${type}` })
   }
 }
 
-// Runs the LA-2A kernel over the region purely to measure it — this is why
+// Runs a compressor kernel over the region purely to measure it — this is why
 // it lives in the worker rather than on the main thread, so knob drags
 // don't jank the UI while the measurement re-runs.
-function la2aAutoMakeup(channelData, sampleRate, params) {
+function autoMakeup(measure, channelData, sampleRate, params) {
   try {
-    self.postMessage({ type: 'done', makeupDb: computeAutoMakeupDb(channelData, sampleRate, params) })
+    self.postMessage({ type: 'done', makeupDb: measure(channelData, sampleRate, params) })
   } catch (err) {
     self.postMessage({ type: 'error', message: err.message })
   }


### PR DESCRIPTION
OptoSmooth covers the slow, self-effacing end of compression. This adds the opposite: an 1176 FET emulation for material that wants to be grabbed rather than levelled.

DSP (src/audio/fet1176Processor.js) follows the same contract as the LA-2A kernel — dependency-free, so one file serves the AudioWorklet preview, the OfflineAudioContext apply and Node verification, and all three stay sample-identical:

  - FET gain cell with the hardware's reversed dials, 800 us to 20 us attack and 1.1 s to 50 ms release, geometrically interpolated across positions 1-7. At the fast settings the cell tracks the waveform rather than an envelope, which is where the grab comes from.
  - Program-dependent release: a minority share of the reduction hangs on a slower tail, so dense program recovers more slowly than isolated peaks.
  - Input is the only threshold control, driving audio path and detector together into a fixed threshold referenced to nominal level (-18 dBFS), the same anchor the LA-2A model uses.
  - 4:1 / 8:1 / 12:1 / 20:1 knees, plus all-buttons-in modeled as its own mode: dropped threshold, ratio climbing with overshoot, lagging attack, longer tail and a much harder-driven FET.
  - Optional two-pole sidechain high-pass (off by default — the hardware's detector is broadband) so plosives don't duck a narration take.
  - Mix control for parallel compression.

Auto makeup carries more weight here than on the OptoSmooth: Input feeds the audio path, so driving the unit harder would otherwise swing output level by tens of dB. With AUTO on, the measured value drives the Output knob itself, so pushing Input is a change of character, not of loudness. Output sits after the saturator, as on the hardware, so the measurement converges in one pass.

UI reuses the existing Knob throughout and extracts the pieces both panels need — floating panel shell, level meters, gain-reduction bar, switch bank — into shared components, with LA2AModal moved onto them. New for this panel is a backlit VU meter with a swinging needle, switchable between gain reduction and output level; deflection is linear in voltage so the dB markings crowd on their own, the way a real face is engraved.

Verified with a Node harness over the kernel: ballistics measured per-sample against spec, block-size independence exact, mix=0 bit-exact dry, stereo gain curve shared, auto makeup accurate to 0.000 dB. Checked end to end in the browser — preview, auto-makeup re-measure on knob drag, and apply.


Claude-Session: https://claude.ai/code/session_01WNk3HQbFifSHzpSuENadQa