### PR TITLE
Keyboard shortcuts, UI polish, and selection bar improvements

### DIFF
--- a/src/components/ContextPanel.vue
+++ b/src/components/ContextPanel.vue
@@ -8,11 +8,28 @@ import FadePanel from './panels/FadePanel.vue'
 import EffectsPanel from './panels/EffectsPanel.vue'
 import PresetsPanel from './panels/PresetsPanel.vue'
 
-const { state } = useEditorState()
+const { state, setActiveTool } = useEditorState()
+
+// Re-clicking the active tool was the only way out of here, which is not a
+// thing a panel with no visible close control tells you.
+function close() {
+  if (state.activeTool) setActiveTool(state.activeTool)
+}
 </script>
 
 <template>
-  <div class="w-[280px] overflow-y-auto shrink-0 border-l border-[rgba(255,255,255,.06)]" style="background:linear-gradient(180deg,#141922,#0e1116)">
+  <div class="w-[280px] shrink-0 relative border-l border-[rgba(255,255,255,.06)] overflow-y-auto" style="background:linear-gradient(180deg,#141922,#0e1116)">
+    <button
+      class="panel-close absolute top-[14px] right-[14px] z-10 w-6 h-6 rounded-[7px] flex items-center justify-center cursor-pointer"
+      title="Close panel (Esc)"
+      aria-label="Close panel"
+      @click="close"
+    >
+      <svg viewBox="0 0 24 24" class="w-3 h-3 fill-none stroke-current" stroke-width="2.5" stroke-linecap="round">
+        <line x1="18" y1="6" x2="6" y2="18" /><line x1="6" y1="6" x2="18" y2="18" />
+      </svg>
+    </button>
+
     <SplitPanel v-if="state.activeTool === 'split'" />
     <TrimPanel v-if="state.activeTool === 'trim'" />
     <SilencePanel v-if="state.activeTool === 'silence'" />
@@ -22,3 +39,20 @@ const { state } = useEditorState()
     <PresetsPanel v-if="state.activeTool === 'presets'" />
   </div>
 </template>
+
+<style scoped>
+.panel-close {
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.09);
+  color: rgba(255, 255, 255, 0.55);
+  transition: background-color 0.15s ease, color 0.15s ease;
+}
+.panel-close:hover {
+  background: rgba(255, 255, 255, 0.1);
+  color: rgba(255, 255, 255, 0.85);
+}
+.panel-close:focus-visible {
+  outline: 2px solid #7fe9f6;
+  outline-offset: 2px;
+}
+</style>

--- a/src/components/EditorScreen.vue
+++ b/src/components/EditorScreen.vue
@@ -16,6 +16,10 @@ const {
 } = useEditorState()
 
 function handleKeydown(e) {
+  // Shift changes e.key's case ('z' → 'Z'), so match on the lowered key
+  // throughout or every Shift-modified shortcut silently never fires.
+  const key = e.key.toLowerCase()
+
   // Space — play/pause (handled in TransportBar via event bus)
   if (e.code === 'Space' && !e.target.closest('input, textarea, button')) {
     e.preventDefault()
@@ -23,35 +27,35 @@ function handleKeydown(e) {
   }
 
   // Ctrl+Z — undo
-  if ((e.ctrlKey || e.metaKey) && !e.shiftKey && e.key === 'z') {
+  if ((e.ctrlKey || e.metaKey) && !e.shiftKey && key === 'z') {
     e.preventDefault()
     if (canUndo.value) undo()
   }
 
   // Ctrl+Shift+Z or Ctrl+Y — redo
-  if ((e.ctrlKey || e.metaKey) && e.shiftKey && e.key === 'z') {
+  if ((e.ctrlKey || e.metaKey) && e.shiftKey && key === 'z') {
     e.preventDefault()
     if (canRedo.value) redo()
   }
-  if ((e.ctrlKey || e.metaKey) && e.key === 'y') {
+  if ((e.ctrlKey || e.metaKey) && key === 'y') {
     e.preventDefault()
     if (canRedo.value) redo()
   }
 
   // Ctrl+X — cut selection
-  if ((e.ctrlKey || e.metaKey) && e.key === 'x' && !e.target.closest('input, textarea')) {
+  if ((e.ctrlKey || e.metaKey) && key === 'x' && !e.target.closest('input, textarea')) {
     e.preventDefault()
     if (hasSelection.value) performCut()
   }
 
   // Ctrl+C — copy selection
-  if ((e.ctrlKey || e.metaKey) && e.key === 'c' && !e.target.closest('input, textarea')) {
+  if ((e.ctrlKey || e.metaKey) && key === 'c' && !e.target.closest('input, textarea')) {
     e.preventDefault()
     if (hasSelection.value) performCopy()
   }
 
   // Ctrl+V — paste at playhead
-  if ((e.ctrlKey || e.metaKey) && e.key === 'v' && !e.target.closest('input, textarea')) {
+  if ((e.ctrlKey || e.metaKey) && key === 'v' && !e.target.closest('input, textarea')) {
     e.preventDefault()
     if (hasClipboard.value) performPaste(state.playhead)
   }
@@ -91,18 +95,25 @@ onUnmounted(() => {
       <!-- Workspace -->
       <div class="flex flex-col flex-1 overflow-hidden">
         <FloatingToolbar />
-        <!-- Waveform + SelectionBar overlay (overlay avoids resizing the canvas) -->
         <div class="flex-1 min-h-0 p-[14px] pl-5 flex flex-col gap-[10px]">
-          <WaveformOverview v-if="state.currentFile" />
-          <div class="relative flex-1 min-h-0 flex gap-2">
-            <DbfsScale />
-            <div
-              class="relative flex-1 min-h-0 flex flex-col overflow-hidden rounded-[12px]"
-              style="background:linear-gradient(180deg,#0c0f13,#080a0d);box-shadow:inset 0 0 0 1px rgba(255,255,255,.05),inset 0 2px 16px rgba(0,0,0,.7)"
-            >
+          <!-- Overview is indented by the dBFS gutter so its time axis shares an
+               x-origin with the main waveform below it. -->
+          <div class="flex shrink-0">
+            <div class="w-7 shrink-0"></div>
+            <WaveformOverview class="flex-1" />
+          </div>
+          <div
+            class="relative flex-1 min-h-0 flex flex-col overflow-hidden rounded-[12px]"
+            style="background:linear-gradient(180deg,#0c0f13,#080a0d);box-shadow:inset 0 0 0 1px rgba(255,255,255,.05),inset 0 2px 16px rgba(0,0,0,.7)"
+          >
+            <!-- The scale shares the canvas's box exactly, so its ticks land on
+                 the amplitudes they name. SelectionBar sits below in flow rather
+                 than overlaying the waveform's loudest peaks. -->
+            <div class="flex-1 min-h-0 flex">
+              <DbfsScale />
               <WaveformArea />
-              <SelectionBar class="absolute bottom-0 left-0 right-0 z-20" />
             </div>
+            <SelectionBar />
           </div>
         </div>
         <TransportBar />

--- a/src/components/EditorScreen.vue
+++ b/src/components/EditorScreen.vue
@@ -13,67 +13,139 @@ import ContextPanel from './ContextPanel.vue'
 const {
   state, performDelete, performCut, performCopy, performPaste,
   undo, redo, canUndo, canRedo, hasSelection, hasClipboard,
+  selectAll, clearSelection, setPlayhead, totalDuration, setActiveTool,
 } = useEditorState()
+
+const NUDGE_SECONDS = 1
+const NUDGE_SECONDS_COARSE = 5
+
+// A shortcut must never reach the timeline from inside a text field — the guard
+// belongs on every branch, not just the clipboard ones.
+function isTextField(target) {
+  return !!target.closest?.('input, textarea, select, [contenteditable="true"]')
+}
+
+function closeTopModal() {
+  if (state.la2aModalOpen) { state.la2aModalOpen = false; return true }
+  if (state.fet1176ModalOpen) { state.fet1176ModalOpen = false; return true }
+  return false
+}
 
 function handleKeydown(e) {
   // Shift changes e.key's case ('z' → 'Z'), so match on the lowered key
   // throughout or every Shift-modified shortcut silently never fires.
   const key = e.key.toLowerCase()
+  const inText = isTextField(e.target)
+  const modalOpen = state.la2aModalOpen || state.fet1176ModalOpen
 
-  // Space — play/pause (handled in TransportBar via event bus)
-  if (e.code === 'Space' && !e.target.closest('input, textarea, button')) {
+  // Escape — close the top modal, then the context panel, then the selection.
+  if (e.key === 'Escape') {
+    if (closeTopModal()) { e.preventDefault(); return }
+    if (hasSelection.value) { clearSelection(); e.preventDefault(); return }
+    // Route through setActiveTool rather than closing the panel directly, or
+    // the toolbar keeps showing the tool as active with nothing open.
+    if (state.contextPanelOpen && state.activeTool) { setActiveTool(state.activeTool); e.preventDefault() }
+    return
+  }
+
+  // Nothing below should reach the timeline behind a modal or the processing
+  // overlay — the editor used to keep taking edits through both.
+  if (modalOpen || state.isProcessing || inText) return
+
+  // Space — play/pause (handled in TransportBar via event bus). Focus lands on
+  // whichever button was last clicked, and in an editor Space means transport,
+  // not "press that button again".
+  if (e.code === 'Space') {
     e.preventDefault()
+    if (e.target instanceof HTMLElement && e.target !== document.body) e.target.blur()
     window.dispatchEvent(new CustomEvent('wavely:toggle-play'))
+    return
   }
 
   // Ctrl+Z — undo
   if ((e.ctrlKey || e.metaKey) && !e.shiftKey && key === 'z') {
     e.preventDefault()
     if (canUndo.value) undo()
+    return
   }
 
   // Ctrl+Shift+Z or Ctrl+Y — redo
-  if ((e.ctrlKey || e.metaKey) && e.shiftKey && key === 'z') {
+  if ((e.ctrlKey || e.metaKey) && ((e.shiftKey && key === 'z') || key === 'y')) {
     e.preventDefault()
     if (canRedo.value) redo()
+    return
   }
-  if ((e.ctrlKey || e.metaKey) && key === 'y') {
+
+  // Ctrl+A — select all, matching the SelectionBar button
+  if ((e.ctrlKey || e.metaKey) && key === 'a') {
     e.preventDefault()
-    if (canRedo.value) redo()
+    selectAll()
+    return
   }
 
   // Ctrl+X — cut selection
-  if ((e.ctrlKey || e.metaKey) && key === 'x' && !e.target.closest('input, textarea')) {
+  if ((e.ctrlKey || e.metaKey) && key === 'x') {
+    if (!hasSelection.value) return
     e.preventDefault()
-    if (hasSelection.value) performCut()
+    performCut()
+    return
   }
 
-  // Ctrl+C — copy selection
-  if ((e.ctrlKey || e.metaKey) && key === 'c' && !e.target.closest('input, textarea')) {
+  // Ctrl+C — copy selection. Left alone when the user is copying page text
+  // (a filename, a measurement from the report) rather than audio.
+  if ((e.ctrlKey || e.metaKey) && key === 'c') {
+    const textSelected = !window.getSelection()?.isCollapsed
+    if (!hasSelection.value || textSelected) return
     e.preventDefault()
-    if (hasSelection.value) performCopy()
+    performCopy()
+    return
   }
 
   // Ctrl+V — paste at playhead
-  if ((e.ctrlKey || e.metaKey) && key === 'v' && !e.target.closest('input, textarea')) {
+  if ((e.ctrlKey || e.metaKey) && key === 'v') {
+    if (!hasClipboard.value) return
     e.preventDefault()
-    if (hasClipboard.value) performPaste(state.playhead)
+    performPaste(state.playhead)
+    return
   }
 
+  if (e.ctrlKey || e.metaKey) return
+
   // Delete / Backspace — delete selection
-  if ((e.key === 'Delete' || e.key === 'Backspace') && !e.target.closest('input, textarea')) {
+  if (e.key === 'Delete' || e.key === 'Backspace') {
+    if (!hasSelection.value) return
     e.preventDefault()
-    if (hasSelection.value) performDelete()
+    performDelete()
+    return
+  }
+
+  // Arrow keys — nudge the playhead; Home / End jump to the edges.
+  if (e.key === 'ArrowLeft' || e.key === 'ArrowRight') {
+    e.preventDefault()
+    const step = e.shiftKey ? NUDGE_SECONDS_COARSE : NUDGE_SECONDS
+    setPlayhead(state.playhead + (e.key === 'ArrowRight' ? step : -step))
+    return
+  }
+  if (e.key === 'Home') {
+    e.preventDefault()
+    setPlayhead(0)
+    return
+  }
+  if (e.key === 'End') {
+    e.preventDefault()
+    setPlayhead(totalDuration.value)
+    return
   }
 
   // + / = — zoom in
-  if ((e.key === '+' || e.key === '=') && !e.target.closest('input, textarea')) {
+  if (e.key === '+' || e.key === '=') {
     e.preventDefault()
     window.dispatchEvent(new CustomEvent('wavely:zoom-in'))
+    return
   }
 
   // - — zoom out
-  if (e.key === '-' && !e.target.closest('input, textarea')) {
+  if (e.key === '-') {
     e.preventDefault()
     window.dispatchEvent(new CustomEvent('wavely:zoom-out'))
   }

--- a/src/components/FloatingToolbar.vue
+++ b/src/components/FloatingToolbar.vue
@@ -14,6 +14,13 @@ const tools = [
     icon: '<path d="M12 20h9"/><path d="M16.5 3.5a2.121 2.121 0 013 3L7 19l-4 1 1-4L16.5 3.5z"/>',
   },
   {
+    // SilencePanel existed but nothing could set activeTool to 'silence', so the
+    // panel was unreachable — Silence was only available as the SelectionBar's
+    // instant-apply button, with no explanation of what it does.
+    id: 'silence', label: 'Silence',
+    icon: '<line x1="8" y1="6" x2="21" y2="6"/><line x1="8" y1="12" x2="21" y2="12"/><line x1="8" y1="18" x2="21" y2="18"/>',
+  },
+  {
     id: 'fade', label: 'Fade',
     icon: '<path d="M9 18V5l12-2v13"/><circle cx="6" cy="18" r="3"/><circle cx="18" cy="16" r="3"/>',
   },
@@ -41,49 +48,56 @@ function handleZoomOut() {
 </script>
 
 <template>
-  <div class="h-[60px] flex items-center px-5 shrink-0 border-b border-[rgba(255,255,255,.06)]" style="background:linear-gradient(180deg,#12161b,#0e1216)">
-    <div class="flex-1"></div>
-    <div class="flex items-center gap-[4px] p-[5px] rounded-[13px]" style="background:rgba(255,255,255,.04);box-shadow:inset 0 0 0 1px rgba(255,255,255,.05)">
+  <div class="h-[60px] flex items-center gap-3 px-5 shrink-0 border-b border-[rgba(255,255,255,.06)]" style="background:linear-gradient(180deg,#12161b,#0e1216)">
+    <div class="flex-1 min-w-0"></div>
+    <!-- min-w-0 + scroll: the tool group gives up centring before it collides
+         with the zoom controls on a narrow window. -->
+    <div class="tool-group flex items-center gap-[4px] p-[5px] rounded-[13px] min-w-0 overflow-x-auto" style="background:rgba(255,255,255,.04);box-shadow:inset 0 0 0 1px rgba(255,255,255,.05)">
       <BaseButton
         v-for="tool in tools"
         :key="tool.id"
         size="md" :pill="false" toggle
         :active="state.activeTool === tool.id"
-        class="whitespace-nowrap"
+        class="whitespace-nowrap shrink-0"
         @click="setActiveTool(tool.id)"
-        :title="tool.label"
       >
         <svg viewBox="0 0 24 24" width="15" height="15" class="fill-none stroke-current shrink-0" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" v-html="tool.icon"></svg>
         {{ tool.label }}
       </BaseButton>
     </div>
+    <!-- No min-w-0 here on purpose: this side must never shrink below its own
+         content, or its basis-0 box collapses and the buttons spill leftward
+         over the tool group. -->
     <div class="flex-1 flex justify-end gap-2">
-      <button
-        class="w-[34px] h-[34px] rounded-[9px] border cursor-pointer flex items-center justify-center transition-colors relative group"
-        style="border-color:rgba(255,255,255,.09);background:rgba(255,255,255,.04);color:rgba(255,255,255,.6)"
+      <BaseButton
+        size="xs" color="ghost" square
         @click="handleZoomIn"
         title="Zoom In (+)"
+        aria-label="Zoom in"
       >
         <svg viewBox="0 0 24 24" width="16" height="16" class="fill-none stroke-current" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
           <circle cx="11" cy="11" r="8"/><path d="M21 21l-4.35-4.35"/><line x1="11" y1="8" x2="11" y2="14"/><line x1="8" y1="11" x2="14" y2="11"/>
         </svg>
-        <span class="absolute -bottom-8 left-1/2 -translate-x-1/2 bg-[#1c2129] text-[#eaf6f8] text-[10px] font-bold px-2 py-0.5 rounded-md opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none whitespace-nowrap">
-          Zoom In
-        </span>
-      </button>
-      <button
-        class="w-[34px] h-[34px] rounded-[9px] border cursor-pointer flex items-center justify-center transition-colors relative group"
-        style="border-color:rgba(255,255,255,.09);background:rgba(255,255,255,.04);color:rgba(255,255,255,.6)"
+      </BaseButton>
+      <BaseButton
+        size="xs" color="ghost" square
         @click="handleZoomOut"
         title="Zoom Out (-)"
+        aria-label="Zoom out"
       >
         <svg viewBox="0 0 24 24" width="16" height="16" class="fill-none stroke-current" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
           <circle cx="11" cy="11" r="8"/><path d="M21 21l-4.35-4.35"/><line x1="8" y1="11" x2="14" y2="11"/>
         </svg>
-        <span class="absolute -bottom-8 left-1/2 -translate-x-1/2 bg-[#1c2129] text-[#eaf6f8] text-[10px] font-bold px-2 py-0.5 rounded-md opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none whitespace-nowrap">
-          Zoom Out
-        </span>
-      </button>
+      </BaseButton>
     </div>
   </div>
 </template>
+
+<style scoped>
+.tool-group {
+  scrollbar-width: none;
+}
+.tool-group::-webkit-scrollbar {
+  display: none;
+}
+</style>

--- a/src/components/SelectionBar.vue
+++ b/src/components/SelectionBar.vue
@@ -1,6 +1,7 @@
 <script setup>
 import { computed } from "vue"
 import { useEditorState } from "../composables/useEditorState.js"
+import BaseButton from "./ui/BaseButton.vue"
 
 const {
   state,
@@ -61,53 +62,52 @@ function handleDelete() {
   performDelete()
   showToast("Selection deleted")
 }
-
-const ACTION_CLASS =
-  "flex items-center gap-[5px] px-[11px] py-[5px] rounded-[7px] border-none cursor-pointer transition-all whitespace-nowrap font-['Inter'] text-[10.5px] font-semibold disabled:opacity-35 disabled:cursor-default"
-const ACTION_STYLE = "background:rgba(255,255,255,.06);color:rgba(255,255,255,.7)"
 </script>
 
 <template>
+  <!-- Scrolls rather than clips: with the context panel open on a narrow window
+       the readouts and actions together exceed the bar, and the trailing
+       actions were being cut off with no way to reach them. -->
   <div
-    class="h-9 flex items-center px-[14px] gap-[10px] font-['Inter'] shrink-0 border-t border-[rgba(255,255,255,.08)]"
+    class="selection-bar h-9 flex items-center px-[14px] gap-[10px] font-['Inter'] shrink-0 overflow-x-auto border-t border-[rgba(255,255,255,.08)]"
     style="background:rgba(5,7,9,.85);backdrop-filter:blur(4px)">
-    <span class="text-[10.5px] font-bold tracking-[.08em] text-[rgba(255,255,255,.4)] whitespace-nowrap uppercase"
+    <span class="text-[10.5px] font-bold tracking-[.08em] text-[rgba(255,255,255,.4)] whitespace-nowrap uppercase shrink-0"
       >Selection</span
     >
     <span
-      class="font-['JetBrains_Mono'] text-[11.5px] font-semibold tabular-nums"
+      class="font-['JetBrains_Mono'] text-[11.5px] font-semibold tabular-nums shrink-0"
       :class="hasSelection ? 'text-[#7fe9f6]' : 'text-[rgba(255,255,255,.28)]'"
       >{{ formatTime(state.selection?.start) }}</span
     >
     <span class="text-[10.5px] text-[rgba(255,255,255,.3)] font-bold">→</span>
     <span
-      class="font-['JetBrains_Mono'] text-[11.5px] font-semibold tabular-nums"
+      class="font-['JetBrains_Mono'] text-[11.5px] font-semibold tabular-nums shrink-0"
       :class="hasSelection ? 'text-[#7fe9f6]' : 'text-[rgba(255,255,255,.28)]'"
       >{{ formatTime(state.selection?.end) }}</span
     >
 
-    <div class="w-px h-3.5 bg-[rgba(255,255,255,.1)]"></div>
+    <div class="w-px h-3.5 shrink-0 bg-[rgba(255,255,255,.1)]"></div>
 
-    <span class="text-[10.5px] font-bold tracking-[.08em] text-[rgba(255,255,255,.4)] whitespace-nowrap uppercase"
+    <span class="text-[10.5px] font-bold tracking-[.08em] text-[rgba(255,255,255,.4)] whitespace-nowrap uppercase shrink-0"
       >Duration</span
     >
     <span
-      class="font-['JetBrains_Mono'] text-[11.5px] font-semibold tabular-nums"
+      class="font-['JetBrains_Mono'] text-[11.5px] font-semibold tabular-nums shrink-0"
       :class="hasSelection ? 'text-[rgba(255,255,255,.7)]' : 'text-[rgba(255,255,255,.28)]'"
       >{{ selectionDuration }}</span
     >
 
     <span
       v-if="!hasSelection"
-      class="text-[10.5px] font-medium text-[rgba(255,255,255,.3)] whitespace-nowrap"
+      class="text-[10.5px] font-medium text-[rgba(255,255,255,.3)] whitespace-nowrap shrink-0"
       >Drag on the waveform to select</span
     >
 
-    <div class="flex items-center gap-[6px] ml-auto">
+    <div class="flex items-center gap-[6px] ml-auto shrink-0 pl-2">
       <!-- Select All — the only action here that needs no precondition -->
-      <button
-        :class="ACTION_CLASS"
-        :style="ACTION_STYLE"
+      <BaseButton
+        size="xs" color="ghost" :pill="false"
+        class="whitespace-nowrap font-semibold"
         title="Select All (Ctrl+A)"
         @click="selectAll">
         <svg
@@ -118,10 +118,10 @@ const ACTION_STYLE = "background:rgba(255,255,255,.06);color:rgba(255,255,255,.7
           <path d="M9 12l2 2 4-4" />
         </svg>
         Select All
-      </button>
-      <button
-        :class="ACTION_CLASS"
-        :style="ACTION_STYLE"
+      </BaseButton>
+      <BaseButton
+        size="xs" color="ghost" :pill="false"
+        class="whitespace-nowrap font-semibold"
         :disabled="!hasSelection"
         title="Copy (Ctrl+C)"
         @click="handleCopy">
@@ -133,10 +133,10 @@ const ACTION_STYLE = "background:rgba(255,255,255,.06);color:rgba(255,255,255,.7
           <path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1" />
         </svg>
         Copy
-      </button>
-      <button
-        :class="ACTION_CLASS"
-        :style="ACTION_STYLE"
+      </BaseButton>
+      <BaseButton
+        size="xs" color="ghost" :pill="false"
+        class="whitespace-nowrap font-semibold"
         :disabled="!hasClipboard"
         title="Paste at playhead (Ctrl+V)"
         @click="handlePaste">
@@ -148,10 +148,10 @@ const ACTION_STYLE = "background:rgba(255,255,255,.06);color:rgba(255,255,255,.7
           <rect x="8" y="2" width="8" height="4" rx="1" ry="1" />
         </svg>
         Paste
-      </button>
-      <button
-        :class="ACTION_CLASS"
-        :style="ACTION_STYLE"
+      </BaseButton>
+      <BaseButton
+        size="xs" color="ghost" :pill="false"
+        class="whitespace-nowrap font-semibold"
         :disabled="!hasSelection"
         title="Replace selection with silence"
         @click="handleSilence">
@@ -164,10 +164,10 @@ const ACTION_STYLE = "background:rgba(255,255,255,.06);color:rgba(255,255,255,.7
           <line x1="8" y1="18" x2="21" y2="18" />
         </svg>
         Silence
-      </button>
-      <button
-        :class="ACTION_CLASS"
-        :style="ACTION_STYLE"
+      </BaseButton>
+      <BaseButton
+        size="xs" color="ghost" :pill="false"
+        class="whitespace-nowrap font-semibold"
         :disabled="!hasSelection"
         title="Cut (Ctrl+X)"
         @click="handleCut">
@@ -182,10 +182,10 @@ const ACTION_STYLE = "background:rgba(255,255,255,.06);color:rgba(255,255,255,.7
           <line x1="8.12" y1="8.12" x2="12" y2="12" />
         </svg>
         Cut
-      </button>
-      <button
-        :class="ACTION_CLASS"
-        :style="ACTION_STYLE"
+      </BaseButton>
+      <BaseButton
+        size="xs" color="ghost" :pill="false"
+        class="whitespace-nowrap font-semibold"
         :disabled="!hasSelection"
         title="Delete selection (Del)"
         @click="handleDelete">
@@ -198,7 +198,16 @@ const ACTION_STYLE = "background:rgba(255,255,255,.06);color:rgba(255,255,255,.7
           <path d="M19 6l-1 14a2 2 0 01-2 2H8a2 2 0 01-2-2L5 6" />
         </svg>
         Delete
-      </button>
+      </BaseButton>
     </div>
   </div>
 </template>
+
+<style scoped>
+.selection-bar {
+  scrollbar-width: none;
+}
+.selection-bar::-webkit-scrollbar {
+  display: none;
+}
+</style>

--- a/src/components/SelectionBar.vue
+++ b/src/components/SelectionBar.vue
@@ -1,4 +1,5 @@
 <script setup>
+import { computed } from "vue"
 import { useEditorState } from "../composables/useEditorState.js"
 
 const {
@@ -6,6 +7,7 @@ const {
   hasSelection,
   hasClipboard,
   performSilence,
+  performDelete,
   performCut,
   performCopy,
   performPaste,
@@ -13,26 +15,56 @@ const {
   showToast,
 } = useEditorState()
 
+// The bar is always mounted, so every readout has to survive selection === null.
+const EMPTY = "—"
+
 function formatTime(seconds) {
+  if (!Number.isFinite(seconds)) return EMPTY
   const m = Math.floor(seconds / 60)
   const s = (seconds % 60).toFixed(2)
   return `${m}:${s.padStart(5, "0")}`
 }
 
+const selectionDuration = computed(() => {
+  if (!hasSelection.value) return EMPTY
+  return `${(state.selection.end - state.selection.start).toFixed(2)}s`
+})
+
+// Every action below is a no-op without its precondition, so the toast only
+// fires once the operation has actually run.
 function handleCopy() {
+  if (!hasSelection.value) return
   performCopy()
   showToast("Copied to clipboard")
 }
 
 function handleCut() {
+  if (!hasSelection.value) return
   performCut()
   showToast("Cut to clipboard")
 }
 
 function handlePaste() {
+  if (!hasClipboard.value) return
   performPaste(state.playhead)
   showToast("Pasted at playhead")
 }
+
+function handleSilence() {
+  if (!hasSelection.value) return
+  performSilence()
+  showToast("Region silenced")
+}
+
+function handleDelete() {
+  if (!hasSelection.value) return
+  performDelete()
+  showToast("Selection deleted")
+}
+
+const ACTION_CLASS =
+  "flex items-center gap-[5px] px-[11px] py-[5px] rounded-[7px] border-none cursor-pointer transition-all whitespace-nowrap font-['Inter'] text-[10.5px] font-semibold disabled:opacity-35 disabled:cursor-default"
+const ACTION_STYLE = "background:rgba(255,255,255,.06);color:rgba(255,255,255,.7)"
 </script>
 
 <template>
@@ -42,11 +74,15 @@ function handlePaste() {
     <span class="text-[10.5px] font-bold tracking-[.08em] text-[rgba(255,255,255,.4)] whitespace-nowrap uppercase"
       >Selection</span
     >
-    <span class="font-['JetBrains_Mono'] text-[11.5px] font-semibold text-[#7fe9f6] tabular-nums"
+    <span
+      class="font-['JetBrains_Mono'] text-[11.5px] font-semibold tabular-nums"
+      :class="hasSelection ? 'text-[#7fe9f6]' : 'text-[rgba(255,255,255,.28)]'"
       >{{ formatTime(state.selection?.start) }}</span
     >
     <span class="text-[10.5px] text-[rgba(255,255,255,.3)] font-bold">→</span>
-    <span class="font-['JetBrains_Mono'] text-[11.5px] font-semibold text-[#7fe9f6] tabular-nums"
+    <span
+      class="font-['JetBrains_Mono'] text-[11.5px] font-semibold tabular-nums"
+      :class="hasSelection ? 'text-[#7fe9f6]' : 'text-[rgba(255,255,255,.28)]'"
       >{{ formatTime(state.selection?.end) }}</span
     >
 
@@ -55,15 +91,24 @@ function handlePaste() {
     <span class="text-[10.5px] font-bold tracking-[.08em] text-[rgba(255,255,255,.4)] whitespace-nowrap uppercase"
       >Duration</span
     >
-    <span class="font-['JetBrains_Mono'] text-[11.5px] font-semibold text-[rgba(255,255,255,.7)] tabular-nums"
-      >{{ (state.selection?.end - state.selection?.start).toFixed(2) }}s</span
+    <span
+      class="font-['JetBrains_Mono'] text-[11.5px] font-semibold tabular-nums"
+      :class="hasSelection ? 'text-[rgba(255,255,255,.7)]' : 'text-[rgba(255,255,255,.28)]'"
+      >{{ selectionDuration }}</span
+    >
+
+    <span
+      v-if="!hasSelection"
+      class="text-[10.5px] font-medium text-[rgba(255,255,255,.3)] whitespace-nowrap"
+      >Drag on the waveform to select</span
     >
 
     <div class="flex items-center gap-[6px] ml-auto">
-      <!-- Select All — always visible when a file is loaded -->
+      <!-- Select All — the only action here that needs no precondition -->
       <button
-        class="flex items-center gap-[5px] px-[11px] py-[5px] rounded-[7px] border-none cursor-pointer transition-all whitespace-nowrap font-['Inter'] text-[10.5px] font-semibold"
-        style="background:rgba(255,255,255,.06);color:rgba(255,255,255,.7)"
+        :class="ACTION_CLASS"
+        :style="ACTION_STYLE"
+        title="Select All (Ctrl+A)"
         @click="selectAll">
         <svg
           viewBox="0 0 24 24"
@@ -75,8 +120,10 @@ function handlePaste() {
         Select All
       </button>
       <button
-        class="flex items-center gap-[5px] px-[11px] py-[5px] rounded-[7px] border-none cursor-pointer transition-all whitespace-nowrap font-['Inter'] text-[10.5px] font-semibold"
-        style="background:rgba(255,255,255,.06);color:rgba(255,255,255,.7)"
+        :class="ACTION_CLASS"
+        :style="ACTION_STYLE"
+        :disabled="!hasSelection"
+        title="Copy (Ctrl+C)"
         @click="handleCopy">
         <svg
           viewBox="0 0 24 24"
@@ -88,9 +135,10 @@ function handlePaste() {
         Copy
       </button>
       <button
-        v-if="hasClipboard"
-        class="flex items-center gap-[5px] px-[11px] py-[5px] rounded-[7px] border-none cursor-pointer transition-all whitespace-nowrap font-['Inter'] text-[10.5px] font-semibold"
-        style="background:rgba(255,255,255,.06);color:rgba(255,255,255,.7)"
+        :class="ACTION_CLASS"
+        :style="ACTION_STYLE"
+        :disabled="!hasClipboard"
+        title="Paste at playhead (Ctrl+V)"
         @click="handlePaste">
         <svg
           viewBox="0 0 24 24"
@@ -102,9 +150,11 @@ function handlePaste() {
         Paste
       </button>
       <button
-        class="flex items-center gap-[5px] px-[11px] py-[5px] rounded-[7px] border-none cursor-pointer transition-all whitespace-nowrap font-['Inter'] text-[10.5px] font-semibold"
-        style="background:rgba(255,255,255,.06);color:rgba(255,255,255,.7)"
-        @click="performSilence">
+        :class="ACTION_CLASS"
+        :style="ACTION_STYLE"
+        :disabled="!hasSelection"
+        title="Replace selection with silence"
+        @click="handleSilence">
         <svg
           viewBox="0 0 24 24"
           class="w-3 h-3 fill-none stroke-current"
@@ -116,8 +166,10 @@ function handlePaste() {
         Silence
       </button>
       <button
-        class="flex items-center gap-[5px] px-[11px] py-[5px] rounded-[7px] border-none cursor-pointer transition-all whitespace-nowrap font-['Inter'] text-[10.5px] font-semibold"
-        style="background:rgba(255,255,255,.06);color:rgba(255,255,255,.7)"
+        :class="ACTION_CLASS"
+        :style="ACTION_STYLE"
+        :disabled="!hasSelection"
+        title="Cut (Ctrl+X)"
         @click="handleCut">
         <svg
           viewBox="0 0 24 24"
@@ -130,6 +182,22 @@ function handlePaste() {
           <line x1="8.12" y1="8.12" x2="12" y2="12" />
         </svg>
         Cut
+      </button>
+      <button
+        :class="ACTION_CLASS"
+        :style="ACTION_STYLE"
+        :disabled="!hasSelection"
+        title="Delete selection (Del)"
+        @click="handleDelete">
+        <svg
+          viewBox="0 0 24 24"
+          class="w-3 h-3 fill-none stroke-current"
+          stroke-width="2.5">
+          <path d="M3 6h18" />
+          <path d="M8 6V4a2 2 0 012-2h4a2 2 0 012 2v2" />
+          <path d="M19 6l-1 14a2 2 0 01-2 2H8a2 2 0 01-2-2L5 6" />
+        </svg>
+        Delete
       </button>
     </div>
   </div>

--- a/src/components/TopBar.vue
+++ b/src/components/TopBar.vue
@@ -55,30 +55,33 @@ function handleExport() {
 
     <!-- Actions -->
     <div class="flex items-center gap-2">
-      <button
-        class="flex items-center gap-[7px] font-['Inter'] text-[11.5px] font-semibold px-[13px] py-[8px] rounded-[9px] border cursor-pointer transition-colors disabled:cursor-default disabled:pointer-events-none"
-        :class="canUndo ? 'text-[rgba(255,255,255,.7)] border-[rgba(255,255,255,.09)] bg-[rgba(255,255,255,.04)] hover:bg-[rgba(255,255,255,.08)]' : 'text-[rgba(255,255,255,.22)] border-[rgba(255,255,255,.05)] bg-transparent'"
+      <BaseButton
+        size="sm" color="ghost" :pill="false"
         :disabled="!canUndo"
         @click="undo"
         title="Undo (Ctrl+Z)"
       >
         <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 14L4 9l5-5"/><path d="M4 9h11a5 5 0 0 1 0 10h-4"/></svg>
         Undo
-      </button>
-      <button
-        class="flex items-center gap-[7px] font-['Inter'] text-[11.5px] font-semibold px-[13px] py-[8px] rounded-[9px] border cursor-pointer transition-colors disabled:cursor-default disabled:pointer-events-none"
-        :class="canRedo ? 'text-[rgba(255,255,255,.7)] border-[rgba(255,255,255,.09)] bg-[rgba(255,255,255,.04)] hover:bg-[rgba(255,255,255,.08)]' : 'text-[rgba(255,255,255,.22)] border-[rgba(255,255,255,.05)] bg-transparent'"
+      </BaseButton>
+      <BaseButton
+        size="sm" color="ghost" :pill="false"
         :disabled="!canRedo"
         @click="redo"
         title="Redo (Ctrl+Shift+Z)"
       >
         <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 14l5-5-5-5"/><path d="M20 9H9a5 5 0 0 0 0 10h4"/></svg>
         Redo
-      </button>
+      </BaseButton>
 
       <div class="w-px h-6 bg-[rgba(255,255,255,.1)] mx-1"></div>
 
-      <BaseButton size="md" :pill="false" @click="handleExport">
+      <BaseButton
+        size="md" :pill="false"
+        :disabled="state.isProcessing"
+        @click="handleExport"
+        title="Export as WAV"
+      >
         <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3v12"/><path d="M8 11l4 4 4-4"/><path d="M5 19h14"/></svg>
         Export
       </BaseButton>

--- a/src/components/TransportBar.vue
+++ b/src/components/TransportBar.vue
@@ -1,16 +1,25 @@
 <script setup>
-import { ref, onMounted, onUnmounted, watch } from 'vue'
+import { ref, computed, onMounted, onUnmounted, watch } from 'vue'
 import { useEditorState } from '../composables/useEditorState.js'
 import { startPlayback, stopPlayback } from '../audio/playback.js'
-import { getTimelineDuration } from '../audio/operations.js'
 import BaseButton from './ui/BaseButton.vue'
 
 const {
-  state, setPlayhead, getAudioContext, totalDuration, showToast,
+  state, setPlayhead, getAudioContext, totalDuration, hasSelection,
 } = useEditorState()
 
 const isLooping = ref(false)
-const zoomLevel = ref(0) // 0-100 range for slider; 0 = minimum zoom (fit to width)
+const zoomLevel = ref(0) // 0-100 range for slider; 0 = fully zoomed out (fit to width)
+
+// Zoom bounds are owned by WaveformArea — the floor is "whole file fits the
+// viewport", which depends on duration and viewport width. Mirroring them here
+// keeps slider position 0 meaning the same thing the waveform means by it.
+const minPps = ref(10)
+const maxPps = ref(2000)
+
+const playTitle = computed(() =>
+  hasSelection.value ? 'Play selection (Space)' : 'Play/Pause (Space)'
+)
 
 function formatTime(seconds) {
   const m = Math.floor(seconds / 60)
@@ -86,21 +95,29 @@ function handleTogglePlay() {
   togglePlay()
 }
 
+// The slider is dragged continuously while the waveform redraws and re-emits
+// its view state, so a naive sync would fight the pointer mid-gesture.
+const isDraggingZoom = ref(false)
+
 function handleZoomSlider() {
-  // Map 0-100 to pixelsPerSecond range (10-2000) using exponential scale
-  const minPPS = 10
-  const maxPPS = 2000
   const t = zoomLevel.value / 100
-  const pps = minPPS * Math.pow(maxPPS / minPPS, t)
+  const pps = minPps.value * Math.pow(maxPps.value / minPps.value, t)
   window.dispatchEvent(new CustomEvent('wavely:zoom-set', { detail: { pixelsPerSecond: pps } }))
 }
 
 function handleViewUpdate(e) {
   // Keep slider in sync when zoom changes via scroll wheel, keyboard, or buttons
-  const { pixelsPerSecond } = e.detail
-  const minPPS = 10
-  const maxPPS = 2000
-  const t = Math.log(pixelsPerSecond / minPPS) / Math.log(maxPPS / minPPS)
+  const { pixelsPerSecond, minPixelsPerSecond, maxPixelsPerSecond } = e.detail
+  if (Number.isFinite(minPixelsPerSecond)) minPps.value = minPixelsPerSecond
+  if (Number.isFinite(maxPixelsPerSecond)) maxPps.value = maxPixelsPerSecond
+  if (isDraggingZoom.value) return
+
+  const span = maxPps.value / minPps.value
+  if (!(span > 1)) {
+    zoomLevel.value = 0
+    return
+  }
+  const t = Math.log(pixelsPerSecond / minPps.value) / Math.log(span)
   zoomLevel.value = Math.max(0, Math.min(100, t * 100))
 }
 
@@ -130,30 +147,31 @@ watch(() => state.segments, () => {
     <!-- Transport controls -->
     <div class="flex items-center gap-3 flex-1 justify-center">
       <!-- Skip to start -->
-      <button
-        class="w-10 h-10 rounded-full flex items-center justify-center border cursor-pointer transition-all"
-        style="border-color:rgba(255,255,255,.09);background:rgba(255,255,255,.04);color:rgba(255,255,255,.65)"
+      <BaseButton
+        size="sm" color="ghost" circle
         @click="skipToStart"
-        title="Skip to Start"
+        title="Skip to Start (Home)"
+        aria-label="Skip to start"
       >
         <svg viewBox="0 0 24 24" class="w-[15px] h-[15px] fill-none stroke-current" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polygon points="19 20 9 12 19 4 19 20"/><line x1="5" y1="19" x2="5" y2="5"/></svg>
-      </button>
+      </BaseButton>
 
       <!-- Skip back -->
-      <button
-        class="w-10 h-10 rounded-full flex items-center justify-center border cursor-pointer transition-all"
-        style="border-color:rgba(255,255,255,.09);background:rgba(255,255,255,.04);color:rgba(255,255,255,.65)"
+      <BaseButton
+        size="sm" color="ghost" circle
         @click="skipBack"
         title="Skip Back 5s"
+        aria-label="Skip back 5 seconds"
       >
         <svg viewBox="0 0 24 24" class="w-[15px] h-[15px] fill-none stroke-current" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polygon points="11 19 2 12 11 5 11 19"/><polygon points="22 19 13 12 22 5 22 19"/></svg>
-      </button>
+      </BaseButton>
 
-      <!-- Play/Pause -->
+      <!-- Play/Pause — plays the selection when there is one, so the label says so -->
       <BaseButton
         size="lg" circle
         @click="togglePlay"
-        title="Play/Pause (Space)"
+        :title="playTitle"
+        :aria-label="playTitle"
       >
         <!-- Play icon -->
         <svg v-if="!state.isPlaying" viewBox="0 0 24 24" class="w-[24px] h-[24px] ml-[3px]"><polygon points="6 3 20 12 6 21 6 3" fill="#08161a"/></svg>
@@ -162,26 +180,25 @@ watch(() => state.segments, () => {
       </BaseButton>
 
       <!-- Skip forward -->
-      <button
-        class="w-10 h-10 rounded-full flex items-center justify-center border cursor-pointer transition-all"
-        style="border-color:rgba(255,255,255,.09);background:rgba(255,255,255,.04);color:rgba(255,255,255,.65)"
+      <BaseButton
+        size="sm" color="ghost" circle
         @click="skipForward"
         title="Skip Forward 5s"
+        aria-label="Skip forward 5 seconds"
       >
         <svg viewBox="0 0 24 24" class="w-[15px] h-[15px] fill-none stroke-current" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polygon points="13 19 22 12 13 5 13 19"/><polygon points="2 19 11 12 2 5 2 19"/></svg>
-      </button>
+      </BaseButton>
 
       <!-- Loop -->
-      <button
-        class="w-10 h-10 rounded-full flex items-center justify-center border cursor-pointer transition-all"
-        :style="isLooping
-          ? 'border-color:rgba(53,211,230,.4);background:rgba(53,211,230,.12);color:#7fe9f6'
-          : 'border-color:rgba(255,255,255,.09);background:rgba(255,255,255,.04);color:rgba(255,255,255,.65)'"
+      <BaseButton
+        size="sm" circle toggle :active="isLooping"
+        color="accent" accent="rgba(53,211,230,.14)" text-color="#7fe9f6"
         @click="toggleLoop"
         title="Loop"
+        aria-label="Loop playback"
       >
         <svg viewBox="0 0 24 24" class="w-[15px] h-[15px] fill-none stroke-current" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="17 1 21 5 17 9"/><path d="M3 11V9a4 4 0 014-4h14M7 23l-4-4 4-4"/><path d="M21 13v2a4 4 0 01-4 4H3"/></svg>
-      </button>
+      </BaseButton>
     </div>
 
     <!-- Zoom slider -->
@@ -193,6 +210,11 @@ watch(() => state.segments, () => {
         max="100"
         v-model.number="zoomLevel"
         @input="handleZoomSlider"
+        @pointerdown="isDraggingZoom = true"
+        @pointerup="isDraggingZoom = false"
+        @pointercancel="isDraggingZoom = false"
+        @blur="isDraggingZoom = false"
+        aria-label="Zoom"
         class="zoom-slider w-20 h-[5px] rounded-full appearance-none cursor-pointer"
         :style="{ background: `linear-gradient(to right, #35d3e6 ${zoomLevel}%, rgba(255,255,255,.1) ${zoomLevel}%)` }"
       />

--- a/src/components/WaveformArea.vue
+++ b/src/components/WaveformArea.vue
@@ -8,7 +8,6 @@ const { state, peakCaches, peakCacheVersion, setSelection, setPlayhead, totalDur
 const canvas = ref(null)
 const overlayCanvas = ref(null)
 const container = ref(null)
-const scrollbarTrack = ref(null)
 const scrollLeft = ref(0)
 const pixelsPerSecond = ref(100)
 const isSelecting = ref(false)
@@ -27,64 +26,18 @@ function getMinPps() {
 }
 
 function updateContainerWidth() {
-  // Use canvas.clientWidth — this is the exact width the renderer draws into,
-  // which is smaller than container.clientWidth by the inner div's padding (p-6 = 24px each side).
+  // canvas.clientWidth is the exact width the renderer draws into; the
+  // container is only a fallback for the first tick, before layout settles.
   if (canvas.value && canvas.value.clientWidth > 0) {
     containerWidth.value = canvas.value.clientWidth
   } else if (container.value) {
-    containerWidth.value = container.value.clientWidth - 48
+    containerWidth.value = container.value.clientWidth
   }
 }
 
-// Scrollbar computed values
-const totalContentWidth = computed(() => totalDuration.value * pixelsPerSecond.value)
-const isScrollable = computed(() =>
-  containerWidth.value > 0 && totalContentWidth.value > containerWidth.value
-)
-const thumbWidthPct = computed(() => {
-  if (!totalContentWidth.value || containerWidth.value === 0) return 100
-  return Math.min(100, Math.max(5, (containerWidth.value / totalContentWidth.value) * 100))
-})
 const maxScrollLeft = computed(() =>
   Math.max(0, totalDuration.value - containerWidth.value / pixelsPerSecond.value)
 )
-const thumbLeftPct = computed(() => {
-  if (maxScrollLeft.value <= 0) return 0
-  return (scrollLeft.value / maxScrollLeft.value) * (100 - thumbWidthPct.value)
-})
-
-// Scrollbar drag state
-let sbDragging = false
-let sbDragStartX = 0
-let sbDragStartScroll = 0
-
-function handleScrollbarMouseDown(e) {
-  if (e.button !== 0 || !isScrollable.value) return
-  sbDragging = true
-  sbDragStartX = e.clientX
-  sbDragStartScroll = scrollLeft.value
-  window.addEventListener('mousemove', handleScrollbarMouseMove)
-  window.addEventListener('mouseup', handleScrollbarMouseUp)
-  e.preventDefault()
-  e.stopPropagation()
-}
-
-function handleScrollbarMouseMove(e) {
-  if (!sbDragging || !scrollbarTrack.value) return
-  const dx = e.clientX - sbDragStartX
-  const trackWidth = scrollbarTrack.value.clientWidth
-  const thumbMovable = trackWidth * (1 - thumbWidthPct.value / 100)
-  if (thumbMovable <= 0) return
-  const delta = (dx / thumbMovable) * maxScrollLeft.value
-  scrollLeft.value = Math.max(0, Math.min(maxScrollLeft.value, sbDragStartScroll + delta))
-  drawAll()
-}
-
-function handleScrollbarMouseUp() {
-  sbDragging = false
-  window.removeEventListener('mousemove', handleScrollbarMouseMove)
-  window.removeEventListener('mouseup', handleScrollbarMouseUp)
-}
 
 function drawMain() {
   if (!canvas.value || !state.currentFile) return
@@ -132,7 +85,7 @@ function pxToTime(px) {
 }
 
 function handleMouseDown(e) {
-  if (e.button !== 0 || sbDragging) return
+  if (e.button !== 0) return
   const rect = canvas.value.getBoundingClientRect()
   const x = e.clientX - rect.left
   const time = pxToTime(x)
@@ -268,7 +221,7 @@ onUnmounted(() => {
     ref="container"
     class="flex-1 relative overflow-hidden cursor-crosshair min-h-[120px]"
   >
-    <div class="absolute top-0 left-0 right-0 bottom-2">
+    <div class="absolute inset-0">
       <!-- Both canvases are absolute inset-0 so they occupy the same compositing
            layer space. Main canvas draws waveform peaks; overlay canvas draws
            selection highlight + playhead. pointer-events-none lets mouse events
@@ -284,9 +237,5 @@ onUnmounted(() => {
         class="absolute inset-0 w-full h-full pointer-events-none"
       ></canvas>
     </div>
-
-    <!-- Scrollbar — always visible; full-width thumb when not zoomed in -->
-     <!-- MT -removed bottom scrollbar in favor of WaveformOverview scoll and always SelectionBar on bottom) s-->
-
   </div>
 </template>

--- a/src/components/WaveformArea.vue
+++ b/src/components/WaveformArea.vue
@@ -16,6 +16,11 @@ const containerWidth = ref(0)
 
 // Max zoom level
 const MAX_PPS = 2000
+// One step, shared by the zoom buttons and the keyboard shortcuts, so the three
+// zoom entry points move at a predictable rate.
+const ZOOM_STEP = 1.3
+// The wheel is continuous, so it steps finer than a discrete button press.
+const WHEEL_ZOOM_STEP = 1.1
 
 // Dynamic minimum PPS: zoom out no further than the full waveform fitting the canvas.
 // Use containerWidth (which tracks canvas.clientWidth) so this matches the renderer exactly.
@@ -54,12 +59,16 @@ function drawMain() {
     totalDuration: totalDuration.value,
   })
 
-  // Notify other components of view state
+  // Notify other components of view state. The zoom bounds travel with it so
+  // the transport's slider can map its track onto the range that actually
+  // exists for this file and viewport, rather than a hardcoded guess.
   window.dispatchEvent(new CustomEvent('wavely:view-update', {
     detail: {
       scrollLeft: scrollLeft.value,
       pixelsPerSecond: pixelsPerSecond.value,
       visibleDuration: containerWidth.value / pixelsPerSecond.value,
+      minPixelsPerSecond: getMinPps(),
+      maxPixelsPerSecond: MAX_PPS,
     },
   }))
 }
@@ -118,28 +127,28 @@ function handleMouseUp() {
 function handleWheel(e) {
   e.preventDefault()
 
-  if (e.deltaX !== 0 && !e.shiftKey) {
-    // Horizontal trackpad scroll → pan
-    scrollLeft.value = Math.max(0, Math.min(maxScrollLeft.value, scrollLeft.value + e.deltaX / pixelsPerSecond.value))
-    drawAll()
-  } else if (e.shiftKey && e.deltaY !== 0) {
-    // Shift + vertical scroll → pan
-    scrollLeft.value = Math.max(0, Math.min(maxScrollLeft.value, scrollLeft.value + e.deltaY / pixelsPerSecond.value))
-    drawAll()
-  } else if (e.deltaY !== 0) {
-    // Vertical scroll (plain or Ctrl/Meta) → zoom, anchored at mouse position
-    const zoomFactor = e.deltaY > 0 ? 0.9 : 1.1
+  // Ctrl/Meta + wheel → zoom, anchored at the pointer. Plain wheel pans, which
+  // is what a two-finger trackpad scroll — the most common gesture over this
+  // surface — should do; it used to zoom instead.
+  if ((e.ctrlKey || e.metaKey) && e.deltaY !== 0) {
+    const zoomFactor = e.deltaY > 0 ? 1 / WHEEL_ZOOM_STEP : WHEEL_ZOOM_STEP
     const rect = canvas.value.getBoundingClientRect()
     const mouseX = e.clientX - rect.left
     const timeAtMouse = pxToTime(mouseX)
 
-    const minPps = getMinPps()
-    pixelsPerSecond.value = Math.max(minPps, Math.min(MAX_PPS, pixelsPerSecond.value * zoomFactor))
+    pixelsPerSecond.value = Math.max(getMinPps(), Math.min(MAX_PPS, pixelsPerSecond.value * zoomFactor))
 
     // Keep the time under the mouse cursor stable
     scrollLeft.value = Math.max(0, Math.min(maxScrollLeft.value, timeAtMouse - mouseX / pixelsPerSecond.value))
     drawAll()
+    return
   }
+
+  // Otherwise pan, taking whichever axis the device reports.
+  const delta = e.deltaX !== 0 ? e.deltaX : e.deltaY
+  if (delta === 0) return
+  scrollLeft.value = Math.max(0, Math.min(maxScrollLeft.value, scrollLeft.value + delta / pixelsPerSecond.value))
+  drawAll()
 }
 
 function clampScroll() {
@@ -147,13 +156,13 @@ function clampScroll() {
 }
 
 function handleZoomIn() {
-  pixelsPerSecond.value = Math.min(MAX_PPS, pixelsPerSecond.value * 1.3)
+  pixelsPerSecond.value = Math.min(MAX_PPS, pixelsPerSecond.value * ZOOM_STEP)
   clampScroll()
   drawAll()
 }
 
 function handleZoomOut() {
-  pixelsPerSecond.value = Math.max(getMinPps(), pixelsPerSecond.value / 1.3)
+  pixelsPerSecond.value = Math.max(getMinPps(), pixelsPerSecond.value / ZOOM_STEP)
   clampScroll()
   drawAll()
 }
@@ -194,12 +203,23 @@ watch(peakCacheVersion, () => drawMain())
 
 function handleResize() {
   updateContainerWidth()
+  clampScroll()
   drawAll()
 }
+
+// The window is not the only thing that resizes this canvas — opening or
+// closing the context panel changes its width too, and without this the
+// bitmap kept its old width and the waveform rendered stretched, with peaks
+// no longer above the time grid they belong to.
+let resizeObserver = null
 
 onMounted(() => {
   updateContainerWidth()
   drawAll()
+  if (typeof ResizeObserver !== 'undefined' && container.value) {
+    resizeObserver = new ResizeObserver(handleResize)
+    resizeObserver.observe(container.value)
+  }
   window.addEventListener('resize', handleResize)
   window.addEventListener('wavely:zoom-in', handleZoomIn)
   window.addEventListener('wavely:zoom-out', handleZoomOut)
@@ -208,6 +228,7 @@ onMounted(() => {
 })
 
 onUnmounted(() => {
+  resizeObserver?.disconnect()
   window.removeEventListener('resize', handleResize)
   window.removeEventListener('wavely:zoom-in', handleZoomIn)
   window.removeEventListener('wavely:zoom-out', handleZoomOut)

--- a/src/components/WaveformOverview.vue
+++ b/src/components/WaveformOverview.vue
@@ -138,14 +138,23 @@ function handleResize() {
 watch(() => [state.segments, state.currentFile], () => drawMini(), { deep: true })
 watch(peakCacheVersion, () => drawMini())
 
+// Same reason as the main waveform: the context panel changes this strip's
+// width without the window ever resizing.
+let resizeObserver = null
+
 onMounted(() => {
   updateStripWidth()
   drawMini()
+  if (typeof ResizeObserver !== 'undefined' && strip.value) {
+    resizeObserver = new ResizeObserver(handleResize)
+    resizeObserver.observe(strip.value)
+  }
   window.addEventListener('resize', handleResize)
   window.addEventListener('wavely:view-update', handleViewUpdate)
 })
 
 onUnmounted(() => {
+  resizeObserver?.disconnect()
   window.removeEventListener('resize', handleResize)
   window.removeEventListener('wavely:view-update', handleViewUpdate)
   window.removeEventListener('mousemove', onDragMove)

--- a/src/components/ui/BaseButton.vue
+++ b/src/components/ui/BaseButton.vue
@@ -2,62 +2,115 @@
 import { computed } from 'vue'
 
 const props = defineProps({
-  size: { type: String, default: 'md' },       // 'sm' | 'md' | 'lg'
-  color: { type: String, default: 'primary' },  // 'primary' | 'accent'
+  size: { type: String, default: 'md' },        // 'xs' | 'sm' | 'md' | 'lg'
+  color: { type: String, default: 'primary' },  // 'primary' | 'accent' | 'ghost'
   accent: { type: String, default: null },      // CSS color, used when color="accent"
   textColor: { type: String, default: null },   // override text color, used when color="accent"
   block: { type: Boolean, default: false },     // full width
   pill: { type: Boolean, default: true },       // fully rounded vs. rounded corners
   circle: { type: Boolean, default: false },    // fixed-diameter circular icon button
+  square: { type: Boolean, default: false },    // fixed-diameter rounded-square icon button
   toggle: { type: Boolean, default: false },    // on/off appearance driven by `active`
   active: { type: Boolean, default: true },
 })
 
+// Radius follows size rather than being chosen per call site, so a row of
+// mixed-size controls reads as one scale.
 const SIZES = {
-  sm: { pad: 'px-3 py-2', text: 'text-[11px]', gap: 'gap-[6px]', diameter: '40px' },
-  md: { pad: 'px-4 py-[10px]', text: 'text-[12.5px]', gap: 'gap-[7px]', diameter: '48px' },
-  lg: { pad: 'px-4 py-[13px]', text: 'text-[12.5px]', gap: 'gap-[7px]', diameter: '58px' },
+  xs: { pad: 'px-[11px] py-[5px]', text: 'text-[10.5px]', gap: 'gap-[5px]', diameter: '34px', radius: '8px' },
+  sm: { pad: 'px-3 py-2', text: 'text-[11px]', gap: 'gap-[6px]', diameter: '40px', radius: '8px' },
+  md: { pad: 'px-4 py-[10px]', text: 'text-[12.5px]', gap: 'gap-[7px]', diameter: '48px', radius: '10px' },
+  lg: { pad: 'px-4 py-[13px]', text: 'text-[12.5px]', gap: 'gap-[7px]', diameter: '58px', radius: '10px' },
 }
 
 const sizeTokens = computed(() => SIZES[props.size] ?? SIZES.md)
 
-const shapeClass = computed(() => {
-  if (props.circle) return 'rounded-full'
-  return props.pill ? 'rounded-full' : 'rounded-[10px]'
+const isIcon = computed(() => props.circle || props.square)
+
+const radius = computed(() => {
+  if (props.circle) return '9999px'
+  if (props.square) return sizeTokens.value.radius
+  return props.pill ? '9999px' : sizeTokens.value.radius
 })
 
+// Hover and focus can't live in an inline style attribute, so every surface is
+// published as a custom property and the rules below key off them.
+const GHOST = {
+  '--btn-bg': 'rgba(255,255,255,.04)',
+  '--btn-bg-hover': 'rgba(255,255,255,.10)',
+  '--btn-fg': 'rgba(255,255,255,.7)',
+  '--btn-border': '1px solid rgba(255,255,255,.09)',
+}
+
+const OFF = {
+  '--btn-bg': 'transparent',
+  '--btn-bg-hover': 'rgba(255,255,255,.07)',
+  '--btn-fg': 'rgba(255,255,255,.6)',
+  '--btn-border': '1px solid transparent',
+}
+
 const onStyle = computed(() => {
+  if (props.color === 'ghost') return GHOST
   if (props.color === 'accent') {
     return {
-      background: props.accent,
-      color: props.textColor ?? '#08161a',
+      '--btn-bg': props.accent,
+      '--btn-bg-hover': props.accent,
+      '--btn-fg': props.textColor ?? '#08161a',
+      '--btn-border': '1px solid transparent',
     }
   }
   return {
-    background: '#86e8ff',
-    color: '#08161a',
+    '--btn-bg': '#86e8ff',
+    '--btn-bg-hover': '#9beeff',
+    '--btn-fg': '#08161a',
+    '--btn-border': '1px solid transparent',
   }
 })
 
-const offStyle = {
-  background: 'transparent',
-  color: 'rgba(255,255,255,.6)',
-}
-
-const buttonStyle = computed(() => (props.toggle && !props.active) ? offStyle : onStyle.value)
+const buttonStyle = computed(() => ((props.toggle && !props.active) ? OFF : onStyle.value))
 </script>
 
 <template>
   <button
-    class="flex items-center justify-center border-none cursor-pointer font-bold tracking-[.02em] transition-opacity disabled:opacity-40 disabled:cursor-default"
+    class="base-btn flex items-center justify-center cursor-pointer font-bold tracking-[.02em]"
+    :aria-pressed="toggle ? String(active) : undefined"
     :class="[
-      shapeClass,
-      circle ? '' : [sizeTokens.pad, sizeTokens.text],
+      isIcon ? '' : [sizeTokens.pad, sizeTokens.text],
       sizeTokens.gap,
       block ? 'w-full' : '',
     ]"
-    :style="[buttonStyle, circle ? { width: sizeTokens.diameter, height: sizeTokens.diameter } : {}]"
+    :style="[
+      buttonStyle,
+      { borderRadius: radius },
+      isIcon ? { width: sizeTokens.diameter, height: sizeTokens.diameter } : {},
+    ]"
   >
     <slot />
   </button>
 </template>
+
+<style scoped>
+.base-btn {
+  background: var(--btn-bg);
+  color: var(--btn-fg);
+  border: var(--btn-border);
+  transition: background-color 0.15s ease, opacity 0.15s ease, filter 0.15s ease;
+}
+.base-btn:hover:not(:disabled) {
+  background: var(--btn-bg-hover);
+  /* Solid fills carry their own hover colour; this lifts the accent variant,
+     whose fill is supplied by the caller. */
+  filter: brightness(1.06);
+}
+.base-btn:active:not(:disabled) {
+  filter: brightness(0.96);
+}
+.base-btn:focus-visible {
+  outline: 2px solid #7fe9f6;
+  outline-offset: 2px;
+}
+.base-btn:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+</style>


### PR DESCRIPTION
## Summary

This PR adds comprehensive keyboard shortcut support, improves the SelectionBar with better UX patterns, refines button styling across the app, and fixes layout issues with the waveform and context panel.

## Key Changes

**Keyboard Shortcuts (EditorScreen.vue)**
- Added Escape key to close modals, context panel, and selections in sequence
- Added Ctrl+A for Select All
- Added Delete/Backspace to delete selections (with precondition checks)
- Added arrow keys (Left/Right) to nudge playhead by 1s (or 5s with Shift)
- Added Home/End to jump to file start/end
- Improved Ctrl+C to avoid interfering with page text selection
- Fixed Ctrl+Y as alternative redo shortcut
- Added guards to prevent shortcuts from firing inside text fields or when modals are open

**SelectionBar Improvements (SelectionBar.vue)**
- Replaced inline button styles with reusable `BaseButton` component
- Added precondition checks in all action handlers (Copy, Cut, Paste, Silence, Delete) so toasts only fire when operations actually run
- Added Delete action button (was missing from UI despite being in composable)
- Added Silence action handler with toast feedback
- Added visual feedback for empty selection state (grayed-out readouts, helper text "Drag on the waveform to select")
- Added `overflow-x-auto` to handle narrow windows where controls exceed available space
- Added `shrink-0` classes to prevent readouts from collapsing
- Computed `selectionDuration` to safely handle null selection state

**BaseButton Component Enhancements (BaseButton.vue)**
- Added `xs` size variant for compact controls (SelectionBar buttons)
- Added `ghost` color variant for subtle, low-contrast buttons
- Added `square` prop for fixed-diameter rounded-square icon buttons
- Refactored to use CSS custom properties for colors, enabling proper hover/active states
- Added `aria-pressed` for toggle buttons
- Improved focus-visible outline styling
- Added scoped styles for better state management (hover, active, disabled, focus)

**Layout Fixes**
- **EditorScreen.vue:** Fixed WaveformOverview alignment by wrapping it with the dBFS gutter width, so time axes align
- **EditorScreen.vue:** Moved SelectionBar from absolute overlay to flow layout below waveform (prevents clipping of tall peaks)
- **WaveformArea.vue:** Removed custom scrollbar implementation (was unused/broken)
- **WaveformArea.vue:** Added ResizeObserver to handle context panel open/close resizing the canvas
- **WaveformArea.vue:** Fixed wheel zoom to require Ctrl/Meta modifier; plain wheel now pans (matches trackpad expectations)
- **WaveformArea.vue:** Improved zoom step constants (ZOOM_STEP, WHEEL_ZOOM_STEP) for consistent scaling across buttons and keyboard
- **WaveformOverview.vue:** Added ResizeObserver for same reason as main waveform

**TransportBar Improvements (TransportBar.vue)**
- Replaced inline button styles with `BaseButton` component
- Added dynamic play button title that says "Play selection" when selection exists
- Added zoom bounds tracking (minPps/maxPps) from WaveformArea view updates
- Added `isDraggingZoom` flag to prevent slider fighting waveform zoom changes mid-gesture
- Improved zoom slider math to handle dynamic bounds

**ContextPanel & FloatingToolbar**
- Added close button (X) to context panel with Escape key support
- Added "Silence" tool to FloatingToolbar (was in composable but unreachable)
- Improved toolbar layout to scroll on narrow windows instead of clipping

**TopBar.vue**
- Replaced inline button styles with `BaseButton` component for consistency

## Implementation Details

- All action handlers now check preconditions before calling operations, ensuring toasts only fire on successful execution
- Keyboard shortcuts use lowercased `e.key` to handle Shift-modified keys correctly (e.g., Ctrl+Shift+Z for redo)
- Text field detection via `isTextField()` helper prevents shortcuts from firing in inputs/textareas/contenteditable

https://claude.ai/code/session_01Np6dPvLDPSizYBsgCA8tKW