### PR TITLE
Add real-time Air Band and Vocal Saturation effects with DSP kernels

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "node --test \"test/**/*.test.js\""
   },
   "dependencies": {
     "uuid": "^13.0.0",

--- a/src/api/spotEffects.js
+++ b/src/api/spotEffects.js
@@ -4,6 +4,14 @@
  * Spot effects run on a short user selection, bypass the preset chain on the
  * server, and return the processed WAV directly. No job polling — the request
  * resolves with the processed audio.
+ *
+ * Currently unused by the client: vocal saturation was the only caller and now
+ * runs in an AudioWorklet (src/audio/vocalSatProcessor.js), which removed the
+ * upload round-trip. Kept because it is still the right shape for the spot
+ * operations that genuinely have to run server-side — noise reduction being
+ * the obvious one, since DeepFilterNet3 has no browser implementation here.
+ * The server's /api/spot/vocal_saturation route also remains, and the preset
+ * chain's own Python vocalSaturation stage is untouched.
  */
 
 import { renderRegionToBuffer, floatChannelsToWavBlob } from '../audio/processing.js'
@@ -46,27 +54,3 @@ export async function runSpotEffect({
   return await res.blob()
 }
 
-/**
- * Apply Vocal Saturation to a region of the timeline.
- *
- * @param {object} options
- * @param {Array}  options.segments
- * @param {number} options.start
- * @param {number} options.end
- * @param {number} options.sampleRate
- * @param {number} options.channels
- * @param {object} options.params
- * @param {number} options.params.drive
- * @param {number} options.params.wetDry
- * @param {number} options.params.bias            - absolute operating-point offset on the curve (drive-independent)
- * @param {number} options.params.lowCrossover
- * @param {number} options.params.midCrossover
- * @param {number} options.params.softness
- * @param {number} options.params.lowDriveMult    - low-band drive multiplier (× drive)
- * @param {number} options.params.midDriveMult    - mid-band drive multiplier (× drive)
- * @param {number} options.params.highDriveMult   - high-band drive multiplier (× drive)
- * @returns {Promise<Blob>}
- */
-export function applyVocalSaturation(options) {
-  return runSpotEffect({ ...options, operation: 'vocal_saturation' })
-}

--- a/src/audio/airBandProcessor.js
+++ b/src/audio/airBandProcessor.js
@@ -1,0 +1,177 @@
+/**
+ * Air Band — worklet kernel.
+ *
+ * A realtime port of the server's `airBoost` stage
+ * (server/pipeline/airBoost.js), which models the Maag EQ4's Air Band as five
+ * overlapping parametric bells plus a wide high shelf. The Maag shape is a
+ * sigmoid on the log-frequency axis that transitions over roughly four
+ * octaves, which no single shelf reproduces — the bells' skirts sum to it, and
+ * the three negative bell gains pull the shelf's plateau down into the curve.
+ *
+ * This file is BOTH a normal ES module (exports AirBandKernel and
+ * processAirBandBuffer) AND an AudioWorklet module (registers
+ * 'air-band-processor' inside an AudioWorkletGlobalScope). Unlike the two
+ * compressor kernels it imports from ../audio/dsp/, which is why its loader
+ * pulls it through `?worker&url` — see airBandWorkletLoader.js.
+ *
+ * Deliberately NOT ported from the server stage:
+ *
+ *   - the sibilant mask (air_boost_masked.py), which needs a whole-file
+ *     sibilance event map;
+ *   - the predictive precut (air_boost_precut.py), which needs a corpus
+ *     reference curve;
+ *   - the ACX noise-floor compliance loop in computeAirBoostParams, which
+ *     iteratively re-measures the file and steps `gainDb` down.
+ *
+ * All three are mastering-chain concerns that need whole-file analysis. What
+ * remains is a pure, stateless-per-sample filter chain: six biquads whose
+ * gains all scale from one knob. Zero latency.
+ */
+
+import { peaking, highShelf, BiquadCascade } from './dsp/biquad.js'
+
+// Per-band gains are quoted at this plateau and scaled linearly from it, so
+// the fitted constants below stay identical to server/pipeline/airBoost.js.
+const REFERENCE_PLATEAU_DB = 12.5932
+
+const BANDS = [
+  // Parametric bells, Q = 0.5. The 2.4/4.8/9.6 kHz gains are negative: they
+  // are corrective shaping that pulls the shelf's broad plateau down into the
+  // Maag's slower sigmoid, not audible cuts. The summed response is
+  // non-negative at every frequency.
+  { freqHz: 600, type: 'bell', q: 0.5, gRef: -0.02733 },
+  { freqHz: 1200, type: 'bell', q: 0.5, gRef: -0.30754 },
+  { freqHz: 2400, type: 'bell', q: 0.5, gRef: -1.18676 },
+  { freqHz: 4800, type: 'bell', q: 0.5, gRef: -0.90883 },
+  { freqHz: 9600, type: 'bell', q: 0.5, gRef: 0.91883 },
+  // Wide high shelf carrying the bulk of the lift. 3.023 octaves ≈ Q 0.4 —
+  // far gentler than the S = 1 a stock BiquadFilterNode highshelf would give,
+  // which is why the coefficients are built here rather than delegated.
+  { freqHz: 14000, type: 'shelf', wOct: 3.023, gRef: 22.54678 },
+]
+
+export const AIR_BAND_KERNEL_DEFAULTS = {
+  gainDb: 6, // matches the acx_audiobook preset's airBoost.gainDb
+  outputGainDb: 0,
+}
+
+const LN10_OVER_20 = Math.LN10 / 20
+
+function clamp(v, lo, hi) {
+  return v < lo ? lo : v > hi ? hi : v
+}
+
+/** Band coefficients for a given air gain — shared with the curve display. */
+export function airBandSections(sampleRate, gainDb) {
+  const scale = gainDb / REFERENCE_PLATEAU_DB
+  return BANDS.map(b =>
+    b.type === 'bell'
+      ? peaking(sampleRate, b.freqHz, b.q, b.gRef * scale, 'q')
+      : highShelf(sampleRate, b.freqHz, b.wOct, b.gRef * scale, 'octaves'),
+  )
+}
+
+export class AirBandKernel {
+  constructor(sampleRate) {
+    this.sampleRate = sampleRate
+    this.cascade = new BiquadCascade(BANDS.length, 2)
+    this.params = { ...AIR_BAND_KERNEL_DEFAULTS }
+    this.setParams({})
+  }
+
+  /** Merge a partial param update and rebuild coefficients. */
+  setParams(partial) {
+    const p = { ...this.params, ...partial }
+    this.params = p
+    this.gainDb = clamp(p.gainDb, 0, 24)
+    this.cascade.setSections(airBandSections(this.sampleRate, this.gainDb))
+    this.outputLin = Math.exp(p.outputGainDb * LN10_OVER_20)
+  }
+
+  /**
+   * Process one block.
+   *
+   * @param {Float32Array[]} inputChannels
+   * @param {Float32Array[]} outputChannels
+   * @param {number} n
+   */
+  process(inputChannels, outputChannels, n) {
+    const nIn = inputChannels.length
+    const nOut = outputChannels.length
+    if (nIn === 0 || n === 0) {
+      for (let ch = 0; ch < nOut; ch++) outputChannels[ch].fill(0, 0, n)
+      return
+    }
+
+    this.cascade.ensureChannels(nOut)
+
+    const outputLin = this.outputLin
+    for (let ch = 0; ch < nOut; ch++) {
+      // Channels beyond the input count reuse the last one, matching the
+      // convention in la2aProcessor.js / fet1176Processor.js.
+      const input = inputChannels[ch < nIn ? ch : nIn - 1]
+      const out = outputChannels[ch]
+      this.cascade.process(input, out, n, ch)
+      if (outputLin !== 1) {
+        for (let i = 0; i < n; i++) out[i] *= outputLin
+      }
+    }
+  }
+}
+
+/**
+ * One-shot offline convenience: process a whole buffer through a fresh kernel.
+ * Used by verification scripts; the app renders through an OfflineAudioContext
+ * running the worklet so preview and apply share the same code path.
+ */
+export function processAirBandBuffer(channelData, sampleRate, params = {}) {
+  const kernel = new AirBandKernel(sampleRate)
+  kernel.setParams(params)
+
+  const n = channelData[0].length
+  const output = channelData.map(() => new Float32Array(n))
+  const BLOCK = 128
+  for (let off = 0; off < n; off += BLOCK) {
+    const len = Math.min(BLOCK, n - off)
+    kernel.process(
+      channelData.map(c => c.subarray(off, off + len)),
+      output.map(c => c.subarray(off, off + len)),
+      len,
+    )
+  }
+  return { channelData: output }
+}
+
+// ── AudioWorklet registration (worklet scope only) ──────────────────────────
+
+if (typeof registerProcessor === 'function') {
+  class AirBandWorkletProcessor extends AudioWorkletProcessor {
+    constructor(options) {
+      super()
+      this.kernel = new AirBandKernel(sampleRate)
+      if (options?.processorOptions?.params) {
+        this.kernel.setParams(options.processorOptions.params)
+      }
+      this.port.onmessage = (e) => {
+        if (e.data?.type === 'params') this.kernel.setParams(e.data.params)
+      }
+    }
+
+    process(inputs, outputs) {
+      const input = inputs[0]
+      const output = outputs[0]
+      if (!output || output.length === 0) return true
+
+      const n = output[0].length
+      if (!input || input.length === 0) {
+        for (const ch of output) ch.fill(0)
+        return true
+      }
+
+      this.kernel.process(input, output, n)
+      return true
+    }
+  }
+
+  registerProcessor('air-band-processor', AirBandWorkletProcessor)
+}

--- a/src/audio/airBandWorkletLoader.js
+++ b/src/audio/airBandWorkletLoader.js
@@ -1,0 +1,23 @@
+/**
+ * Load the Air Band worklet module into an AudioContext or OfflineAudioContext,
+ * once per context.
+ *
+ * `?worker&url` makes Vite bundle airBandProcessor.js together with everything
+ * it imports from ./dsp/ into one self-contained chunk, then hand back its URL.
+ * That is what lets kernels share the DSP toolkit at all: a raw asset URL
+ * (`new URL(..., import.meta.url)`) is copied verbatim without following its
+ * imports, so the dependency 404s in a production build even though it resolves
+ * in dev.
+ */
+import workletUrl from './airBandProcessor.js?worker&url'
+
+const loadPromises = new WeakMap()
+
+export function ensureAirBandWorklet(context) {
+  let promise = loadPromises.get(context)
+  if (!promise) {
+    promise = context.audioWorklet.addModule(workletUrl)
+    loadPromises.set(context, promise)
+  }
+  return promise
+}

--- a/src/audio/dsp/biquad.js
+++ b/src/audio/dsp/biquad.js
@@ -1,0 +1,247 @@
+/**
+ * RBJ biquad coefficients and a direct-form II transposed processor.
+ *
+ * Dependency-free — imported by AudioWorklet kernels.
+ *
+ * Two deliberate choices about parameterisation:
+ *
+ * 1. Width is expressed the way FFmpeg's `af_biquads.c` expresses it ('q',
+ *    'octaves' or 'slope'), because several preset constants in this codebase
+ *    were fitted against FFmpeg's realisation. The Maag air-band shelf in
+ *    server/pipeline/airBoost.js is declared as `width_type=o, w=3.023`, and
+ *    its per-band gains come out of fit_airboost_bands.py — so reproducing the
+ *    octave→alpha conversion is what makes those constants transfer unchanged.
+ *
+ * 2. Shelves are built here rather than delegated to Web Audio's
+ *    BiquadFilterNode, whose 'highshelf' ignores Q and hard-codes slope S = 1.
+ *    The Maag shelf is ~3 octaves wide (Q ≈ 0.4) — far gentler than S = 1 — so
+ *    the stock node would visibly change the curve, not merely round it off.
+ *
+ * Coefficients are returned pre-normalised by a0, in the shape
+ * `{ b0, b1, b2, a1, a2 }`, so the difference equation is
+ *   y[n] = b0*x[n] + b1*x[n-1] + b2*x[n-2] - a1*y[n-1] - a2*y[n-2]
+ */
+
+/** Convert a bandwidth in octaves to an equivalent Q (RBJ cookbook). */
+export function octavesToQ(octaves) {
+  const s = Math.sinh((Math.LN2 / 2) * octaves)
+  return s === 0 ? Infinity : 1 / (2 * s)
+}
+
+/** Convert a Q to an equivalent bandwidth in octaves. */
+export function qToOctaves(q) {
+  return (2 / Math.LN2) * Math.asinh(1 / (2 * q))
+}
+
+/**
+ * FFmpeg's width → alpha mapping.
+ * @param {number} w0 normalised angular frequency
+ * @param {number} width
+ * @param {'q'|'octaves'|'slope'} widthType
+ * @param {number} A linear amplitude sqrt(gain); only used by 'slope'
+ */
+function alphaFor(w0, width, widthType, A) {
+  const sinW0 = Math.sin(w0)
+  switch (widthType) {
+    case 'q':
+      return sinW0 / (2 * width)
+    case 'octaves':
+      // Guard w0/sin(w0) at DC where sin(w0) → 0.
+      return sinW0 * Math.sinh(((Math.LN2 / 2) * width * w0) / (sinW0 || 1e-20))
+    case 'slope':
+      return (sinW0 / 2) * Math.sqrt((A + 1 / A) * (1 / width - 1) + 2)
+    default:
+      throw new Error(`unknown widthType: ${widthType}`)
+  }
+}
+
+function normalise(b0, b1, b2, a0, a1, a2) {
+  return { b0: b0 / a0, b1: b1 / a0, b2: b2 / a0, a1: a1 / a0, a2: a2 / a0 }
+}
+
+/** Parametric peaking (bell) filter. Matches FFmpeg `equalizer`. */
+export function peaking(sampleRate, freqHz, width, gainDb, widthType = 'q') {
+  const A = Math.pow(10, gainDb / 40)
+  const w0 = (2 * Math.PI * freqHz) / sampleRate
+  const cosW0 = Math.cos(w0)
+  const alpha = alphaFor(w0, width, widthType, A)
+  return normalise(
+    1 + alpha * A, -2 * cosW0, 1 - alpha * A,
+    1 + alpha / A, -2 * cosW0, 1 - alpha / A,
+  )
+}
+
+/** High-shelf. Matches FFmpeg `highshelf`. */
+export function highShelf(sampleRate, freqHz, width, gainDb, widthType = 'q') {
+  const A = Math.pow(10, gainDb / 40)
+  const w0 = (2 * Math.PI * freqHz) / sampleRate
+  const cosW0 = Math.cos(w0)
+  const alpha = alphaFor(w0, width, widthType, A)
+  const twoSqrtAAlpha = 2 * Math.sqrt(A) * alpha
+  return normalise(
+    A * (A + 1 + (A - 1) * cosW0 + twoSqrtAAlpha),
+    -2 * A * (A - 1 + (A + 1) * cosW0),
+    A * (A + 1 + (A - 1) * cosW0 - twoSqrtAAlpha),
+    A + 1 - (A - 1) * cosW0 + twoSqrtAAlpha,
+    2 * (A - 1 - (A + 1) * cosW0),
+    A + 1 - (A - 1) * cosW0 - twoSqrtAAlpha,
+  )
+}
+
+/** Low-shelf. Matches FFmpeg `lowshelf`. */
+export function lowShelf(sampleRate, freqHz, width, gainDb, widthType = 'q') {
+  const A = Math.pow(10, gainDb / 40)
+  const w0 = (2 * Math.PI * freqHz) / sampleRate
+  const cosW0 = Math.cos(w0)
+  const alpha = alphaFor(w0, width, widthType, A)
+  const twoSqrtAAlpha = 2 * Math.sqrt(A) * alpha
+  return normalise(
+    A * (A + 1 - (A - 1) * cosW0 + twoSqrtAAlpha),
+    2 * A * (A - 1 - (A + 1) * cosW0),
+    A * (A + 1 - (A - 1) * cosW0 - twoSqrtAAlpha),
+    A + 1 + (A - 1) * cosW0 + twoSqrtAAlpha,
+    -2 * (A - 1 + (A + 1) * cosW0),
+    A + 1 + (A - 1) * cosW0 - twoSqrtAAlpha,
+  )
+}
+
+export function lowpass(sampleRate, freqHz, q = Math.SQRT1_2) {
+  const w0 = (2 * Math.PI * freqHz) / sampleRate
+  const cosW0 = Math.cos(w0)
+  const alpha = Math.sin(w0) / (2 * q)
+  const b1 = 1 - cosW0
+  return normalise(b1 / 2, b1, b1 / 2, 1 + alpha, -2 * cosW0, 1 - alpha)
+}
+
+export function highpass(sampleRate, freqHz, q = Math.SQRT1_2) {
+  const w0 = (2 * Math.PI * freqHz) / sampleRate
+  const cosW0 = Math.cos(w0)
+  const alpha = Math.sin(w0) / (2 * q)
+  const b0 = (1 + cosW0) / 2
+  return normalise(b0, -(1 + cosW0), b0, 1 + alpha, -2 * cosW0, 1 - alpha)
+}
+
+export function notch(sampleRate, freqHz, q) {
+  const w0 = (2 * Math.PI * freqHz) / sampleRate
+  const cosW0 = Math.cos(w0)
+  const alpha = Math.sin(w0) / (2 * q)
+  return normalise(1, -2 * cosW0, 1, 1 + alpha, -2 * cosW0, 1 - alpha)
+}
+
+/**
+ * Q values for the biquad sections of a Butterworth cascade.
+ *
+ * `scipy.signal.butter(N, ..., output='sos')` produces ceil(N/2) sections; for
+ * even N every section is a biquad with these Q values. Used by the vocal
+ * saturation band split, which is `butter(4, ...)` → two sections.
+ */
+export function butterworthQs(order) {
+  if (order % 2 !== 0) {
+    throw new Error(`butterworthQs supports even orders only, got ${order}`)
+  }
+  const qs = []
+  for (let k = 0; k < order / 2; k++) {
+    qs.push(1 / (2 * Math.cos(((2 * k + 1) * Math.PI) / (2 * order))))
+  }
+  return qs
+}
+
+/**
+ * Direct-form II transposed biquad cascade with per-channel state.
+ *
+ * DF-II-T is the standard choice for float audio: lower roundoff noise than
+ * DF-I at the same cost, and only two state words per section per channel.
+ */
+export class BiquadCascade {
+  /**
+   * @param {number} sectionCount
+   * @param {number} channelCount
+   */
+  constructor(sectionCount, channelCount = 1) {
+    this.sectionCount = sectionCount
+    this.channelCount = channelCount
+    this.coeffs = new Float64Array(sectionCount * 5) // b0,b1,b2,a1,a2 per section
+    // z1/z2 per section per channel, section-major.
+    this.z1 = new Float64Array(sectionCount * channelCount)
+    this.z2 = new Float64Array(sectionCount * channelCount)
+  }
+
+  /** Install coefficients for one section. Does not disturb filter state. */
+  setSection(index, c) {
+    const o = index * 5
+    this.coeffs[o] = c.b0
+    this.coeffs[o + 1] = c.b1
+    this.coeffs[o + 2] = c.b2
+    this.coeffs[o + 3] = c.a1
+    this.coeffs[o + 4] = c.a2
+  }
+
+  /** Install every section from an array of coefficient objects. */
+  setSections(sections) {
+    if (sections.length !== this.sectionCount) {
+      throw new Error(
+        `expected ${this.sectionCount} sections, got ${sections.length}`,
+      )
+    }
+    for (let i = 0; i < sections.length; i++) this.setSection(i, sections[i])
+  }
+
+  reset() {
+    this.z1.fill(0)
+    this.z2.fill(0)
+  }
+
+  /**
+   * Filter `n` samples of one channel in place (or into `output`).
+   * @param {ArrayLike<number>} input
+   * @param {{[i:number]: number}} output may alias `input`
+   * @param {number} n
+   * @param {number} channel
+   */
+  process(input, output, n, channel = 0) {
+    const { sectionCount, channelCount, coeffs, z1, z2 } = this
+    for (let i = 0; i < n; i++) {
+      let x = input[i]
+      for (let s = 0; s < sectionCount; s++) {
+        const o = s * 5
+        const si = s * channelCount + channel
+        const y = coeffs[o] * x + z1[si]
+        z1[si] = coeffs[o + 1] * x - coeffs[o + 3] * y + z2[si]
+        z2[si] = coeffs[o + 2] * x - coeffs[o + 4] * y
+        x = y
+      }
+      output[i] = x
+    }
+  }
+}
+
+/** |H(e^jw)|² of one normalised biquad section at a given frequency. */
+export function sectionResponseSq(c, freqHz, sampleRate) {
+  const w = (2 * Math.PI * freqHz) / sampleRate
+  const cosW = Math.cos(w)
+  const cos2W = Math.cos(2 * w)
+  const { b0, b1, b2, a1, a2 } = c
+  const num =
+    b0 * b0 + b1 * b1 + b2 * b2 + 2 * (b0 * b1 + b1 * b2) * cosW + 2 * b0 * b2 * cos2W
+  const den = 1 + a1 * a1 + a2 * a2 + 2 * (a1 + a1 * a2) * cosW + 2 * a2 * cos2W
+  return num / den
+}
+
+/**
+ * Magnitude response of a cascade, in dB, at each requested frequency.
+ * Drives the EQ curve overlay and makes filter design testable without audio.
+ *
+ * @param {Array<{b0:number,b1:number,b2:number,a1:number,a2:number}>} sections
+ * @param {ArrayLike<number>} freqsHz
+ * @param {number} sampleRate
+ * @returns {Float64Array}
+ */
+export function magnitudeResponseDb(sections, freqsHz, sampleRate) {
+  const out = new Float64Array(freqsHz.length)
+  for (let i = 0; i < freqsHz.length; i++) {
+    let hSq = 1
+    for (const s of sections) hSq *= sectionResponseSq(s, freqsHz[i], sampleRate)
+    out[i] = 10 * Math.log10(Math.max(hSq, 1e-300))
+  }
+  return out
+}

--- a/src/audio/dsp/biquad.js
+++ b/src/audio/dsp/biquad.js
@@ -192,6 +192,29 @@ export class BiquadCascade {
   }
 
   /**
+   * Grow the per-channel state to hold at least `n` channels, preserving the
+   * state of channels that already exist.
+   *
+   * Worklet kernels do not learn their channel count until the first
+   * `process()` call, and it can change if the graph is rewired, so the
+   * cascade has to be able to widen in place.
+   */
+  ensureChannels(n) {
+    if (n <= this.channelCount) return
+    const z1 = new Float64Array(this.sectionCount * n)
+    const z2 = new Float64Array(this.sectionCount * n)
+    for (let s = 0; s < this.sectionCount; s++) {
+      for (let c = 0; c < this.channelCount; c++) {
+        z1[s * n + c] = this.z1[s * this.channelCount + c]
+        z2[s * n + c] = this.z2[s * this.channelCount + c]
+      }
+    }
+    this.z1 = z1
+    this.z2 = z2
+    this.channelCount = n
+  }
+
+  /**
    * Filter `n` samples of one channel in place (or into `output`).
    * @param {ArrayLike<number>} input
    * @param {{[i:number]: number}} output may alias `input`

--- a/src/audio/dsp/clipGainEnvelope.js
+++ b/src/audio/dsp/clipGainEnvelope.js
@@ -1,0 +1,151 @@
+/**
+ * Clip-gain envelope renderer (client copy).
+ *
+ * Pure-JS port of the cosine-fade envelope renderer in
+ * server/scripts/clip_gain_deesser.py. Given a list of treated sibilant events
+ * (as emitted by applyClipGainDeEsser into ctx.results.clipGainDeEsser),
+ * synthesises a per-sample linear gain multiplier ready to drop into a mix
+ * loop.
+ *
+ * Verbatim copy of server/pipeline/clipGainEnvelope.js, which was already
+ * dependency-free. The realtime de-esser rebuilds its envelope on the main
+ * thread whenever a knob moves and posts the Float32Array to the worklet, so
+ * both sides share one definition of the envelope shape.
+ *
+ * KEEP IN SYNC with the server copy, which parallelCompression.js uses to reuse
+ * the clip-gain decision on its wet branch.
+ *
+ * No I/O, no Python spawn, no allocation beyond the returned Float32Array.
+ */
+
+const DEFAULT_FADES = {
+  fricativeInMs:  3.0,
+  fricativeOutMs: 4.0,
+  affricateInMs:  1.5,
+  affricateOutMs: 4.5,
+}
+
+/**
+ * @param {number}   numSamples
+ * @param {number}   sampleRate
+ * @param {Array<{startSample?:number, endSample?:number, startSec?:number,
+ *                endSec?:number, gainDb:number, eventType?:string}>} treatedEvents
+ *   From ctx.results.clipGainDeEsser.treatedEvents.
+ *   startSample/endSample preferred; falls back to startSec/endSec * sampleRate.
+ * @param {Partial<typeof DEFAULT_FADES>} [fades]
+ *   Per-preset fade timings. Falls back to the same defaults the Python script
+ *   uses when keys are absent.
+ * @returns {{ multiplier: Float32Array, eventCount: number, maxReductionDb: number }}
+ */
+export function buildClipGainEnvelope(numSamples, sampleRate, treatedEvents, fades = {}) {
+  const multiplier = new Float32Array(numSamples)
+  multiplier.fill(1.0)
+
+  if (!treatedEvents || treatedEvents.length === 0) {
+    return { multiplier, eventCount: 0, maxReductionDb: 0 }
+  }
+
+  const f = { ...DEFAULT_FADES, ...(fades || {}) }
+  let maxReductionDb = 0
+
+  for (const ev of treatedEvents) {
+    const s = resolveStart(ev, sampleRate)
+    const e = resolveEnd(ev, sampleRate)
+    if (s == null || e == null) continue
+
+    const sClamp = Math.max(0, s)
+    const eClamp = Math.min(numSamples - 1, e)
+    if (eClamp <= sClamp) continue
+
+    const gainLinear  = Math.pow(10, ev.gainDb / 20)
+    const isAffricate = ev.eventType === 'affricate'
+    const fadeInMs    = isAffricate ? f.affricateInMs  : f.fricativeInMs
+    const fadeOutMs   = isAffricate ? f.affricateOutMs : f.fricativeOutMs
+
+    let fadeIn  = Math.max(1, Math.round((fadeInMs  / 1000) * sampleRate))
+    let fadeOut = Math.max(1, Math.round((fadeOutMs / 1000) * sampleRate))
+    const eventLen = eClamp - sClamp + 1
+    if (fadeIn + fadeOut > eventLen) {
+      const scale = eventLen / (fadeIn + fadeOut)
+      fadeIn  = Math.max(1, Math.floor(fadeIn  * scale))
+      fadeOut = Math.max(1, Math.floor(fadeOut * scale))
+    }
+
+    renderEventEnvelope(multiplier, sClamp, eClamp, gainLinear, fadeIn, fadeOut)
+    const absDb = Math.abs(ev.gainDb)
+    if (absDb > maxReductionDb) maxReductionDb = absDb
+  }
+
+  return { multiplier, eventCount: treatedEvents.length, maxReductionDb }
+}
+
+function resolveStart(ev, sampleRate) {
+  if (Number.isInteger(ev.startSample)) return ev.startSample
+  if (typeof ev.startSec === 'number')  return Math.round(ev.startSec * sampleRate)
+  return null
+}
+
+function resolveEnd(ev, sampleRate) {
+  if (Number.isInteger(ev.endSample))  return ev.endSample
+  if (typeof ev.endSec === 'number')   return Math.round(ev.endSec * sampleRate) - 1
+  return null
+}
+
+// Half-Hann ramp of `length` samples: 0->1 (rising) or 1->0 (falling). Zero
+// derivative at both endpoints — matches the Python implementation, which
+// uses linspace(0, π, length, endpoint=True) + (1 - cos)/2.
+function cosineFade(length, rising) {
+  const out = new Float32Array(length)
+  if (length <= 0) return out
+  const denom = length - 1 || 1
+  for (let i = 0; i < length; i++) {
+    const t = (i / denom) * Math.PI
+    const v = (1 - Math.cos(t)) * 0.5
+    out[i] = rising ? v : 1 - v
+  }
+  return out
+}
+
+// Accumulate one event's gain envelope into the file-wide multiplier array.
+// Shape: unity → cosine fade → flat body at gainLinear → cosine fade → unity.
+// Overlapping events compound multiplicatively (matches Python behaviour).
+function renderEventEnvelope(multiplier, eventStart, eventEnd, gainLinear, fadeIn, fadeOut) {
+  const n = multiplier.length
+  const bodyStart = Math.min(n, eventStart + fadeIn)
+  const bodyEnd   = Math.max(bodyStart, eventEnd - fadeOut + 1)
+
+  // Fade-in: unity at eventStart → gainLinear at bodyStart.
+  if (fadeIn > 0 && eventStart < n) {
+    const a = Math.max(0, eventStart)
+    const b = Math.min(n, eventStart + fadeIn)
+    if (b > a) {
+      const ramp = cosineFade(b - a, true)
+      for (let i = 0; i < b - a; i++) {
+        const r   = ramp[i]
+        const seg = (1 - r) + r * gainLinear
+        multiplier[a + i] *= seg
+      }
+    }
+  }
+
+  // Flat body.
+  if (bodyEnd > bodyStart) {
+    const a = Math.max(0, bodyStart)
+    const b = Math.min(n, bodyEnd)
+    for (let i = a; i < b; i++) multiplier[i] *= gainLinear
+  }
+
+  // Fade-out: gainLinear at bodyEnd → unity at eventEnd+1.
+  if (fadeOut > 0 && eventEnd + 1 <= n) {
+    const a = Math.max(0, eventEnd - fadeOut + 1)
+    const b = Math.min(n, eventEnd + 1)
+    if (b > a) {
+      const ramp = cosineFade(b - a, true)
+      for (let i = 0; i < b - a; i++) {
+        const r   = ramp[i]
+        const seg = (1 - r) * gainLinear + r
+        multiplier[a + i] *= seg
+      }
+    }
+  }
+}

--- a/src/audio/dsp/envelope.js
+++ b/src/audio/dsp/envelope.js
@@ -1,0 +1,115 @@
+/**
+ * Envelope / smoothing primitives.
+ *
+ * Dependency-free — imported by AudioWorklet kernels.
+ *
+ * Note there are two coefficient conventions in this codebase and they are NOT
+ * interchangeable. Both are provided under explicit names so ports stay honest:
+ *
+ *   decayCoeff  — `exp(-period / tau)`, the weight kept on the PREVIOUS value.
+ *                 Used as `y = c*y + (1-c)*x`. This is what the Python stages
+ *                 use (resonance_suppressor.py `_time_to_coeff`,
+ *                 air_boost_masked.py `build_frame_envelope`), applied at the
+ *                 STFT frame rate rather than per sample.
+ *
+ *   riseCoeff   — `1 - exp(-period / tau)`, the weight applied to the NEW value.
+ *                 Used as `y += c * (x - y)`. This is what the existing
+ *                 compressor kernels use (la2aProcessor.js, fet1176Processor.js).
+ *
+ * riseCoeff(t) === 1 - decayCoeff(t); mixing them up inverts attack and release.
+ */
+
+/** Weight kept on the previous value. Period and tau in the same units. */
+export function decayCoeff(tauMs, periodMs) {
+  if (tauMs <= 0 || periodMs <= 0) return 0
+  return Math.exp(-periodMs / tauMs)
+}
+
+/** Weight applied to the new value, per sample. */
+export function riseCoeff(tauMs, sampleRate) {
+  if (tauMs <= 0) return 1
+  return 1 - Math.exp(-1 / (sampleRate * (tauMs / 1000)))
+}
+
+/**
+ * One-pole RMS follower.
+ *
+ * Stands in for the whole-file RMS normalisation in vocal_saturation.py, which
+ * computes `sqrt(dot(x,x)/len(x))` over the entire array — not something a
+ * streaming effect can do. A ~300 ms time constant tracks programme level
+ * without audibly pumping on speech.
+ *
+ * `floorLinear` clamps the reported value so silence cannot blow up a
+ * downstream `dryRms / wetRms` division.
+ */
+export class RmsFollower {
+  constructor(sampleRate, tauMs = 300, floorLinear = 1e-6) {
+    this.coeff = riseCoeff(tauMs, sampleRate)
+    this.floorLinear = floorLinear
+    this.meanSq = 0
+  }
+
+  reset() {
+    this.meanSq = 0
+  }
+
+  /** Feed one sample; returns the current RMS estimate. */
+  process(x) {
+    this.meanSq += this.coeff * (x * x - this.meanSq)
+    return this.value
+  }
+
+  /** Feed a block, returning the RMS estimate after the last sample. */
+  processBlock(input, n) {
+    const c = this.coeff
+    let m = this.meanSq
+    for (let i = 0; i < n; i++) {
+      const x = input[i]
+      m += c * (x * x - m)
+    }
+    this.meanSq = m
+    return this.value
+  }
+
+  get value() {
+    return Math.max(Math.sqrt(this.meanSq), this.floorLinear)
+  }
+
+  get db() {
+    return 20 * Math.log10(this.value)
+  }
+}
+
+/**
+ * Attack/release peak follower — asymmetric one-pole, per-sample.
+ * Shared shape with the compressor kernels' detectors.
+ */
+export class AttackReleaseFollower {
+  constructor(sampleRate, attackMs, releaseMs) {
+    this.setTimes(sampleRate, attackMs, releaseMs)
+    this.value = 0
+  }
+
+  setTimes(sampleRate, attackMs, releaseMs) {
+    this.attack = riseCoeff(attackMs, sampleRate)
+    this.release = riseCoeff(releaseMs, sampleRate)
+  }
+
+  reset() {
+    this.value = 0
+  }
+
+  process(x) {
+    const c = x > this.value ? this.attack : this.release
+    this.value += c * (x - this.value)
+    return this.value
+  }
+}
+
+export function linToDb(x) {
+  return 20 * Math.log10(Math.max(x, 1e-12))
+}
+
+export function dbToLin(db) {
+  return Math.pow(10, db / 20)
+}

--- a/src/audio/dsp/envelope.js
+++ b/src/audio/dsp/envelope.js
@@ -43,31 +43,53 @@ export function riseCoeff(tauMs, sampleRate) {
  * downstream `dryRms / wetRms` division.
  */
 export class RmsFollower {
+  /**
+   * @param {number} sampleRate
+   * @param {number} [tauMs=300]
+   * @param {number} [floorLinear=1e-6] clamp on the reported value, so the
+   *   follower is safe to divide by
+   */
   constructor(sampleRate, tauMs = 300, floorLinear = 1e-6) {
     this.coeff = riseCoeff(tauMs, sampleRate)
     this.floorLinear = floorLinear
+    // Warm up with a cumulative mean over roughly one time constant before
+    // handing over to the exponential average. Starting the IIR from zero
+    // makes the first ~tau read far too quiet, which matters wherever this
+    // stands in for a whole-file measurement: a gain derived from it would
+    // swing over the opening moments and leave an audible step at a region
+    // boundary. Seeding from a single sample is not enough either — a tone
+    // that happens to start at a zero crossing seeds zero.
+    this.warmupTarget = Math.max(1, Math.round(sampleRate * (tauMs / 1000)))
+    this.warmupCount = 0
     this.meanSq = 0
   }
 
   reset() {
     this.meanSq = 0
+    this.warmupCount = 0
+  }
+
+  /** Seed the estimate directly and skip the warmup. */
+  prime(meanSq) {
+    this.meanSq = meanSq
+    this.warmupCount = this.warmupTarget
   }
 
   /** Feed one sample; returns the current RMS estimate. */
   process(x) {
-    this.meanSq += this.coeff * (x * x - this.meanSq)
+    const sq = x * x
+    if (this.warmupCount < this.warmupTarget) {
+      this.warmupCount++
+      this.meanSq += (sq - this.meanSq) / this.warmupCount
+    } else {
+      this.meanSq += this.coeff * (sq - this.meanSq)
+    }
     return this.value
   }
 
   /** Feed a block, returning the RMS estimate after the last sample. */
   processBlock(input, n) {
-    const c = this.coeff
-    let m = this.meanSq
-    for (let i = 0; i < n; i++) {
-      const x = input[i]
-      m += c * (x * x - m)
-    }
-    this.meanSq = m
+    for (let i = 0; i < n; i++) this.process(input[i])
     return this.value
   }
 

--- a/src/audio/dsp/f0.js
+++ b/src/audio/dsp/f0.js
@@ -1,0 +1,158 @@
+/**
+ * Per-frame F0 estimation via FFT autocorrelation.
+ *
+ * Dependency-free — imported by AudioWorklet kernels.
+ *
+ * Direct port of server/scripts/estimate_f0_contour.py (`_autocorr_f0_batch`):
+ * zero-mean the frame, autocorrelate via |rfft|² → irfft at 2× length, take the
+ * peak within the lag range implied by [F0_MIN_HZ, F0_MAX_HZ], gate on
+ * MIN_CORR_RATIO, then parabolically interpolate the peak.
+ *
+ * The Python runs this over a whole file at once; the algorithm itself is
+ * strictly per-frame and causal, which is what makes realtime harmonic
+ * protection possible in the resonance suppressor without an analyze pass.
+ *
+ * Two things the whole-file version has that a streaming tracker cannot:
+ *   - a Silero voicing mask. Substituted here by the correlation ratio the
+ *     estimator already computes, optionally combined with a caller-supplied
+ *     energy gate.
+ *   - a whole-file median, used to set the cepstral lifter cutoff. Substituted
+ *     by a rolling median over recent voiced frames, matching the deque pattern
+ *     sibilance_detector.py already uses for its band tracking.
+ */
+
+import { getFFT } from './fft.js'
+
+export const F0_MIN_HZ = 70.0
+export const F0_MAX_HZ = 400.0
+export const MIN_CORR_RATIO = 0.1
+
+/** Rolling-median window, matching sibilance_detector.py's F0_ROLLING_WINDOW_SIZE. */
+export const DEFAULT_MEDIAN_WINDOW = 10
+
+export class F0Tracker {
+  /**
+   * @param {object} opts
+   * @param {number} opts.sampleRate
+   * @param {number} [opts.frameSize=2048] must match the consumer's STFT n_fft
+   * @param {number} [opts.medianWindow=10]
+   * @param {number} [opts.defaultF0=null] seed used before the first voiced frame
+   */
+  constructor({
+    sampleRate,
+    frameSize = 2048,
+    medianWindow = DEFAULT_MEDIAN_WINDOW,
+    defaultF0 = null,
+  }) {
+    this.sampleRate = sampleRate
+    this.frameSize = frameSize
+    this.medianWindow = medianWindow
+    this.defaultF0 = defaultF0
+
+    // Autocorrelation runs at 2× the frame length, as in the Python.
+    this.corrSize = 2 * frameSize
+    this.fft = getFFT(this.corrSize)
+
+    this.lagMin = Math.floor(sampleRate / F0_MAX_HZ)
+    this.lagMax = Math.floor(sampleRate / F0_MIN_HZ)
+
+    const bins = (this.corrSize >>> 1) + 1
+    this._re = new Float64Array(bins)
+    this._im = new Float64Array(bins)
+    this._centred = new Float64Array(frameSize)
+    this._corr = new Float64Array(this.corrSize)
+
+    this._history = []
+    this._sorted = []
+    this.lastF0 = null
+  }
+
+  reset() {
+    this._history.length = 0
+    this.lastF0 = null
+  }
+
+  /**
+   * Estimate F0 for one frame.
+   *
+   * @param {ArrayLike<number>} frame length === frameSize, unwindowed
+   * @param {boolean} [energyGate=true] caller's voicing gate (e.g. above noise floor)
+   * @returns {{ f0: number|null, voiced: boolean, ratio: number }}
+   */
+  estimate(frame, energyGate = true) {
+    const n = this.frameSize
+    if (n < 64 || this.lagMax >= n || this.lagMin >= this.lagMax) {
+      return { f0: null, voiced: false, ratio: 0 }
+    }
+
+    // Zero-mean, matching `f64 - f64.mean(axis=1)`.
+    let mean = 0
+    for (let i = 0; i < n; i++) mean += frame[i]
+    mean /= n
+    const centred = this._centred
+    for (let i = 0; i < n; i++) centred[i] = frame[i] - mean
+
+    // Autocorrelation via the Wiener-Khinchin route: irfft(|rfft(x)|²).
+    this.fft.rfft(centred, this._re, this._im)
+    const bins = (this.corrSize >>> 1) + 1
+    for (let k = 0; k < bins; k++) {
+      const re = this._re[k]
+      const im = this._im[k]
+      this._re[k] = re * re + im * im
+      this._im[k] = 0
+    }
+    this.fft.irfft(this._re, null, this._corr)
+
+    const corr = this._corr
+    const corr0 = corr[0]
+
+    let peak = -Infinity
+    let peakLag = -1
+    for (let lag = this.lagMin; lag < this.lagMax; lag++) {
+      if (corr[lag] > peak) {
+        peak = corr[lag]
+        peakLag = lag
+      }
+    }
+
+    const ratio = corr0 > 0 ? peak / corr0 : 0
+    const voiced = peakLag > 0 && peak > MIN_CORR_RATIO * corr0 && energyGate
+    if (!voiced) {
+      return { f0: null, voiced: false, ratio }
+    }
+
+    // Parabolic interpolation around the peak, guarded exactly as the Python is.
+    let f0 = this.sampleRate / peakLag
+    if (peakLag > 0 && peakLag < n - 1) {
+      const y0 = corr[peakLag - 1]
+      const y1 = corr[peakLag]
+      const y2 = corr[peakLag + 1]
+      const denom = y0 - 2 * y1 + y2
+      if (denom !== 0) {
+        const delta = (0.5 * (y0 - y2)) / denom
+        f0 = this.sampleRate / (peakLag + delta)
+      }
+    }
+
+    this.lastF0 = f0
+    this._history.push(f0)
+    if (this._history.length > this.medianWindow) this._history.shift()
+
+    return { f0, voiced: true, ratio }
+  }
+
+  /**
+   * Rolling median of recent voiced estimates, or the seed default before any
+   * voiced frame has been seen. Drives the cepstral lifter cutoff.
+   */
+  get median() {
+    const h = this._history
+    if (h.length === 0) return this.defaultF0
+    const s = this._sorted
+    s.length = h.length
+    for (let i = 0; i < h.length; i++) s[i] = h[i]
+    s.sort((a, b) => a - b)
+    const mid = s.length >> 1
+    return s.length % 2 ? s[mid] : 0.5 * (s[mid - 1] + s[mid])
+  }
+}

--- a/src/audio/dsp/fft.js
+++ b/src/audio/dsp/fft.js
@@ -1,0 +1,187 @@
+/**
+ * Radix-2 FFT with precomputed tables.
+ *
+ * Dependency-free by design: this module is imported by AudioWorklet kernels,
+ * which are bundled into self-contained chunks via `?worker&url`. Nothing here
+ * may reach for a DOM, Node, or Web Audio global.
+ *
+ * Why not reuse `fftInPlace` from server/pipeline/humEQ.js verbatim: that
+ * implementation recomputes each butterfly's twiddle factor by repeated complex
+ * multiplication, which both costs trig per call and accumulates rounding error
+ * across long inner loops. The realtime path runs hundreds of transforms per
+ * second, so twiddles and the bit-reversal permutation are precomputed once per
+ * size and cached.
+ *
+ * Conventions match numpy so ports from the Python stages stay readable:
+ *   - `rfft`  takes N real samples  → N/2+1 complex bins, unscaled
+ *   - `irfft` takes N/2+1 complex bins → N real samples, scaled by 1/N
+ */
+
+const cache = new Map()
+
+/** Get a memoized FFT instance for a power-of-two size. */
+export function getFFT(size) {
+  let fft = cache.get(size)
+  if (!fft) {
+    fft = new FFT(size)
+    cache.set(size, fft)
+  }
+  return fft
+}
+
+export class FFT {
+  constructor(size) {
+    if (size < 2 || (size & (size - 1)) !== 0) {
+      throw new Error(`FFT size must be a power of two, got ${size}`)
+    }
+    this.size = size
+    this.half = size >>> 1
+
+    // Bit-reversal permutation table.
+    this.rev = new Uint32Array(size)
+    let j = 0
+    for (let i = 1; i < size; i++) {
+      let bit = size >>> 1
+      for (; j & bit; bit >>= 1) j ^= bit
+      j ^= bit
+      this.rev[i] = j
+    }
+
+    // Twiddle tables, one contiguous block per stage.
+    // Stage with half-length `h` occupies [offset, offset + h).
+    this.cos = new Float64Array(size)
+    this.sin = new Float64Array(size)
+    let offset = 0
+    for (let len = 2; len <= size; len <<= 1) {
+      const h = len >>> 1
+      const ang = (-2 * Math.PI) / len
+      for (let k = 0; k < h; k++) {
+        this.cos[offset + k] = Math.cos(ang * k)
+        this.sin[offset + k] = Math.sin(ang * k)
+      }
+      offset += h
+    }
+
+    // Scratch for the real-input helpers, so steady-state processing allocates
+    // nothing on the audio thread.
+    this._re = new Float64Array(size)
+    this._im = new Float64Array(size)
+  }
+
+  /**
+   * In-place complex forward transform. No scaling.
+   * @param {Float64Array} re length === size
+   * @param {Float64Array} im length === size
+   */
+  forward(re, im) {
+    const { size, rev, cos, sin } = this
+
+    for (let i = 1; i < size; i++) {
+      const j = rev[i]
+      if (i < j) {
+        let t = re[i]; re[i] = re[j]; re[j] = t
+        t = im[i]; im[i] = im[j]; im[j] = t
+      }
+    }
+
+    let offset = 0
+    for (let len = 2; len <= size; len <<= 1) {
+      const h = len >>> 1
+      for (let i = 0; i < size; i += len) {
+        for (let k = 0; k < h; k++) {
+          const wRe = cos[offset + k]
+          const wIm = sin[offset + k]
+          const a = i + k
+          const b = a + h
+          const vRe = re[b] * wRe - im[b] * wIm
+          const vIm = re[b] * wIm + im[b] * wRe
+          re[b] = re[a] - vRe
+          im[b] = im[a] - vIm
+          re[a] += vRe
+          im[a] += vIm
+        }
+      }
+      offset += h
+    }
+  }
+
+  /**
+   * In-place complex inverse transform, scaled by 1/size.
+   * Implemented via the conjugate identity: ifft(x) = conj(fft(conj(x))) / N.
+   */
+  inverse(re, im) {
+    const { size } = this
+    for (let i = 0; i < size; i++) im[i] = -im[i]
+    this.forward(re, im)
+    const scale = 1 / size
+    for (let i = 0; i < size; i++) {
+      re[i] *= scale
+      im[i] = -im[i] * scale
+    }
+  }
+
+  /**
+   * Real-input forward transform (numpy `rfft`).
+   *
+   * @param {ArrayLike<number>} input  length === size (shorter input is zero-padded)
+   * @param {Float64Array} outRe  length >= size/2+1
+   * @param {Float64Array} outIm  length >= size/2+1
+   */
+  rfft(input, outRe, outIm) {
+    const { size, half, _re, _im } = this
+    const n = Math.min(input.length, size)
+    for (let i = 0; i < n; i++) _re[i] = input[i]
+    for (let i = n; i < size; i++) _re[i] = 0
+    _im.fill(0)
+
+    this.forward(_re, _im)
+
+    for (let k = 0; k <= half; k++) {
+      outRe[k] = _re[k]
+      outIm[k] = _im[k]
+    }
+  }
+
+  /**
+   * Real-output inverse transform (numpy `irfft`).
+   *
+   * Rebuilds the Hermitian-symmetric full spectrum from the half spectrum, so
+   * bins above Nyquist do not need to be supplied. `inIm` may be null, which is
+   * how the cepstral lifter uses it — a real-valued half spectrum inverts to a
+   * real, symmetric sequence.
+   *
+   * @param {ArrayLike<number>} inRe  length >= size/2+1
+   * @param {ArrayLike<number>|null} inIm  length >= size/2+1, or null for zeros
+   * @param {Float64Array} output  length >= size
+   */
+  irfft(inRe, inIm, output) {
+    const { size, half, _re, _im } = this
+
+    for (let k = 0; k <= half; k++) {
+      _re[k] = inRe[k]
+      _im[k] = inIm ? inIm[k] : 0
+    }
+    // Hermitian mirror for bins above Nyquist.
+    for (let k = half + 1; k < size; k++) {
+      _re[k] = _re[size - k]
+      _im[k] = -_im[size - k]
+    }
+
+    this.inverse(_re, _im)
+
+    for (let i = 0; i < size; i++) output[i] = _re[i]
+  }
+}
+
+/** Number of bins a real FFT of this size produces. */
+export function rfftBinCount(size) {
+  return (size >>> 1) + 1
+}
+
+/** Centre frequency of each rfft bin, in Hz (numpy `rfftfreq`). */
+export function rfftFreqs(size, sampleRate) {
+  const bins = rfftBinCount(size)
+  const out = new Float64Array(bins)
+  for (let k = 0; k < bins; k++) out[k] = (k * sampleRate) / size
+  return out
+}

--- a/src/audio/dsp/stft.js
+++ b/src/audio/dsp/stft.js
@@ -1,0 +1,160 @@
+/**
+ * Streaming STFT / overlap-add framework.
+ *
+ * Dependency-free — imported by AudioWorklet kernels.
+ *
+ * Mirrors the framing convention the Python spectral stages use
+ * (resonance_suppressor.py, air_boost_masked.py, analyze_sibilance_events.py):
+ * n_fft = 2048, hop = 512, periodic Hann, overlap-add normalised by the
+ * accumulated window² rather than by a constant. Normalising by the actual
+ * accumulated window makes reconstruction exact at the signal edges too, which
+ * is what `window_accumulator` does in resonance_suppressor.py.
+ *
+ * Latency is exactly `fftSize` samples: an output position is emitted only once
+ * every frame overlapping it has been accumulated, and the last such frame does
+ * not complete until fftSize further input samples have arrived. Callers must
+ * report this through the effect descriptor so the offline apply path can trim
+ * it and the bypass path can delay-match for A/B.
+ */
+
+import { getFFT, rfftBinCount } from './fft.js'
+
+/** Periodic Hann window — matches scipy `get_window('hann', N, fftbins=True)`. */
+export function hannPeriodic(size) {
+  const w = new Float64Array(size)
+  for (let i = 0; i < size; i++) {
+    w[i] = 0.5 * (1 - Math.cos((2 * Math.PI * i) / size))
+  }
+  return w
+}
+
+export class StftProcessor {
+  /**
+   * @param {object} opts
+   * @param {number} [opts.fftSize=2048]
+   * @param {number} [opts.hopSize=512]
+   */
+  constructor({ fftSize = 2048, hopSize = 512 } = {}) {
+    if (fftSize % hopSize !== 0) {
+      throw new Error('fftSize must be an integer multiple of hopSize')
+    }
+    this.fftSize = fftSize
+    this.hopSize = hopSize
+    this.binCount = rfftBinCount(fftSize)
+    this.fft = getFFT(fftSize)
+    this.window = hannPeriodic(fftSize)
+
+    // Input side: circular buffer holding the most recent fftSize samples.
+    this.inRing = new Float64Array(fftSize)
+    this.inWrite = 0
+    this.sinceHop = 0
+
+    // Scratch, so steady-state processing allocates nothing.
+    this.frame = new Float64Array(fftSize)
+    this.specRe = new Float64Array(this.binCount)
+    this.specIm = new Float64Array(this.binCount)
+
+    // Overlap-add accumulators. Index 0 tracks the start of the current frame.
+    this.ola = new Float64Array(fftSize)
+    this.olaWin = new Float64Array(fftSize)
+
+    // Output FIFO. Pre-loaded with one hop of silence so a pop is always
+    // available before the first frame completes; combined with the frame
+    // scheduling this yields exactly fftSize samples of latency.
+    this.outCap = fftSize + hopSize
+    this.outRing = new Float64Array(this.outCap)
+    this.outRead = 0
+    this.outWrite = hopSize
+    this.outCount = hopSize
+
+    this.frameCount = 0
+  }
+
+  /** Algorithmic latency in samples. */
+  get latencySamples() {
+    return this.fftSize
+  }
+
+  reset() {
+    this.inRing.fill(0)
+    this.inWrite = 0
+    this.sinceHop = 0
+    this.ola.fill(0)
+    this.olaWin.fill(0)
+    this.outRing.fill(0)
+    this.outRead = 0
+    this.outWrite = this.hopSize
+    this.outCount = this.hopSize
+    this.frameCount = 0
+  }
+
+  /**
+   * Push a block of input and pull the same number of output samples.
+   *
+   * `frameFn(specRe, specIm, binCount, ctx)` is invoked once per completed
+   * frame and may modify the spectrum in place. Pass null for pass-through
+   * (useful for measuring reconstruction error).
+   *
+   * @param {ArrayLike<number>} input
+   * @param {{[i:number]: number}} output may alias `input`
+   * @param {number} n
+   * @param {((re:Float64Array, im:Float64Array, bins:number, self:StftProcessor)=>void)|null} frameFn
+   */
+  process(input, output, n, frameFn) {
+    const { fftSize, hopSize } = this
+    for (let i = 0; i < n; i++) {
+      // Write input first, so a frame completing on this sample is pushed to
+      // the FIFO before we pop — otherwise the FIFO underruns on the very
+      // first frame boundary.
+      this.inRing[this.inWrite] = input[i]
+      this.inWrite = this.inWrite + 1 === fftSize ? 0 : this.inWrite + 1
+      if (++this.sinceHop === hopSize) {
+        this.sinceHop = 0
+        this._processFrame(frameFn)
+      }
+
+      output[i] = this.outRing[this.outRead]
+      this.outRead = this.outRead + 1 === this.outCap ? 0 : this.outRead + 1
+      this.outCount--
+    }
+  }
+
+  _processFrame(frameFn) {
+    const { fftSize, hopSize, window, inRing, frame, ola, olaWin, specRe, specIm } =
+      this
+
+    // Gather the ring into linear order (oldest first) and window it.
+    let r = this.inWrite // oldest sample sits at the write cursor
+    for (let i = 0; i < fftSize; i++) {
+      frame[i] = inRing[r] * window[i]
+      r = r + 1 === fftSize ? 0 : r + 1
+    }
+
+    this.fft.rfft(frame, specRe, specIm)
+    if (frameFn) frameFn(specRe, specIm, this.binCount, this)
+    this.fft.irfft(specRe, specIm, frame)
+
+    // Overlap-add, synthesis-windowed.
+    for (let i = 0; i < fftSize; i++) {
+      const w = window[i]
+      ola[i] += frame[i] * w
+      olaWin[i] += w * w
+    }
+
+    // Emit one hop: positions 0..hopSize are now fully accumulated.
+    for (let i = 0; i < hopSize; i++) {
+      const denom = olaWin[i]
+      this.outRing[this.outWrite] = denom > 1e-12 ? ola[i] / denom : 0
+      this.outWrite = this.outWrite + 1 === this.outCap ? 0 : this.outWrite + 1
+      this.outCount++
+    }
+
+    // Slide the accumulators forward by one hop.
+    ola.copyWithin(0, hopSize)
+    ola.fill(0, fftSize - hopSize)
+    olaWin.copyWithin(0, hopSize)
+    olaWin.fill(0, fftSize - hopSize)
+
+    this.frameCount++
+  }
+}

--- a/src/audio/effects/airBand.js
+++ b/src/audio/effects/airBand.js
@@ -1,0 +1,114 @@
+/**
+ * Air Band — real-time effect chain wrapper.
+ *
+ * The DSP lives in ../airBandProcessor.js (five Maag-style parametric bells
+ * plus a wide high shelf, all scaling from one knob) and runs in an
+ * AudioWorklet. The offline apply path renders through the same worklet in an
+ * OfflineAudioContext, so the preview is sample-identical to what gets written
+ * to the timeline.
+ *
+ * The worklet module loads asynchronously; until it's ready the effect passes
+ * audio through unprocessed, then splices the worklet node in.
+ */
+
+import { ensureAirBandWorklet } from '../airBandWorkletLoader.js'
+import { createLevelTap } from './levelTap.js'
+
+export const AIR_BAND_DEFAULTS = {
+  air: 6, // dB of air lift, 0–24
+  output: 0, // output trim dB, for level-matched A/B
+}
+
+/** Map UI param names to kernel param names. */
+export function toKernelParams(params) {
+  return {
+    gainDb: params.air,
+    outputGainDb: params.output,
+  }
+}
+
+export function createAirBand(audioContext) {
+  const input = audioContext.createGain()
+  // preOutput is a stable internal hand-off: the chain calls .disconnect()
+  // on `output` during rebuilds (wiping ALL its outgoing connections), so
+  // nothing internal may hang off `output` — taps and the worklet feed
+  // preOutput instead, and preOutput -> output survives every rebuild.
+  const preOutput = audioContext.createGain()
+  const output = audioContext.createGain()
+
+  let params = { ...AIR_BAND_DEFAULTS }
+  let worklet = null
+  let destroyed = false
+
+  // Pass through until the worklet module is loaded, then splice it in.
+  input.connect(preOutput)
+  preOutput.connect(output)
+
+  ensureAirBandWorklet(audioContext)
+    .then(() => {
+      if (destroyed) return
+      worklet = new AudioWorkletNode(audioContext, 'air-band-processor', {
+        processorOptions: { params: toKernelParams(params) },
+      })
+      input.disconnect(preOutput)
+      input.connect(worklet)
+      worklet.connect(preOutput)
+    })
+    .catch((err) => {
+      console.error('Air Band worklet failed to load, running bypassed:', err)
+    })
+
+  // Level meter taps on dedicated monitor nodes fed from stable internal
+  // points (input / preOutput), never from `output` — see note above.
+  const inputMonitor = audioContext.createGain()
+  input.connect(inputMonitor)
+  const outputMonitor = audioContext.createGain()
+  preOutput.connect(outputMonitor)
+
+  const inputTap = createLevelTap(audioContext, inputMonitor)
+  const outputTap = createLevelTap(audioContext, outputMonitor)
+
+  return {
+    input,
+    output,
+
+    setParam(name, value) {
+      if (name in params) {
+        params[name] = value
+        worklet?.port.postMessage({ type: 'params', params: toKernelParams(params) })
+      }
+    },
+
+    getParam(name) {
+      return params[name]
+    },
+
+    getInputLevelDb() {
+      return inputTap.getLevelDb()
+    },
+
+    getOutputLevelDb() {
+      return outputTap.getLevelDb()
+    },
+
+    destroy() {
+      destroyed = true
+      input.disconnect()
+      worklet?.disconnect()
+      preOutput.disconnect()
+      output.disconnect()
+      inputMonitor.disconnect()
+      outputMonitor.disconnect()
+      inputTap.destroy()
+      outputTap.destroy()
+    },
+  }
+}
+
+export const airBandEffect = {
+  id: 'air-band',
+  name: 'Air Band',
+  createNodes(audioContext) {
+    return createAirBand(audioContext)
+  },
+}

--- a/src/audio/effects/vocalSat.js
+++ b/src/audio/effects/vocalSat.js
@@ -1,0 +1,126 @@
+/**
+ * Vocal Saturation — real-time effect chain wrapper.
+ *
+ * The DSP lives in ../vocalSatProcessor.js (complementary three-band split,
+ * blended tanh/arctan transfer with per-band drive, gain-neutral parallel
+ * blend) and runs in an AudioWorklet. The offline apply path renders through
+ * the same worklet in an OfflineAudioContext, so the preview is
+ * sample-identical to what gets written to the timeline.
+ *
+ * This replaces a server round-trip: the panel used to POST the rendered
+ * selection to /api/spot/vocal_saturation and wait on a modal.
+ *
+ * The worklet module loads asynchronously; until it's ready the effect passes
+ * audio through unprocessed, then splices the worklet node in.
+ */
+
+import { ensureVocalSatWorklet } from '../vocalSatWorkletLoader.js'
+import { createLevelTap } from './levelTap.js'
+
+// Same names and defaults the panel already used, so the UI is unchanged.
+export const VOCAL_SAT_DEFAULTS = {
+  drive: 2.0,
+  wetDry: 0.3,
+  bias: 0.5,
+  softness: 0.3,
+  lowCrossover: 500,
+  midCrossover: 3500,
+  lowDriveMult: 5.0,
+  midDriveMult: 0.1,
+  highDriveMult: 0.1,
+}
+
+/** Map UI param names to kernel param names — 1:1 for this effect. */
+export function toKernelParams(params) {
+  return {
+    drive: params.drive,
+    wetDry: params.wetDry,
+    bias: params.bias,
+    softness: params.softness,
+    lowCrossover: params.lowCrossover,
+    midCrossover: params.midCrossover,
+    lowDriveMult: params.lowDriveMult,
+    midDriveMult: params.midDriveMult,
+    highDriveMult: params.highDriveMult,
+  }
+}
+
+export function createVocalSat(audioContext) {
+  const input = audioContext.createGain()
+  // preOutput is a stable internal hand-off — see the note in airBand.js.
+  const preOutput = audioContext.createGain()
+  const output = audioContext.createGain()
+
+  let params = { ...VOCAL_SAT_DEFAULTS }
+  let worklet = null
+  let destroyed = false
+
+  input.connect(preOutput)
+  preOutput.connect(output)
+
+  ensureVocalSatWorklet(audioContext)
+    .then(() => {
+      if (destroyed) return
+      worklet = new AudioWorkletNode(audioContext, 'vocal-sat-processor', {
+        processorOptions: { params: toKernelParams(params) },
+      })
+      input.disconnect(preOutput)
+      input.connect(worklet)
+      worklet.connect(preOutput)
+    })
+    .catch((err) => {
+      console.error('Vocal Saturation worklet failed to load, running bypassed:', err)
+    })
+
+  const inputMonitor = audioContext.createGain()
+  input.connect(inputMonitor)
+  const outputMonitor = audioContext.createGain()
+  preOutput.connect(outputMonitor)
+
+  const inputTap = createLevelTap(audioContext, inputMonitor)
+  const outputTap = createLevelTap(audioContext, outputMonitor)
+
+  return {
+    input,
+    output,
+
+    setParam(name, value) {
+      if (name in params) {
+        params[name] = value
+        worklet?.port.postMessage({ type: 'params', params: toKernelParams(params) })
+      }
+    },
+
+    getParam(name) {
+      return params[name]
+    },
+
+    getInputLevelDb() {
+      return inputTap.getLevelDb()
+    },
+
+    getOutputLevelDb() {
+      return outputTap.getLevelDb()
+    },
+
+    destroy() {
+      destroyed = true
+      input.disconnect()
+      worklet?.disconnect()
+      preOutput.disconnect()
+      output.disconnect()
+      inputMonitor.disconnect()
+      outputMonitor.disconnect()
+      inputTap.destroy()
+      outputTap.destroy()
+    },
+  }
+}
+
+export const vocalSatEffect = {
+  id: 'vocal-sat',
+  name: 'Vocal Saturation',
+  createNodes(audioContext) {
+    return createVocalSat(audioContext)
+  },
+}

--- a/src/audio/la2aWorkletLoader.js
+++ b/src/audio/la2aWorkletLoader.js
@@ -1,16 +1,22 @@
 /**
  * Load the LA-2A worklet module into an AudioContext or OfflineAudioContext,
- * once per context. la2aProcessor.js is referenced as a raw asset URL (it is
- * deliberately dependency-free so it works unbundled in the worklet scope).
+ * once per context.
+ *
+ * `?worker&url` bundles la2aProcessor.js and any of its imports into one
+ * self-contained chunk. This kernel happens to be dependency-free, but the
+ * loaders are kept uniform: the raw-asset form (`new URL(..., import.meta.url)`)
+ * silently stops working the moment a kernel imports anything, and it fails only
+ * in production builds — dev resolves the import fine. Going through the
+ * bundler also minifies the kernel, which the raw-asset path does not.
  */
+import workletUrl from './la2aProcessor.js?worker&url'
+
 const loadPromises = new WeakMap()
 
 export function ensureLA2AWorklet(context) {
   let promise = loadPromises.get(context)
   if (!promise) {
-    promise = context.audioWorklet.addModule(
-      new URL('./la2aProcessor.js', import.meta.url)
-    )
+    promise = context.audioWorklet.addModule(workletUrl)
     loadPromises.set(context, promise)
   }
   return promise

--- a/src/audio/processing.js
+++ b/src/audio/processing.js
@@ -6,6 +6,16 @@ import {
   FET1176_DEFAULTS,
   toKernelParams as toFET1176KernelParams,
 } from './effects/fet1176Compressor.js'
+import { ensureAirBandWorklet } from './airBandWorkletLoader.js'
+import {
+  AIR_BAND_DEFAULTS,
+  toKernelParams as toAirBandKernelParams,
+} from './effects/airBand.js'
+import { ensureVocalSatWorklet } from './vocalSatWorkletLoader.js'
+import {
+  VOCAL_SAT_DEFAULTS,
+  toKernelParams as toVocalSatKernelParams,
+} from './effects/vocalSat.js'
 
 /**
  * Render a region of the timeline to a flat PCM buffer.
@@ -315,6 +325,24 @@ export function applyFET1176Region(segments, start, end, params, sampleRate, cha
     ensureWorklet: ensureFET1176Worklet,
     processorName: 'fet1176-processor',
     kernelParams: toFET1176KernelParams({ ...FET1176_DEFAULTS, ...params }),
+  })
+}
+
+/** Apply Air Band to a region. */
+export function applyAirBandRegion(segments, start, end, params, sampleRate, channels) {
+  return applyWorkletRegion(segments, start, end, sampleRate, channels, {
+    ensureWorklet: ensureAirBandWorklet,
+    processorName: 'air-band-processor',
+    kernelParams: toAirBandKernelParams({ ...AIR_BAND_DEFAULTS, ...params }),
+  })
+}
+
+/** Apply Vocal Saturation to a region. */
+export function applyVocalSatRegion(segments, start, end, params, sampleRate, channels) {
+  return applyWorkletRegion(segments, start, end, sampleRate, channels, {
+    ensureWorklet: ensureVocalSatWorklet,
+    processorName: 'vocal-sat-processor',
+    kernelParams: toVocalSatKernelParams({ ...VOCAL_SAT_DEFAULTS, ...params }),
   })
 }
 

--- a/src/audio/vocalSatProcessor.js
+++ b/src/audio/vocalSatProcessor.js
@@ -1,0 +1,269 @@
+/**
+ * Vocal Saturation — worklet kernel.
+ *
+ * A realtime port of server/scripts/vocal_saturation.py: a complementary
+ * three-band split, a blended tanh/arctan transfer with per-band drive, and a
+ * gain-neutral parallel blend back against the dry signal.
+ *
+ * This file is BOTH a normal ES module (exports VocalSatKernel and
+ * processVocalSatBuffer) AND an AudioWorklet module (registers
+ * 'vocal-sat-processor'). It imports from ./dsp/, so its loader pulls it
+ * through `?worker&url` — see vocalSatWorkletLoader.js.
+ *
+ * Two deliberate deviations from the Python, both consequences of the fact
+ * that a streaming effect cannot see the whole file:
+ *
+ * 1. LEVEL MATCHING. The Python normalises twice against whole-file RMS —
+ *    `wet *= dry_rms/wet_rms` then `output *= dry_rms/out_rms`. Here each of
+ *    those three measurements is a one-pole follower (RMS_TAU_MS). The
+ *    structure is identical; the values track programme level instead of being
+ *    constant over the file. Followers are primed from the first sample so the
+ *    opening of a region is not under-normalised.
+ *
+ * 2. NO OVERSAMPLING. The Python runs the nonlinearity at 2x via a 15-tap
+ *    Kaiser half-band whenever a band's effective drive reaches 0.5 — at
+ *    default settings the low band runs at 10 — relying on resample_poly to
+ *    compensate group delay internally. A streaming 2x up/down pair costs
+ *    exactly 7 samples of latency at the base rate, which would make this a
+ *    latent effect and force delay compensation through the offline apply path.
+ *
+ *    Measured cost of leaving it out (test/dsp/vocalSat.test.js, bin-centred
+ *    tones so spectral leakage is not mistaken for aliasing): alias-to-signal
+ *    is -91.8 dB at defaults, -87.2 dB on a 122 Hz tone, -92.6 dB even at
+ *    drive 5, and -79.1 dB fully wet. All far below audibility, so the effect
+ *    stays genuinely zero-latency at no practical cost. Revisit only if a
+ *    future band runs a much harder curve.
+ */
+
+import { lowpass, highpass, butterworthQs, BiquadCascade } from './dsp/biquad.js'
+import { RmsFollower } from './dsp/envelope.js'
+
+export const VOCAL_SAT_KERNEL_DEFAULTS = {
+  drive: 2.0,
+  wetDry: 0.3,
+  bias: 0.5,
+  softness: 0.3,
+  lowCrossover: 500,
+  midCrossover: 3500,
+  lowDriveMult: 5.0,
+  midDriveMult: 0.1,
+  highDriveMult: 0.1,
+}
+
+/**
+ * Time constant for the three level-matching followers. Long enough not to
+ * pump on syllables, short enough to track a change of delivery.
+ */
+const RMS_TAU_MS = 300
+
+// Matches the `+ 1e-8` in vocal_saturation.py's _rms, and keeps the two
+// divisions below finite through silence.
+const RMS_FLOOR = 1e-8
+
+const TWO_OVER_PI = 2 / Math.PI
+
+function clamp(v, lo, hi) {
+  return v < lo ? lo : v > hi ? hi : v
+}
+
+/**
+ * Blended tanh/arctan transfer with the bias operating point removed.
+ * Direct port of `_apply_transfer`.
+ */
+function applyTransfer(pre, softness, bias) {
+  if (softness <= 0) return Math.tanh(pre) - Math.tanh(bias)
+  if (softness >= 1) return TWO_OVER_PI * (Math.atan(pre) - Math.atan(bias))
+  const yTanh = Math.tanh(pre)
+  const yAtan = TWO_OVER_PI * Math.atan(pre)
+  const biasRef =
+    (1 - softness) * Math.tanh(bias) + softness * TWO_OVER_PI * Math.atan(bias)
+  return (1 - softness) * yTanh + softness * yAtan - biasRef
+}
+
+/** Per-channel filter and follower state. */
+class ChannelState {
+  constructor(sampleRate) {
+    const qs = butterworthQs(4)
+    this.lp = new BiquadCascade(qs.length, 1)
+    this.hp = new BiquadCascade(qs.length, 1)
+    this.dryRms = new RmsFollower(sampleRate, RMS_TAU_MS, RMS_FLOOR)
+    this.wetRms = new RmsFollower(sampleRate, RMS_TAU_MS, RMS_FLOOR)
+    this.outRms = new RmsFollower(sampleRate, RMS_TAU_MS, RMS_FLOOR)
+  }
+}
+
+export class VocalSatKernel {
+  constructor(sampleRate) {
+    this.sampleRate = sampleRate
+    this.butterQs = butterworthQs(4)
+    this.channels = []
+    this.params = { ...VOCAL_SAT_KERNEL_DEFAULTS }
+    this.setParams({})
+  }
+
+  /** Merge a partial param update and recompute derived state. */
+  setParams(partial) {
+    const p = { ...this.params, ...partial }
+    this.params = p
+
+    const nyquist = this.sampleRate / 2
+    this.lowCrossover = clamp(p.lowCrossover, 20, nyquist * 0.98)
+    this.midCrossover = clamp(p.midCrossover, this.lowCrossover + 1, nyquist * 0.98)
+
+    // butter(4, ...) → two biquad sections; sosfilt is causal, so a direct
+    // cascade matches it.
+    this.lpSections = this.butterQs.map(q => lowpass(this.sampleRate, this.lowCrossover, q))
+    this.hpSections = this.butterQs.map(q => highpass(this.sampleRate, this.midCrossover, q))
+    for (const c of this.channels) {
+      c.lp.setSections(this.lpSections)
+      c.hp.setSections(this.hpSections)
+    }
+
+    this.softness = clamp(p.softness, 0, 1)
+    this.bias = p.bias
+    this.wetDry = Math.max(0, p.wetDry)
+    this.lowDrive = p.drive * p.lowDriveMult
+    this.midDrive = p.drive * p.midDriveMult
+    this.highDrive = p.drive * p.highDriveMult
+  }
+
+  _ensureChannels(n) {
+    while (this.channels.length < n) {
+      const c = new ChannelState(this.sampleRate)
+      c.lp.setSections(this.lpSections)
+      c.hp.setSections(this.hpSections)
+      this.channels.push(c)
+    }
+  }
+
+  /**
+   * Process one block.
+   *
+   * @param {Float32Array[]} inputChannels
+   * @param {Float32Array[]} outputChannels
+   * @param {number} n
+   */
+  process(inputChannels, outputChannels, n) {
+    const nIn = inputChannels.length
+    const nOut = outputChannels.length
+    if (nIn === 0 || n === 0) {
+      for (let ch = 0; ch < nOut; ch++) outputChannels[ch].fill(0, 0, n)
+      return
+    }
+
+    this._ensureChannels(nOut)
+
+    const { softness, bias, wetDry, lowDrive, midDrive, highDrive } = this
+
+    const { low: lowBuf, high: highBuf } = this._scratch(n)
+
+    for (let ch = 0; ch < nOut; ch++) {
+      const input = inputChannels[ch < nIn ? ch : nIn - 1]
+      const out = outputChannels[ch]
+      const st = this.channels[ch]
+
+      // Band split, as in vocal_saturation.py:
+      //   low  = sosfilt(sos_lp, audio)
+      //   high = sosfilt(sos_hp, audio)
+      //   mid  = audio - low - high      (complementary — sums back exactly)
+      st.lp.process(input, lowBuf, n, 0)
+      st.hp.process(input, highBuf, n, 0)
+
+      for (let i = 0; i < n; i++) {
+        const x = input[i]
+        const low = lowBuf[i]
+        const high = highBuf[i]
+        const mid = x - low - high
+
+        const wet =
+          applyTransfer(low * lowDrive + bias, softness, bias) +
+          applyTransfer(mid * midDrive + bias, softness, bias) +
+          applyTransfer(high * highDrive + bias, softness, bias)
+
+        const dryRms = st.dryRms.process(x)
+        const wetRms = st.wetRms.process(wet)
+
+        // wet *= dry_rms / wet_rms
+        const wetMatched = wet * (dryRms / wetRms)
+        // output = audio + wet_dry * wet
+        const blended = x + wetDry * wetMatched
+        // output *= dry_rms / out_rms
+        const outRms = st.outRms.process(blended)
+        const y = blended * (dryRms / outRms)
+
+        out[i] = y > 1 ? 1 : y < -1 ? -1 : y
+      }
+    }
+  }
+
+  /**
+   * Band scratch buffers, grown on demand. Float64 so the complementary
+   * subtraction `mid = x - low - high` does not lose precision before the
+   * nonlinearity sees it. Channels are processed sequentially, so one pair
+   * serves all of them.
+   */
+  _scratch(n) {
+    if (!this._lowBuf || this._lowBuf.length < n) {
+      this._lowBuf = new Float64Array(n)
+      this._highBuf = new Float64Array(n)
+    }
+    return { low: this._lowBuf, high: this._highBuf }
+  }
+}
+
+/**
+ * One-shot offline convenience: process a whole buffer through a fresh kernel.
+ * Used by verification scripts; the app renders through an OfflineAudioContext
+ * running the worklet so preview and apply share the same code path.
+ */
+export function processVocalSatBuffer(channelData, sampleRate, params = {}) {
+  const kernel = new VocalSatKernel(sampleRate)
+  kernel.setParams(params)
+
+  const n = channelData[0].length
+  const output = channelData.map(() => new Float32Array(n))
+  const BLOCK = 128
+  for (let off = 0; off < n; off += BLOCK) {
+    const len = Math.min(BLOCK, n - off)
+    kernel.process(
+      channelData.map(c => c.subarray(off, off + len)),
+      output.map(c => c.subarray(off, off + len)),
+      len,
+    )
+  }
+  return { channelData: output }
+}
+
+// ── AudioWorklet registration (worklet scope only) ──────────────────────────
+
+if (typeof registerProcessor === 'function') {
+  class VocalSatWorkletProcessor extends AudioWorkletProcessor {
+    constructor(options) {
+      super()
+      this.kernel = new VocalSatKernel(sampleRate)
+      if (options?.processorOptions?.params) {
+        this.kernel.setParams(options.processorOptions.params)
+      }
+      this.port.onmessage = (e) => {
+        if (e.data?.type === 'params') this.kernel.setParams(e.data.params)
+      }
+    }
+
+    process(inputs, outputs) {
+      const input = inputs[0]
+      const output = outputs[0]
+      if (!output || output.length === 0) return true
+
+      const n = output[0].length
+      if (!input || input.length === 0) {
+        for (const ch of output) ch.fill(0)
+        return true
+      }
+
+      this.kernel.process(input, output, n)
+      return true
+    }
+  }
+
+  registerProcessor('vocal-sat-processor', VocalSatWorkletProcessor)
+}

--- a/src/audio/vocalSatWorkletLoader.js
+++ b/src/audio/vocalSatWorkletLoader.js
@@ -1,13 +1,13 @@
 /**
- * Load the FET Punch worklet module into an AudioContext or
- * OfflineAudioContext, once per context. See la2aWorkletLoader.js for why
+ * Load the Vocal Saturation worklet module into an AudioContext or
+ * OfflineAudioContext, once per context. See airBandWorkletLoader.js for why
  * these go through `?worker&url` rather than a raw asset URL.
  */
-import workletUrl from './fet1176Processor.js?worker&url'
+import workletUrl from './vocalSatProcessor.js?worker&url'
 
 const loadPromises = new WeakMap()
 
-export function ensureFET1176Worklet(context) {
+export function ensureVocalSatWorklet(context) {
   let promise = loadPromises.get(context)
   if (!promise) {
     promise = context.audioWorklet.addModule(workletUrl)

--- a/src/components/panels/AirBandModal.vue
+++ b/src/components/panels/AirBandModal.vue
@@ -1,0 +1,191 @@
+<script setup>
+import { computed, onMounted } from 'vue'
+import { useAirBand } from '../../composables/useAirBand.js'
+import { useEditorState } from '../../composables/useEditorState.js'
+import { airBandSections } from '../../audio/airBandProcessor.js'
+import { magnitudeResponseDb } from '../../audio/dsp/biquad.js'
+import Knob from '../knobs/Knob.vue'
+import LevelMeter from '../meters/LevelMeter.vue'
+import FloatingWindow from './FloatingWindow.vue'
+import ApplyAction from '../ui/ApplyAction.vue'
+
+defineProps({ z: { type: Number, default: 500 } })
+
+const {
+  airBandAir, airBandOutput, airBandPreview, airBandInputDb, airBandOutputDb,
+  hasSelection, togglePreview, syncAir, syncOutput, apply, teardown, closeModal,
+} = useAirBand()
+
+const { state } = useEditorState()
+
+// Default to engaged when the panel opens, matching the other plugin windows.
+onMounted(() => {
+  if (!airBandPreview.value) togglePreview()
+})
+
+const ACCENT = '#7fd4e8'
+
+// ── Response curve ──────────────────────────────────────────────────────────
+// Drawn from the same coefficient builders the kernel uses, so what is on
+// screen is the filter that is running rather than a redrawn approximation.
+const CURVE_W = 360
+const CURVE_H = 96
+const F_MIN = 100
+const F_MAX = 20000
+const DB_MAX = 14
+
+const CURVE_FREQS = Array.from({ length: 160 }, (_, i) =>
+  F_MIN * Math.pow(F_MAX / F_MIN, i / 159),
+)
+
+const GRID_FREQS = [100, 1000, 10000]
+
+function xFor(freqHz) {
+  return (Math.log2(freqHz / F_MIN) / Math.log2(F_MAX / F_MIN)) * CURVE_W
+}
+
+function yFor(db) {
+  // 0 dB sits on the baseline; the curve only ever lifts.
+  return CURVE_H - (db / DB_MAX) * CURVE_H
+}
+
+const curvePath = computed(() => {
+  // The response is sample-rate dependent, so use the file's rate where we
+  // have one and fall back to the most common rate before a file is loaded.
+  const sr = state.currentFile?.sampleRate ?? 44100
+  const sections = airBandSections(sr, airBandAir.value)
+  const db = magnitudeResponseDb(sections, CURVE_FREQS, sr)
+  return CURVE_FREQS.map(
+    (f, i) => `${i === 0 ? 'M' : 'L'}${xFor(f).toFixed(1)},${yFor(db[i]).toFixed(1)}`,
+  ).join(' ')
+})
+
+const curveFill = computed(
+  () => `${curvePath.value} L${CURVE_W},${CURVE_H} L0,${CURVE_H} Z`,
+)
+
+function formatAir(v) {
+  return `+${v.toFixed(1)}`
+}
+
+function formatOutput(v) {
+  return `${v > 0 ? '+' : ''}${v.toFixed(1)}`
+}
+
+function gridLabel(f) {
+  return f >= 1000 ? `${f / 1000}k` : String(f)
+}
+
+// Preview is transport playback — the worklet is already in the chain, so what
+// makes it live is that audio is running while you turn the knob.
+function togglePlayback() {
+  window.dispatchEvent(new CustomEvent('wavely:toggle-play'))
+}
+
+function close() {
+  teardown()
+}
+
+async function applyAndClose() {
+  await apply()
+  teardown()
+  closeModal()
+}
+</script>
+
+<template>
+  <FloatingWindow
+    window-id="air-band"
+    :z="z"
+    :width="600"
+    :accent="ACCENT"
+    brand-lead="AIR"
+    brand-tail="BAND"
+    :engaged="airBandPreview"
+    @toggle-engaged="togglePreview"
+    @close="close"
+  >
+    <div class="px-[26px] pt-[22px] pb-[26px]">
+      <div class="flex items-center justify-between gap-[22px]">
+        <LevelMeter :db="airBandInputDb" label="IN" :height="120" />
+
+        <div class="flex-1 flex flex-col items-center">
+          <!-- Response curve -->
+          <svg
+            :viewBox="`0 0 ${CURVE_W} ${CURVE_H}`"
+            class="w-full"
+            :style="{ height: `${CURVE_H}px` }"
+            preserveAspectRatio="none"
+          >
+            <line
+              v-for="f in GRID_FREQS" :key="f"
+              :x1="xFor(f)" :y1="0" :x2="xFor(f)" :y2="CURVE_H"
+              stroke="rgba(255,255,255,.07)" stroke-width="1"
+            />
+            <line
+              :x1="0" :y1="CURVE_H" :x2="CURVE_W" :y2="CURVE_H"
+              stroke="rgba(255,255,255,.14)" stroke-width="1"
+            />
+            <path :d="curveFill" :fill="ACCENT" fill-opacity="0.12" />
+            <path :d="curvePath" :stroke="ACCENT" stroke-width="2" fill="none" />
+          </svg>
+          <div class="flex w-full justify-between mt-[4px] px-[2px]">
+            <span
+              v-for="f in GRID_FREQS" :key="f"
+              style="font:600 8px 'JetBrains Mono',monospace;letter-spacing:.08em;color:rgba(255,255,255,.28)"
+            >{{ gridLabel(f) }}</span>
+          </div>
+
+          <div class="flex gap-[38px] mt-[16px]">
+            <div class="w-[128px]">
+              <Knob
+                :model-value="airBandAir"
+                @update:model-value="syncAir"
+                :min="0" :max="12" :step="0.1"
+                label="Air" :accent="ACCENT" :format-value="formatAir"
+                :disabled="!airBandPreview"
+              />
+            </div>
+            <div class="w-[92px]">
+              <Knob
+                :model-value="airBandOutput"
+                @update:model-value="syncOutput"
+                :min="-12" :max="12" :step="0.1" :value-font-px="13"
+                label="Output" :accent="ACCENT" :format-value="formatOutput"
+                :disabled="!airBandPreview"
+              />
+            </div>
+          </div>
+        </div>
+
+        <LevelMeter :db="airBandOutputDb" label="OUT" :height="120" />
+      </div>
+
+      <p
+        class="mt-[16px] text-center"
+        style="font:500 10px/1.5 'Inter';color:rgba(255,255,255,.35)"
+      >
+        Maag-style air lift — a wide shelf shaped by five overlapping bells.
+        Adds presence without the harshness of a narrow high boost.
+      </p>
+
+      <div class="mt-[16px] pt-[16px]" style="border-top:1px solid rgba(255,255,255,.06)">
+        <ApplyAction
+          size="md"
+          show-preview
+          previewable
+          :previewing="state.isPlaying"
+          :accent="ACCENT"
+          text-color="#08171c"
+          :met="hasSelection"
+          message="Make a selection to add air"
+          label="Apply Air Band"
+          :disabled="!airBandPreview"
+          disabled-hint="Turn Air Band on to apply it"
+          @toggle-preview="togglePlayback"
+          @apply="applyAndClose"
+        />
+      </div>
+    </div>
+  </FloatingWindow>
+</template>

--- a/src/components/panels/windows/VocalSaturationWindow.vue
+++ b/src/components/panels/windows/VocalSaturationWindow.vue
@@ -1,77 +1,53 @@
 <script setup>
-import { ref } from 'vue'
+import { onMounted } from 'vue'
+import { useVocalSaturation } from '../../../composables/useVocalSaturation.js'
 import { useEditorState } from '../../../composables/useEditorState.js'
-import { computePeakCache } from '../../../audio/processing.js'
-import { applyVocalSaturation } from '../../../api/spotEffects.js'
 import FloatingWindow from '../FloatingWindow.vue'
 import Knob from '../../knobs/Knob.vue'
 import DeviceSlider from '../../knobs/DeviceSlider.vue'
+import LevelMeter from '../../meters/LevelMeter.vue'
 import ApplyAction from '../../ui/ApplyAction.vue'
 
 defineProps({ z: { type: Number, default: 500 } })
 
 const {
-  state, hasSelection, getAudioContext, replaceRegion, setPeakCache,
-  startProcessing, endProcessing, showToast,
-} = useEditorState()
+  vsDrive, vsWetDry, vsBias, vsSoftness,
+  vsLowCrossover, vsMidCrossover,
+  vsLowDriveMult, vsMidDriveMult, vsHighDriveMult,
+  vsPreview, vsInputDb, vsOutputDb, hasSelection,
+  togglePreview,
+  syncDrive, syncWetDry, syncBias, syncSoftness,
+  syncLowCrossover, syncMidCrossover,
+  syncLowDriveMult, syncMidDriveMult, syncHighDriveMult,
+  apply, teardown, closeModal,
+} = useVocalSaturation()
+
+const { state } = useEditorState()
+
+// Default to engaged when the panel opens, matching the other plugin windows.
+onMounted(() => {
+  if (!vsPreview.value) togglePreview()
+})
 
 const ACCENT = '#ff8a5b'
-
-// Defaults match the server-side script defaults.
-const drive         = ref(2.0)
-const wetDry        = ref(0.3)
-const bias          = ref(0.5)
-const softness      = ref(0.3)
-const lowCrossover  = ref(500)
-const midCrossover  = ref(3500)
-const lowDriveMult  = ref(5.0)
-const midDriveMult  = ref(0.1)
-const highDriveMult = ref(0.1)
 
 const twoDp = v => v.toFixed(2)
 const percent = v => `${Math.round(v * 100)}`
 const hertz = v => `${Math.round(v)} Hz`
 const multiplier = v => `${v.toFixed(2)}×`
 
-async function applySaturation() {
-  if (!state.selection) return
-  const { start, end } = state.selection
+function togglePlayback() {
+  window.dispatchEvent(new CustomEvent('wavely:toggle-play'))
+}
 
-  startProcessing('Saturating...')
-  try {
-    const blob = await applyVocalSaturation({
-      segments:   state.segments,
-      start, end,
-      sampleRate: state.currentFile.sampleRate,
-      channels:   state.currentFile.channels,
-      params: {
-        drive:         drive.value,
-        wetDry:        wetDry.value,
-        bias:          bias.value,
-        lowCrossover:  lowCrossover.value,
-        midCrossover:  midCrossover.value,
-        softness:      softness.value,
-        lowDriveMult:  lowDriveMult.value,
-        midDriveMult:  midDriveMult.value,
-        highDriveMult: highDriveMult.value,
-      },
-    })
+function close() {
+  teardown()
+}
 
-    const ctx = getAudioContext()
-    const arrayBuffer = await blob.arrayBuffer()
-    const buffer = await ctx.decodeAudioData(arrayBuffer)
-    const bufferId = replaceRegion(start, end, buffer)
-
-    const cache = await computePeakCache(buffer, 256)
-    setPeakCache(bufferId, cache)
-
-    showToast('Vocal saturation applied')
-  } catch (err) {
-    console.error('Vocal saturation failed:', err)
-    showToast('Vocal saturation failed')
-  } finally {
-    endProcessing()
-  }
+async function applyAndClose() {
+  await apply()
+  teardown()
+  closeModal()
 }
 </script>
 
@@ -83,27 +59,43 @@ async function applySaturation() {
     :accent="ACCENT"
     brand-lead="VOCAL"
     brand-tail="SAT"
-    :show-engage="false"
+    :engaged="vsPreview"
+    @toggle-engaged="togglePreview"
+    @close="close"
   >
     <div class="px-[26px] pt-[22px] pb-[24px]">
-      <!-- The four you dial by ear get knobs. -->
-      <div class="flex items-start justify-center gap-[34px]">
-        <div class="w-[112px]">
-          <Knob v-model="drive" :min="0" :max="5" :step="0.05"
-                label="Drive" :accent="ACCENT" :format-value="twoDp" />
+      <div class="flex items-center justify-between gap-[20px]">
+        <LevelMeter :db="vsInputDb" label="IN" :height="132" />
+
+        <!-- The four you dial by ear get knobs. -->
+        <div class="flex-1 flex items-start justify-center gap-[30px]">
+          <div class="w-[104px]">
+            <Knob :model-value="vsDrive" @update:model-value="syncDrive"
+                  :min="0" :max="5" :step="0.05"
+                  label="Drive" :accent="ACCENT" :format-value="twoDp"
+                  :disabled="!vsPreview" />
+          </div>
+          <div class="w-[104px]">
+            <Knob :model-value="vsWetDry" @update:model-value="syncWetDry"
+                  :min="0" :max="1" :step="0.01"
+                  label="Wet / Dry" :accent="ACCENT" :format-value="percent"
+                  :disabled="!vsPreview" />
+          </div>
+          <div class="w-[104px]">
+            <Knob :model-value="vsBias" @update:model-value="syncBias"
+                  :min="0" :max="1.5" :step="0.01"
+                  label="Bias" :accent="ACCENT" :format-value="twoDp"
+                  :disabled="!vsPreview" />
+          </div>
+          <div class="w-[104px]">
+            <Knob :model-value="vsSoftness" @update:model-value="syncSoftness"
+                  :min="0" :max="1" :step="0.01"
+                  label="Softness" :accent="ACCENT" :format-value="twoDp"
+                  :disabled="!vsPreview" />
+          </div>
         </div>
-        <div class="w-[112px]">
-          <Knob v-model="wetDry" :min="0" :max="1" :step="0.01"
-                label="Wet / Dry" :accent="ACCENT" :format-value="percent" />
-        </div>
-        <div class="w-[112px]">
-          <Knob v-model="bias" :min="0" :max="1.5" :step="0.01"
-                label="Bias" :accent="ACCENT" :format-value="twoDp" />
-        </div>
-        <div class="w-[112px]">
-          <Knob v-model="softness" :min="0" :max="1" :step="0.01"
-                label="Softness" :accent="ACCENT" :format-value="twoDp" />
-        </div>
+
+        <LevelMeter :db="vsOutputDb" label="OUT" :height="132" />
       </div>
 
       <!-- Band shaping: wide numeric ranges you read rather than feel, so
@@ -118,16 +110,26 @@ async function applySaturation() {
         </div>
 
         <div class="grid grid-cols-2 gap-x-[30px] gap-y-[15px]">
-          <DeviceSlider v-model="lowCrossover" :min="100" :max="2000" :step="10"
-                        label="Low Crossover" :accent="ACCENT" :format-value="hertz" />
-          <DeviceSlider v-model="midCrossover" :min="1000" :max="8000" :step="50"
-                        label="Mid Crossover" :accent="ACCENT" :format-value="hertz" />
-          <DeviceSlider v-model="lowDriveMult" :min="0" :max="10" :step="0.05"
-                        label="Low Drive" :accent="ACCENT" :format-value="multiplier" />
-          <DeviceSlider v-model="midDriveMult" :min="0" :max="10" :step="0.05"
-                        label="Mid Drive" :accent="ACCENT" :format-value="multiplier" />
-          <DeviceSlider v-model="highDriveMult" :min="0" :max="10" :step="0.05"
-                        label="High Drive" :accent="ACCENT" :format-value="multiplier" />
+          <DeviceSlider :model-value="vsLowCrossover" @update:model-value="syncLowCrossover"
+                        :min="100" :max="2000" :step="10"
+                        label="Low Crossover" :accent="ACCENT" :format-value="hertz"
+                        :disabled="!vsPreview" />
+          <DeviceSlider :model-value="vsMidCrossover" @update:model-value="syncMidCrossover"
+                        :min="1000" :max="8000" :step="50"
+                        label="Mid Crossover" :accent="ACCENT" :format-value="hertz"
+                        :disabled="!vsPreview" />
+          <DeviceSlider :model-value="vsLowDriveMult" @update:model-value="syncLowDriveMult"
+                        :min="0" :max="10" :step="0.05"
+                        label="Low Drive" :accent="ACCENT" :format-value="multiplier"
+                        :disabled="!vsPreview" />
+          <DeviceSlider :model-value="vsMidDriveMult" @update:model-value="syncMidDriveMult"
+                        :min="0" :max="10" :step="0.05"
+                        label="Mid Drive" :accent="ACCENT" :format-value="multiplier"
+                        :disabled="!vsPreview" />
+          <DeviceSlider :model-value="vsHighDriveMult" @update:model-value="syncHighDriveMult"
+                        :min="0" :max="10" :step="0.05"
+                        label="High Drive" :accent="ACCENT" :format-value="multiplier"
+                        :disabled="!vsPreview" />
         </div>
       </div>
 
@@ -135,13 +137,17 @@ async function applySaturation() {
         <ApplyAction
           size="md"
           show-preview
-          :previewable="false"
+          previewable
+          :previewing="state.isPlaying"
           :accent="ACCENT"
           text-color="#2b1006"
           :met="hasSelection"
           message="Make a selection to saturate"
           label="Apply Saturation"
-          @apply="applySaturation"
+          :disabled="!vsPreview"
+          disabled-hint="Turn Vocal Sat on to apply it"
+          @toggle-preview="togglePlayback"
+          @apply="applyAndClose"
         />
       </div>
     </div>

--- a/src/composables/useAirBand.js
+++ b/src/composables/useAirBand.js
@@ -1,0 +1,157 @@
+import { ref } from 'vue'
+import { useEditorState } from './useEditorState.js'
+import { useWindows } from './useWindows.js'
+import { applyAirBandRegion, computePeakCache } from '../audio/processing.js'
+import { getEffectChain } from '../audio/effectChain.js'
+import { airBandEffect, AIR_BAND_DEFAULTS } from '../audio/effects/airBand.js'
+
+// Registry id of this plugin's window. Must match the entry in src/ui/registry.js.
+export const AIR_BAND_WINDOW_ID = 'air-band'
+
+// Singleton reactive state shared between the sidebar trigger and the modal.
+const airBandAir = ref(AIR_BAND_DEFAULTS.air)
+const airBandOutput = ref(AIR_BAND_DEFAULTS.output)
+const airBandPreview = ref(false)
+const airBandInputDb = ref(-Infinity)
+const airBandOutputDb = ref(-Infinity)
+let meterId = null
+
+function currentParams() {
+  return {
+    air: airBandAir.value,
+    output: airBandOutput.value,
+  }
+}
+
+export function useAirBand() {
+  const {
+    state, getAudioContext, hasSelection, replaceRegion, setPeakCache,
+    startProcessing, endProcessing, showToast,
+  } = useEditorState()
+  const { openWindow, closeWindow } = useWindows()
+
+  function initChain() {
+    const ctx = getAudioContext()
+    const chain = getEffectChain(ctx)
+    if (!chain.effects.find(e => e.id === airBandEffect.id)) {
+      chain.addEffect(airBandEffect)
+    }
+    return chain
+  }
+
+  function startMeters(chain) {
+    stopMeters()
+    function tick() {
+      const nodes = chain.effects.find(e => e.id === airBandEffect.id)?.nodes
+      if (nodes) {
+        airBandInputDb.value = nodes.getInputLevelDb()
+        airBandOutputDb.value = nodes.getOutputLevelDb()
+      }
+      meterId = requestAnimationFrame(tick)
+    }
+    meterId = requestAnimationFrame(tick)
+  }
+
+  function stopMeters() {
+    if (meterId !== null) {
+      cancelAnimationFrame(meterId)
+      meterId = null
+    }
+    airBandInputDb.value = -Infinity
+    airBandOutputDb.value = -Infinity
+  }
+
+  function pushAllParams(chain) {
+    for (const [name, value] of Object.entries(currentParams())) {
+      chain.updateParam(airBandEffect.id, name, value)
+    }
+  }
+
+  function togglePreview() {
+    const chain = initChain()
+    airBandPreview.value = !airBandPreview.value
+    chain.setEnabled(airBandEffect.id, airBandPreview.value)
+
+    if (airBandPreview.value) {
+      pushAllParams(chain)
+      startMeters(chain)
+    } else {
+      stopMeters()
+    }
+  }
+
+  function pushParam(name, value) {
+    if (!airBandPreview.value) return
+    const chain = getEffectChain(getAudioContext())
+    chain.updateParam(airBandEffect.id, name, value)
+  }
+
+  function syncAir(v) {
+    airBandAir.value = v
+    pushParam('air', v)
+  }
+
+  function syncOutput(v) {
+    airBandOutput.value = v
+    pushParam('output', v)
+  }
+
+  async function apply() {
+    if (!state.selection) return
+    const { start, end } = state.selection
+
+    const wasPreviewing = airBandPreview.value
+    if (wasPreviewing) togglePreview()
+
+    startProcessing('Applying Air Band...')
+    try {
+      const buffer = await applyAirBandRegion(
+        state.segments, start, end,
+        currentParams(),
+        state.currentFile.sampleRate, state.currentFile.channels,
+      )
+      const bufferId = replaceRegion(start, end, buffer)
+      const cache = await computePeakCache(buffer, 256)
+      setPeakCache(bufferId, cache)
+      showToast('Air Band applied')
+    } catch (err) {
+      console.error('Air Band failed:', err)
+      showToast('Air Band failed')
+    } finally {
+      endProcessing()
+    }
+  }
+
+  function teardown() {
+    stopMeters()
+    if (airBandPreview.value) {
+      const chain = getEffectChain(getAudioContext())
+      chain.setEnabled(airBandEffect.id, false)
+      airBandPreview.value = false
+    }
+  }
+
+  function openModal() {
+    openWindow(AIR_BAND_WINDOW_ID)
+  }
+
+  function closeModal() {
+    closeWindow(AIR_BAND_WINDOW_ID)
+  }
+
+  return {
+    airBandAir,
+    airBandOutput,
+    airBandPreview,
+    airBandInputDb,
+    airBandOutputDb,
+    hasSelection,
+    togglePreview,
+    syncAir,
+    syncOutput,
+    apply,
+    teardown,
+    openModal,
+    closeModal,
+  }
+}

--- a/src/composables/useVocalSaturation.js
+++ b/src/composables/useVocalSaturation.js
@@ -1,0 +1,191 @@
+import { ref } from 'vue'
+import { useEditorState } from './useEditorState.js'
+import { useWindows } from './useWindows.js'
+import { applyVocalSatRegion, computePeakCache } from '../audio/processing.js'
+import { getEffectChain } from '../audio/effectChain.js'
+import { vocalSatEffect, VOCAL_SAT_DEFAULTS } from '../audio/effects/vocalSat.js'
+
+// Registry id of this plugin's window. Must match the entry in src/ui/registry.js.
+export const VOCAL_SAT_WINDOW_ID = 'vocal-saturation'
+
+// Singleton reactive state shared between the sidebar trigger and the modal.
+const vsDrive = ref(VOCAL_SAT_DEFAULTS.drive)
+const vsWetDry = ref(VOCAL_SAT_DEFAULTS.wetDry)
+const vsBias = ref(VOCAL_SAT_DEFAULTS.bias)
+const vsSoftness = ref(VOCAL_SAT_DEFAULTS.softness)
+const vsLowCrossover = ref(VOCAL_SAT_DEFAULTS.lowCrossover)
+const vsMidCrossover = ref(VOCAL_SAT_DEFAULTS.midCrossover)
+const vsLowDriveMult = ref(VOCAL_SAT_DEFAULTS.lowDriveMult)
+const vsMidDriveMult = ref(VOCAL_SAT_DEFAULTS.midDriveMult)
+const vsHighDriveMult = ref(VOCAL_SAT_DEFAULTS.highDriveMult)
+
+const vsPreview = ref(false)
+const vsInputDb = ref(-Infinity)
+const vsOutputDb = ref(-Infinity)
+let meterId = null
+
+function currentParams() {
+  return {
+    drive: vsDrive.value,
+    wetDry: vsWetDry.value,
+    bias: vsBias.value,
+    softness: vsSoftness.value,
+    lowCrossover: vsLowCrossover.value,
+    midCrossover: vsMidCrossover.value,
+    lowDriveMult: vsLowDriveMult.value,
+    midDriveMult: vsMidDriveMult.value,
+    highDriveMult: vsHighDriveMult.value,
+  }
+}
+
+export function useVocalSaturation() {
+  const {
+    state, getAudioContext, hasSelection, replaceRegion, setPeakCache,
+    startProcessing, endProcessing, showToast,
+  } = useEditorState()
+  const { openWindow, closeWindow } = useWindows()
+
+  function initChain() {
+    const ctx = getAudioContext()
+    const chain = getEffectChain(ctx)
+    if (!chain.effects.find(e => e.id === vocalSatEffect.id)) {
+      chain.addEffect(vocalSatEffect)
+    }
+    return chain
+  }
+
+  function startMeters(chain) {
+    stopMeters()
+    function tick() {
+      const nodes = chain.effects.find(e => e.id === vocalSatEffect.id)?.nodes
+      if (nodes) {
+        vsInputDb.value = nodes.getInputLevelDb()
+        vsOutputDb.value = nodes.getOutputLevelDb()
+      }
+      meterId = requestAnimationFrame(tick)
+    }
+    meterId = requestAnimationFrame(tick)
+  }
+
+  function stopMeters() {
+    if (meterId !== null) {
+      cancelAnimationFrame(meterId)
+      meterId = null
+    }
+    vsInputDb.value = -Infinity
+    vsOutputDb.value = -Infinity
+  }
+
+  function pushAllParams(chain) {
+    for (const [name, value] of Object.entries(currentParams())) {
+      chain.updateParam(vocalSatEffect.id, name, value)
+    }
+  }
+
+  function togglePreview() {
+    const chain = initChain()
+    vsPreview.value = !vsPreview.value
+    chain.setEnabled(vocalSatEffect.id, vsPreview.value)
+
+    if (vsPreview.value) {
+      pushAllParams(chain)
+      startMeters(chain)
+    } else {
+      stopMeters()
+    }
+  }
+
+  function pushParam(name, value) {
+    if (!vsPreview.value) return
+    const chain = getEffectChain(getAudioContext())
+    chain.updateParam(vocalSatEffect.id, name, value)
+  }
+
+  function syncParam(name, refVar, value) {
+    refVar.value = value
+    pushParam(name, value)
+  }
+
+  const syncDrive = v => syncParam('drive', vsDrive, v)
+  const syncWetDry = v => syncParam('wetDry', vsWetDry, v)
+  const syncBias = v => syncParam('bias', vsBias, v)
+  const syncSoftness = v => syncParam('softness', vsSoftness, v)
+  const syncLowCrossover = v => syncParam('lowCrossover', vsLowCrossover, v)
+  const syncMidCrossover = v => syncParam('midCrossover', vsMidCrossover, v)
+  const syncLowDriveMult = v => syncParam('lowDriveMult', vsLowDriveMult, v)
+  const syncMidDriveMult = v => syncParam('midDriveMult', vsMidDriveMult, v)
+  const syncHighDriveMult = v => syncParam('highDriveMult', vsHighDriveMult, v)
+
+  async function apply() {
+    if (!state.selection) return
+    const { start, end } = state.selection
+
+    const wasPreviewing = vsPreview.value
+    if (wasPreviewing) togglePreview()
+
+    startProcessing('Saturating...')
+    try {
+      const buffer = await applyVocalSatRegion(
+        state.segments, start, end,
+        currentParams(),
+        state.currentFile.sampleRate, state.currentFile.channels,
+      )
+      const bufferId = replaceRegion(start, end, buffer)
+      const cache = await computePeakCache(buffer, 256)
+      setPeakCache(bufferId, cache)
+      showToast('Vocal saturation applied')
+    } catch (err) {
+      console.error('Vocal saturation failed:', err)
+      showToast('Vocal saturation failed')
+    } finally {
+      endProcessing()
+    }
+  }
+
+  function teardown() {
+    stopMeters()
+    if (vsPreview.value) {
+      const chain = getEffectChain(getAudioContext())
+      chain.setEnabled(vocalSatEffect.id, false)
+      vsPreview.value = false
+    }
+  }
+
+  function openModal() {
+    openWindow(VOCAL_SAT_WINDOW_ID)
+  }
+
+  function closeModal() {
+    closeWindow(VOCAL_SAT_WINDOW_ID)
+  }
+
+  return {
+    vsDrive,
+    vsWetDry,
+    vsBias,
+    vsSoftness,
+    vsLowCrossover,
+    vsMidCrossover,
+    vsLowDriveMult,
+    vsMidDriveMult,
+    vsHighDriveMult,
+    vsPreview,
+    vsInputDb,
+    vsOutputDb,
+    hasSelection,
+    togglePreview,
+    syncDrive,
+    syncWetDry,
+    syncBias,
+    syncSoftness,
+    syncLowCrossover,
+    syncMidCrossover,
+    syncLowDriveMult,
+    syncMidDriveMult,
+    syncHighDriveMult,
+    apply,
+    teardown,
+    openModal,
+    closeModal,
+  }
+}

--- a/src/ui/icons.js
+++ b/src/ui/icons.js
@@ -41,6 +41,8 @@ export const ICONS = {
   opto: '<circle cx="12" cy="12" r="10"/><path d="M12 6v6l4 2"/>',
   fet: '<polyline points="13 2 4 14 11 14 10 22 20 10 13 10 13 2"/>',
   saturation: '<path d="M3 12c3 0 3-6 6-6s3 12 6 12 3-6 6-6"/>',
+  // A rising shelf: flat, then a gentle knee up to a plateau — the air curve.
+  air: '<path d="M2 17c5 0 8 0 11-5s5-5 9-5"/><path d="M2 21h20" opacity=".35"/>',
   noise: '<path d="M12 2a3 3 0 013 3v7a3 3 0 01-6 0V5a3 3 0 013-3z"/><path d="M19 10v2a7 7 0 01-14 0v-2M12 19v3M8 23h8"/>',
   // Waveform, flat stretch, waveform — the gap being targeted. Was a second
   // copy of the `cut` scissors, which is the clipboard verb's glyph.

--- a/src/ui/registry.js
+++ b/src/ui/registry.js
@@ -7,6 +7,7 @@ import PresetsPanel from '../components/panels/PresetsPanel.vue'
 
 import LA2AModal from '../components/panels/LA2AModal.vue'
 import FET1176Modal from '../components/panels/FET1176Modal.vue'
+import AirBandModal from '../components/panels/AirBandModal.vue'
 import NormalizeWindow from '../components/panels/windows/NormalizeWindow.vue'
 import VocalSaturationWindow from '../components/panels/windows/VocalSaturationWindow.vue'
 import NoiseReductionWindow from '../components/panels/windows/NoiseReductionWindow.vue'
@@ -250,6 +251,18 @@ export const OPERATIONS = [
     requires: 'selection',
     surface: 'window',
     component: VocalSaturationWindow,
+  },
+  {
+    id: 'air-band',
+    label: 'Air Band',
+    desc: 'High-shelf presence lift',
+    category: 'effects',
+    group: 'Tone',
+    icon: 'air',
+    keywords: ['air', 'maag', 'shelf', 'high', 'presence', 'sheen', 'treble', 'eq'],
+    requires: 'selection',
+    surface: 'window',
+    component: AirBandModal,
   },
   {
     id: 'noise-reduction',

--- a/test/dsp/airBand.test.js
+++ b/test/dsp/airBand.test.js
@@ -1,0 +1,143 @@
+/**
+ * Run with:  npm test
+ */
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  AirBandKernel,
+  airBandSections,
+  processAirBandBuffer,
+} from '../../src/audio/airBandProcessor.js'
+import { magnitudeResponseDb } from '../../src/audio/dsp/biquad.js'
+import { getFFT, rfftBinCount } from '../../src/audio/dsp/fft.js'
+
+const SR = 44100
+const N = 32768
+
+/** True frequency response of the kernel, measured from its impulse response. */
+function measuredResponseDb(params, freqs) {
+  const amp = 0.25
+  const imp = new Float32Array(N)
+  imp[0] = amp
+  const { channelData } = processAirBandBuffer([imp], SR, params)
+
+  const fft = getFFT(N)
+  const bins = rfftBinCount(N)
+  const re = new Float64Array(bins)
+  const im = new Float64Array(bins)
+  fft.rfft(channelData[0], re, im)
+
+  return freqs.map(f => {
+    const k = Math.round((f * N) / SR)
+    return 20 * Math.log10(Math.hypot(re[k], im[k]) / amp)
+  })
+}
+
+const PROBE = [100, 300, 600, 1200, 2400, 4800, 9600, 14000, 18000]
+
+test('kernel response matches the curve the UI draws', () => {
+  // AirBandModal renders magnitudeResponseDb(airBandSections(...)). If these
+  // disagree the display is lying about what is being applied.
+  for (const gainDb of [3, 6, 12]) {
+    const analytic = magnitudeResponseDb(airBandSections(SR, gainDb), PROBE, SR)
+    const measured = measuredResponseDb({ gainDb }, PROBE)
+    for (let i = 0; i < PROBE.length; i++) {
+      assert.ok(
+        Math.abs(analytic[i] - measured[i]) < 0.02,
+        `gain ${gainDb} at ${PROBE[i]} Hz: curve ${analytic[i].toFixed(4)}, kernel ${measured[i].toFixed(4)}`,
+      )
+    }
+  }
+})
+
+test('gain scales linearly from the reference plateau', () => {
+  // 6 dB is half of 12 dB in per-band gain terms, so the shelf plateau should
+  // land near half as much lift.
+  const at6 = measuredResponseDb({ gainDb: 6 }, [18000])[0]
+  const at12 = measuredResponseDb({ gainDb: 12 }, [18000])[0]
+  assert.ok(at6 > 4 && at6 < 7, `6 dB setting lifted ${at6.toFixed(2)} dB at 18 kHz`)
+  assert.ok(
+    Math.abs(at12 / at6 - 2) < 0.06,
+    `expected roughly double, got ${at12.toFixed(2)} vs ${at6.toFixed(2)}`,
+  )
+})
+
+test('is transparent at zero air', () => {
+  const n = 4096
+  const sig = new Float32Array(n)
+  for (let i = 0; i < n; i++) sig[i] = 0.4 * Math.sin(i / 6) + 0.2 * Math.sin(i / 1.7)
+  const { channelData } = processAirBandBuffer([sig], SR, { gainDb: 0 })
+  let maxErr = 0
+  for (let i = 0; i < n; i++) maxErr = Math.max(maxErr, Math.abs(channelData[0][i] - sig[i]))
+  assert.ok(maxErr < 1e-6, `not transparent at 0 dB: max error ${maxErr}`)
+})
+
+test('leaves the low end alone at operating gain', () => {
+  // The whole point of the Maag shape: presence without touching body. At the
+  // preset gain of 6 dB, sub-300 Hz must stay effectively untouched or the
+  // stage would raise the noise floor it is meant to leave alone.
+  const lf = measuredResponseDb({ gainDb: 6 }, [50, 100, 200, 300])
+  for (const v of lf) assert.ok(Math.abs(v) < 0.03, `LF moved by ${v.toFixed(4)} dB`)
+})
+
+test('output trim is a clean gain', () => {
+  const n = 2048
+  const sig = new Float32Array(n)
+  for (let i = 0; i < n; i++) sig[i] = 0.3 * Math.sin(i / 9)
+  const flat = processAirBandBuffer([sig], SR, { gainDb: 4, outputGainDb: 0 }).channelData[0]
+  const trimmed = processAirBandBuffer([sig], SR, { gainDb: 4, outputGainDb: -6 }).channelData[0]
+  const expected = Math.pow(10, -6 / 20)
+  for (let i = 512; i < n; i++) {
+    assert.ok(
+      Math.abs(trimmed[i] - flat[i] * expected) < 1e-6,
+      `trim mismatch at ${i}`,
+    )
+  }
+})
+
+test('channels are filtered independently', () => {
+  const n = 512
+  const impulse = new Float32Array(n)
+  impulse[0] = 1
+  const silence = new Float32Array(n)
+  const { channelData } = processAirBandBuffer([impulse, silence], SR, { gainDb: 8 })
+  let energy = 0
+  for (let i = 0; i < n; i++) energy += Math.abs(channelData[1][i])
+  assert.equal(energy, 0, 'silent channel picked up the other channel’s impulse')
+  assert.ok(channelData[0][0] !== 0, 'signal channel produced nothing')
+})
+
+test('block size does not change the result', () => {
+  const n = 5000
+  const sig = new Float32Array(n)
+  for (let i = 0; i < n; i++) sig[i] = Math.sin(i / 11) * 0.3
+
+  const oneShot = processAirBandBuffer([sig], SR, { gainDb: 6 }).channelData[0]
+
+  const kernel = new AirBandKernel(SR)
+  kernel.setParams({ gainDb: 6 })
+  const chunked = new Float32Array(n)
+  let off = 0
+  for (const size of [1, 7, 128, 999, 333]) {
+    while (off < n) {
+      const len = Math.min(size, n - off)
+      kernel.process(
+        [sig.subarray(off, off + len)],
+        [chunked.subarray(off, off + len)],
+        len,
+      )
+      off += len
+      if (len === size) break
+    }
+  }
+  // Finish whatever remains in 128-sample blocks.
+  while (off < n) {
+    const len = Math.min(128, n - off)
+    kernel.process([sig.subarray(off, off + len)], [chunked.subarray(off, off + len)], len)
+    off += len
+  }
+
+  let maxErr = 0
+  for (let i = 0; i < n; i++) maxErr = Math.max(maxErr, Math.abs(oneShot[i] - chunked[i]))
+  assert.ok(maxErr < 1e-6, `block-size dependence: max error ${maxErr}`)
+})

--- a/test/dsp/biquad.test.js
+++ b/test/dsp/biquad.test.js
@@ -234,6 +234,36 @@ test('cascade keeps per-channel state independent', () => {
   }
 })
 
+test('ensureChannels widens without disturbing existing channels', () => {
+  const c = lowpass(SR, 500, 0.7)
+  const wide = new BiquadCascade(1, 2)
+  wide.setSections([c])
+  const narrow = new BiquadCascade(1, 1)
+  narrow.setSections([c])
+
+  const n = 128
+  const sig = new Float64Array(n)
+  for (let i = 0; i < n; i++) sig[i] = Math.sin(i / 5)
+
+  // Run half the signal through both, then widen the narrow one mid-stream.
+  const half = n >> 1
+  const a = new Float64Array(n)
+  const b = new Float64Array(n)
+  wide.process(sig, a, half, 0)
+  narrow.process(sig, b, half, 0)
+  narrow.ensureChannels(4)
+  assert.equal(narrow.channelCount, 4)
+  wide.process(sig.subarray(half), a.subarray(half), half, 0)
+  narrow.process(sig.subarray(half), b.subarray(half), half, 0)
+
+  for (let i = 0; i < n; i++) {
+    assert.ok(Math.abs(a[i] - b[i]) < 1e-15, `state lost on widen at ${i}`)
+  }
+  // Narrowing is a no-op rather than a truncation.
+  narrow.ensureChannels(2)
+  assert.equal(narrow.channelCount, 4)
+})
+
 test('reset clears state', () => {
   const cascade = new BiquadCascade(1, 1)
   cascade.setSections([lowpass(SR, 500, 0.7)])

--- a/test/dsp/biquad.test.js
+++ b/test/dsp/biquad.test.js
@@ -1,0 +1,249 @@
+/**
+ * Run with:  npm test
+ */
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  peaking,
+  highShelf,
+  lowShelf,
+  lowpass,
+  highpass,
+  notch,
+  octavesToQ,
+  qToOctaves,
+  butterworthQs,
+  BiquadCascade,
+  magnitudeResponseDb,
+} from '../../src/audio/dsp/biquad.js'
+
+const SR = 44100
+
+/**
+ * Measure a cascade's actual gain at a frequency by running a sine through it
+ * and reading the steady-state amplitude. Keeps magnitudeResponseDb honest —
+ * an analytic response that disagrees with the filter it describes is worse
+ * than no response at all, since it drives the EQ curve display.
+ */
+function measuredGainDb(sections, freqHz, sampleRate = SR) {
+  const n = Math.max(8192, Math.ceil((sampleRate / freqHz) * 200))
+  const cascade = new BiquadCascade(sections.length, 1)
+  cascade.setSections(sections)
+  const input = new Float64Array(n)
+  for (let i = 0; i < n; i++) input[i] = Math.sin((2 * Math.PI * freqHz * i) / sampleRate)
+  const output = new Float64Array(n)
+  cascade.process(input, output, n, 0)
+  // Ignore the first half as settling time; take the peak of the tail.
+  let peak = 0
+  for (let i = n >> 1; i < n; i++) peak = Math.max(peak, Math.abs(output[i]))
+  return 20 * Math.log10(peak)
+}
+
+test('octavesToQ round-trips with qToOctaves', () => {
+  for (const oct of [0.25, 0.5, 1, 2, 3.023]) {
+    assert.ok(Math.abs(qToOctaves(octavesToQ(oct)) - oct) < 1e-12)
+  }
+})
+
+test('peaking filter hits its nominal gain at centre frequency', () => {
+  for (const gainDb of [-12, -6, -3, 3, 6, 12]) {
+    const c = peaking(SR, 1000, 1.0, gainDb)
+    const measured = measuredGainDb([c], 1000)
+    assert.ok(
+      Math.abs(measured - gainDb) < 0.05,
+      `peaking ${gainDb} dB measured ${measured.toFixed(3)}`,
+    )
+  }
+})
+
+test('peaking filter is unity far from centre', () => {
+  const c = peaking(SR, 1000, 4.0, 12)
+  assert.ok(Math.abs(measuredGainDb([c], 60)) < 0.2)
+  assert.ok(Math.abs(measuredGainDb([c], 15000)) < 0.2)
+})
+
+test('magnitudeResponseDb agrees with the filter it describes', () => {
+  const sections = [
+    peaking(SR, 300, 1.4, -4),
+    peaking(SR, 3000, 0.8, 5),
+    highShelf(SR, 8000, 0.7, 3),
+  ]
+  const freqs = [100, 300, 800, 1500, 3000, 6000, 8000, 12000]
+  const analytic = magnitudeResponseDb(sections, freqs, SR)
+  for (let i = 0; i < freqs.length; i++) {
+    const measured = measuredGainDb(sections, freqs[i])
+    assert.ok(
+      Math.abs(analytic[i] - measured) < 0.05,
+      `at ${freqs[i]} Hz: analytic ${analytic[i].toFixed(3)} vs measured ${measured.toFixed(3)}`,
+    )
+  }
+})
+
+test('shelves reach their nominal gain in the passband', () => {
+  const hs = highShelf(SR, 4000, 0.7, 6)
+  assert.ok(Math.abs(measuredGainDb([hs], 18000) - 6) < 0.3)
+  assert.ok(Math.abs(measuredGainDb([hs], 200)) < 0.3)
+
+  const ls = lowShelf(SR, 200, 0.7, -6)
+  assert.ok(Math.abs(measuredGainDb([ls], 40) + 6) < 0.3)
+  assert.ok(Math.abs(measuredGainDb([ls], 8000)) < 0.3)
+})
+
+test('octave width behaves monotonically and differs from slope=1', () => {
+  // The whole reason shelves are hand-rolled: Web Audio hard-codes S=1, while
+  // the Maag air band is declared at 3.023 octaves. If those produced the same
+  // curve there would be no reason to write this code.
+  const wide = highShelf(SR, 14000, 3.023, 6, 'octaves')
+  const s1 = highShelf(SR, 14000, 1.0, 6, 'slope')
+  const probe = 6000
+  const wideDb = measuredGainDb([wide], probe)
+  const s1Db = measuredGainDb([s1], probe)
+  assert.ok(
+    Math.abs(wideDb - s1Db) > 1.0,
+    `expected a materially different curve, got ${wideDb.toFixed(2)} vs ${s1Db.toFixed(2)} dB`,
+  )
+  // Wider shelf reaches further down in frequency.
+  assert.ok(wideDb > s1Db, 'the 3-octave shelf should lift 6 kHz more than S=1 does')
+})
+
+test('lowpass/highpass are -3 dB at cutoff with Butterworth Q', () => {
+  const lp = lowpass(SR, 1000, Math.SQRT1_2)
+  assert.ok(Math.abs(measuredGainDb([lp], 1000) + 3.0103) < 0.05)
+  const hp = highpass(SR, 1000, Math.SQRT1_2)
+  assert.ok(Math.abs(measuredGainDb([hp], 1000) + 3.0103) < 0.05)
+})
+
+test('notch deeply attenuates its centre only', () => {
+  const c = notch(SR, 120, 30)
+  assert.ok(measuredGainDb([c], 120) < -20, 'notch should cut hard at centre')
+  assert.ok(Math.abs(measuredGainDb([c], 60)) < 0.5, 'and leave an octave away alone')
+  assert.ok(Math.abs(measuredGainDb([c], 240)) < 0.5)
+})
+
+test('butterworthQs gives a maximally flat 4th-order response', () => {
+  const qs = butterworthQs(4)
+  assert.equal(qs.length, 2)
+  const sections = qs.map(q => lowpass(SR, 1000, q))
+  // Flat in the passband...
+  assert.ok(Math.abs(measuredGainDb(sections, 100)) < 0.05)
+  assert.ok(Math.abs(measuredGainDb(sections, 300)) < 0.05)
+  // ...-3 dB at cutoff...
+  assert.ok(Math.abs(measuredGainDb(sections, 1000) + 3.0103) < 0.1)
+  // ...and rolling off at 24 dB/octave (measured an octave into the stopband).
+  const oneOct = measuredGainDb(sections, 2000)
+  const twoOct = measuredGainDb(sections, 4000)
+  assert.ok(
+    Math.abs(twoOct - oneOct + 24) < 1.5,
+    `expected ~24 dB/oct, got ${(oneOct - twoOct).toFixed(2)} dB`,
+  )
+})
+
+test('air band matches FFmpeg af_biquads', () => {
+  // The Maag air-band constants in server/pipeline/airBoost.js were fitted
+  // against FFmpeg's realisation (fit_airboost_bands.py), so they only transfer
+  // if our coefficients reproduce FFmpeg's. Golden values are FFmpeg's measured
+  // impulse response for the full 6-band chain at gainDb=6; verified over
+  // gainDb 3/6/12 with a worst deviation of 1.0e-3 dB, which is FFmpeg's f32
+  // impulse-response quantisation rather than a coefficient difference.
+  const REFERENCE_PLATEAU_DB = 12.5932
+  const BANDS = [
+    { freqHz: 600, type: 'bell', q: 0.5, gRef: -0.02733 },
+    { freqHz: 1200, type: 'bell', q: 0.5, gRef: -0.30754 },
+    { freqHz: 2400, type: 'bell', q: 0.5, gRef: -1.18676 },
+    { freqHz: 4800, type: 'bell', q: 0.5, gRef: -0.90883 },
+    { freqHz: 9600, type: 'bell', q: 0.5, gRef: +0.91883 },
+    { freqHz: 14000, type: 'shelf', wOct: 3.023, gRef: +22.54678 },
+  ]
+  const scale = 6 / REFERENCE_PLATEAU_DB
+  const sections = BANDS.map(b =>
+    b.type === 'bell'
+      ? peaking(SR, b.freqHz, b.q, b.gRef * scale, 'q')
+      : highShelf(SR, b.freqHz, b.wOct, b.gRef * scale, 'octaves'),
+  )
+
+  const golden = [
+    [200, 0.00771], [600, 0.12904], [1200, 0.64985], [2400, 2.03291],
+    [4800, 3.86623], [9600, 5.28343], [14000, 5.55684], [18000, 5.69645],
+  ]
+  const freqs = golden.map(g => g[0])
+  const ours = magnitudeResponseDb(sections, freqs, SR)
+  for (let i = 0; i < golden.length; i++) {
+    assert.ok(
+      Math.abs(ours[i] - golden[i][1]) < 2e-3,
+      `at ${golden[i][0]} Hz: ffmpeg ${golden[i][1]}, ours ${ours[i].toFixed(5)}`,
+    )
+  }
+
+  // Low-frequency lift. NOTE: the comment at server/pipeline/airBoost.js:76
+  // states "Low-frequency lift below 300 Hz is < 0.04 dB at reference plateau".
+  // That is inaccurate — FFmpeg measures 0.08835 dB at 300 Hz at the plateau,
+  // matching us to 8e-5 dB. The < 0.04 dB claim holds only below ~210 Hz.
+  // Pinned here to the values FFmpeg actually produces.
+  const atPlateau = magnitudeResponseDb(
+    BANDS.map(b =>
+      b.type === 'bell'
+        ? peaking(SR, b.freqHz, b.q, b.gRef, 'q')
+        : highShelf(SR, b.freqHz, b.wOct, b.gRef, 'octaves'),
+    ),
+    [50, 100, 200, 300],
+    SR,
+  )
+  const plateauGolden = [0.00211, 0.0086, 0.0369, 0.08835]
+  for (let i = 0; i < plateauGolden.length; i++) {
+    assert.ok(
+      Math.abs(atPlateau[i] - plateauGolden[i]) < 1e-3,
+      `plateau LF at index ${i}: expected ~${plateauGolden[i]}, got ${atPlateau[i].toFixed(5)}`,
+    )
+  }
+
+  // What actually matters in practice: at the gainDb=6 the presets use, the
+  // sub-300 Hz lift really is negligible, which is what keeps it ACX-safe.
+  const atOperating = magnitudeResponseDb(sections, [50, 100, 200, 300], SR)
+  for (const v of atOperating) {
+    assert.ok(v < 0.025, `operating-gain LF lift ${v.toFixed(4)} dB is higher than expected`)
+  }
+})
+
+test('isolated octave-width shelf matches FFmpeg', () => {
+  // The octave→alpha conversion is the part most likely to diverge, so it is
+  // pinned on its own. Golden values from FFmpeg
+  // `highshelf=f=14000:width_type=o:w=3.023:g=6`.
+  const c = highShelf(SR, 14000, 3.023, 6, 'octaves')
+  const measured = magnitudeResponseDb([c], [6000], SR)[0]
+  assert.ok(Math.abs(measured - 2.67) < 5e-3, `at 6 kHz got ${measured.toFixed(4)}`)
+})
+
+test('cascade keeps per-channel state independent', () => {
+  const c = lowpass(SR, 500, 0.7)
+  const cascade = new BiquadCascade(1, 2)
+  cascade.setSections([c])
+
+  const n = 64
+  const impulse = new Float64Array(n)
+  impulse[0] = 1
+  const silence = new Float64Array(n)
+
+  const outL = new Float64Array(n)
+  const outR = new Float64Array(n)
+  cascade.process(impulse, outL, n, 0)
+  cascade.process(silence, outR, n, 1)
+
+  assert.ok(outL[0] > 0, 'left channel should respond to its impulse')
+  for (let i = 0; i < n; i++) {
+    assert.equal(outR[i], 0, `right channel leaked at ${i}: ${outR[i]}`)
+  }
+})
+
+test('reset clears state', () => {
+  const cascade = new BiquadCascade(1, 1)
+  cascade.setSections([lowpass(SR, 500, 0.7)])
+  const n = 32
+  const impulse = new Float64Array(n)
+  impulse[0] = 1
+  const a = new Float64Array(n)
+  cascade.process(impulse, a, n, 0)
+  cascade.reset()
+  const b = new Float64Array(n)
+  cascade.process(impulse, b, n, 0)
+  for (let i = 0; i < n; i++) assert.ok(Math.abs(a[i] - b[i]) < 1e-15)
+})

--- a/test/dsp/envelope.test.js
+++ b/test/dsp/envelope.test.js
@@ -1,0 +1,103 @@
+/**
+ * Run with:  npm test
+ */
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  decayCoeff,
+  riseCoeff,
+  RmsFollower,
+  AttackReleaseFollower,
+  linToDb,
+  dbToLin,
+} from '../../src/audio/dsp/envelope.js'
+
+const SR = 44100
+
+test('decayCoeff matches the Python _time_to_coeff', () => {
+  // resonance_suppressor.py: np.exp(-frame_period_ms / time_ms)
+  const framePeriodMs = (512 / 44100) * 1000
+  for (const tau of [15, 80, 250]) {
+    const expected = Math.exp(-framePeriodMs / tau)
+    assert.ok(Math.abs(decayCoeff(tau, framePeriodMs) - expected) < 1e-15)
+  }
+  assert.equal(decayCoeff(0, 10), 0)
+  assert.equal(decayCoeff(10, 0), 0)
+})
+
+test('riseCoeff matches the compressor kernels', () => {
+  // la2aProcessor.js: 1 - Math.exp(-1 / (sr * seconds))
+  for (const tauMs of [10, 35, 150]) {
+    const expected = 1 - Math.exp(-1 / (SR * (tauMs / 1000)))
+    assert.ok(Math.abs(riseCoeff(tauMs, SR) - expected) < 1e-15)
+  }
+})
+
+test('the two conventions are complements at the same period', () => {
+  const periodMs = 1000 / SR
+  const tau = 50
+  assert.ok(Math.abs(riseCoeff(tau, SR) - (1 - decayCoeff(tau, periodMs))) < 1e-12)
+})
+
+test('RmsFollower converges to the true RMS of a sine', () => {
+  const f = new RmsFollower(SR, 50)
+  const amp = 0.5
+  const n = SR // one second, far beyond a 50 ms time constant
+  for (let i = 0; i < n; i++) f.process(amp * Math.sin((2 * Math.PI * 440 * i) / SR))
+  const expected = amp / Math.SQRT2
+  assert.ok(
+    Math.abs(f.value - expected) < 0.01,
+    `expected ~${expected.toFixed(4)}, got ${f.value.toFixed(4)}`,
+  )
+})
+
+test('RmsFollower never returns zero, so it is safe as a divisor', () => {
+  // This is the whole reason the floor exists: vocal_saturation.py divides by
+  // wet_rms and out_rms, and a streaming follower will see true silence.
+  const f = new RmsFollower(SR, 50, 1e-6)
+  for (let i = 0; i < SR; i++) f.process(0)
+  assert.ok(f.value >= 1e-6, `floor breached: ${f.value}`)
+  assert.ok(Number.isFinite(1 / f.value))
+  assert.ok(Number.isFinite(f.db))
+})
+
+test('processBlock matches per-sample processing', () => {
+  const n = 1024
+  const sig = new Float64Array(n)
+  for (let i = 0; i < n; i++) sig[i] = Math.sin(i / 10) * 0.4
+
+  const a = new RmsFollower(SR, 100)
+  for (let i = 0; i < n; i++) a.process(sig[i])
+
+  const b = new RmsFollower(SR, 100)
+  b.processBlock(sig, n)
+
+  assert.ok(Math.abs(a.value - b.value) < 1e-15)
+})
+
+test('RmsFollower reset returns it to the initial state', () => {
+  const f = new RmsFollower(SR, 100)
+  for (let i = 0; i < 1000; i++) f.process(0.5)
+  f.reset()
+  assert.equal(f.meanSq, 0)
+})
+
+test('AttackReleaseFollower rises fast and falls slow', () => {
+  const f = new AttackReleaseFollower(SR, 1, 200)
+  // Step up: with a 1 ms attack, 10 ms should be essentially settled.
+  for (let i = 0; i < SR * 0.01; i++) f.process(1)
+  assert.ok(f.value > 0.99, `attack too slow: ${f.value}`)
+  // Step down: with a 200 ms release, 10 ms should barely move.
+  for (let i = 0; i < SR * 0.01; i++) f.process(0)
+  assert.ok(f.value > 0.9, `release too fast: ${f.value}`)
+  // ...but a full second gets there.
+  for (let i = 0; i < SR; i++) f.process(0)
+  assert.ok(f.value < 0.01, `release never completed: ${f.value}`)
+})
+
+test('linToDb and dbToLin round-trip', () => {
+  for (const db of [-60, -20, -6, 0, 6]) {
+    assert.ok(Math.abs(linToDb(dbToLin(db)) - db) < 1e-12)
+  }
+  assert.ok(linToDb(0) <= -240, 'zero must clamp, not return -Infinity')
+})

--- a/test/dsp/envelope.test.js
+++ b/test/dsp/envelope.test.js
@@ -80,6 +80,47 @@ test('RmsFollower reset returns it to the initial state', () => {
   for (let i = 0; i < 1000; i++) f.process(0.5)
   f.reset()
   assert.equal(f.meanSq, 0)
+  assert.equal(f.warmupCount, 0)
+})
+
+test('RmsFollower reaches a usable estimate within a few cycles', () => {
+  // Matters at region boundaries: a gain derived from a follower ramping up
+  // from zero would swing over the opening ~tau and leave an audible step.
+  // The warmup uses a cumulative mean, so accuracy arrives after roughly one
+  // cycle of the signal rather than after one time constant.
+  const f = new RmsFollower(SR, 300)
+  const amp = 0.5
+  const freq = 200
+  const expected = amp / Math.SQRT2
+  const cycleSamples = SR / freq
+
+  // After three cycles (~15 ms) the estimate should already be close, versus
+  // the 300 ms an unwarmed exponential average would need.
+  for (let i = 0; i < cycleSamples * 3; i++) {
+    f.process(amp * Math.sin((2 * Math.PI * freq * i) / SR))
+  }
+  assert.ok(
+    Math.abs(f.value - expected) < 0.05,
+    `after 3 cycles: expected ~${expected.toFixed(3)}, got ${f.value.toFixed(3)}`,
+  )
+})
+
+test('RmsFollower warmup hands over to the exponential average', () => {
+  const f = new RmsFollower(SR, 10) // short tau so warmup ends quickly
+  for (let i = 0; i < f.warmupTarget; i++) f.process(0.5)
+  assert.equal(f.warmupCount, f.warmupTarget)
+  assert.ok(Math.abs(f.value - 0.5) < 1e-9)
+
+  // Now a level change should track at the IIR rate, not the cumulative one.
+  for (let i = 0; i < SR * 0.2; i++) f.process(0.1)
+  assert.ok(Math.abs(f.value - 0.1) < 1e-3, `did not track after warmup: ${f.value}`)
+})
+
+test('explicit prime skips the warmup entirely', () => {
+  const f = new RmsFollower(SR, 300)
+  f.prime(0.25) // meanSq
+  assert.ok(Math.abs(f.value - 0.5) < 1e-12)
+  assert.equal(f.warmupCount, f.warmupTarget)
 })
 
 test('AttackReleaseFollower rises fast and falls slow', () => {

--- a/test/dsp/f0.test.js
+++ b/test/dsp/f0.test.js
@@ -1,0 +1,178 @@
+/**
+ * Run with:  npm test
+ */
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { F0Tracker, F0_MIN_HZ, F0_MAX_HZ } from '../../src/audio/dsp/f0.js'
+
+const SR = 44100
+const FRAME = 2048
+
+/** Sawtooth — rich in harmonics, like a glottal source. */
+function sawFrame(freqHz, n = FRAME, sampleRate = SR, phase = 0) {
+  const out = new Float64Array(n)
+  for (let i = 0; i < n; i++) {
+    const t = ((freqHz * (i + phase)) / sampleRate) % 1
+    out[i] = 2 * t - 1
+  }
+  return out
+}
+
+function makeTracker(opts = {}) {
+  return new F0Tracker({ sampleRate: SR, frameSize: FRAME, ...opts })
+}
+
+test('estimates the pitch of a sawtooth across the vocal range', () => {
+  for (const f of [80, 100, 120, 150, 200, 250, 300, 380]) {
+    const t = makeTracker()
+    const { f0, voiced } = t.estimate(sawFrame(f))
+    assert.ok(voiced, `${f} Hz should read voiced`)
+    const errCents = 1200 * Math.log2(f0 / f)
+    assert.ok(
+      Math.abs(errCents) < 25,
+      `${f} Hz estimated ${f0.toFixed(2)} (${errCents.toFixed(1)} cents off)`,
+    )
+  }
+})
+
+test('parabolic interpolation is applied', () => {
+  // 137 Hz lands between integer lags at 44.1 kHz (44100/137 = 321.9), so the
+  // estimate must not be exactly sr/integerLag.
+  const { f0 } = makeTracker().estimate(sawFrame(137))
+  let nearestIntegerLagF0 = Infinity
+  for (const lag of [321, 322, 323]) {
+    if (Math.abs(SR / lag - f0) < Math.abs(nearestIntegerLagF0 - f0)) {
+      nearestIntegerLagF0 = SR / lag
+    }
+  }
+  assert.notEqual(f0, nearestIntegerLagF0)
+  assert.ok(Math.abs(f0 - nearestIntegerLagF0) > 1e-6, 'interpolation had no effect')
+})
+
+test('matches the Python reference implementation', () => {
+  // Golden values captured from server/scripts/estimate_f0_contour.py's
+  // _autocorr_f0_batch run over identical frames. Cross-checked over 29 cases:
+  // worst deviation 1.2e-9 Hz, zero voiced/unvoiced disagreements.
+  //
+  // Some of these are not "correct" pitches — saw65 and saw440 fall outside
+  // [F0_MIN_HZ, F0_MAX_HZ] and land on octave artefacts. They are pinned
+  // deliberately: the contract is fidelity to the reference, quirks included,
+  // so a future optimisation cannot quietly change behaviour.
+  const golden = [
+    ['saw65', 65, 113.820707],
+    ['saw80', 80, 80.012255],
+    ['saw97.3', 97.3, 97.32528],
+    ['saw118.7', 118.7, 118.661028],
+    ['saw137', 137, 136.947433],
+    ['saw173.2', 173.2, 173.164218],
+    ['saw250', 250, 250.009401],
+    ['saw400', 400, 400.250051],
+    ['saw440', 440, 220.01977],
+  ]
+  for (const [label, inputHz, expected] of golden) {
+    const { f0 } = makeTracker().estimate(sawFrame(inputHz))
+    assert.ok(
+      Math.abs(f0 - expected) < 1e-6,
+      `${label}: expected ${expected}, got ${f0}`,
+    )
+  }
+})
+
+test('matches the reference on harmonic stacks and mixtures', () => {
+  const harmonicStack = (f0Hz, firstHarmonic) => {
+    const out = new Float64Array(FRAME)
+    for (let i = 0; i < FRAME; i++) {
+      let s = 0
+      for (let h = firstHarmonic; h <= 12; h++) {
+        s += (1 / h) * Math.sin((2 * Math.PI * f0Hz * h * i) / SR)
+      }
+      out[i] = s / 3
+    }
+    return out
+  }
+
+  // Full stack, and the missing-fundamental case — both should resolve to 150 Hz.
+  assert.ok(Math.abs(makeTracker().estimate(harmonicStack(150, 1)).f0 - 150.167946) < 1e-6)
+  assert.ok(Math.abs(makeTracker().estimate(harmonicStack(150, 2)).f0 - 150.138623) < 1e-6)
+
+  // Two simultaneous pitches: the reference locks to the stronger one.
+  const mix = new Float64Array(FRAME)
+  for (let i = 0; i < FRAME; i++) {
+    mix[i] =
+      0.6 * (2 * (((120 * i) / SR) % 1) - 1) + 0.4 * (2 * (((190 * i) / SR) % 1) - 1)
+  }
+  assert.ok(Math.abs(makeTracker().estimate(mix).f0 - 119.863462) < 1e-6)
+})
+
+test('white noise is not reported as voiced', () => {
+  const t = makeTracker()
+  let s = 12345
+  const frame = new Float64Array(FRAME)
+  for (let i = 0; i < FRAME; i++) {
+    s = (s * 1103515245 + 12345) & 0x7fffffff
+    frame[i] = s / 0x3fffffff - 1
+  }
+  const { voiced } = t.estimate(frame)
+  assert.equal(voiced, false, 'noise should fail the correlation-ratio gate')
+})
+
+test('silence is not reported as voiced', () => {
+  const t = makeTracker()
+  const { voiced, f0 } = t.estimate(new Float64Array(FRAME))
+  assert.equal(voiced, false)
+  assert.equal(f0, null)
+})
+
+test('the caller energy gate can veto an otherwise periodic frame', () => {
+  const t = makeTracker()
+  const { voiced } = t.estimate(sawFrame(150), false)
+  assert.equal(voiced, false, 'energy gate should override the correlation gate')
+})
+
+test('is insensitive to DC offset', () => {
+  const a = makeTracker().estimate(sawFrame(150)).f0
+  const withDc = sawFrame(150)
+  for (let i = 0; i < withDc.length; i++) withDc[i] += 0.7
+  const b = makeTracker().estimate(withDc).f0
+  assert.ok(Math.abs(a - b) < 1e-9, `DC changed the estimate: ${a} vs ${b}`)
+})
+
+test('rolling median tracks the speaker and ignores unvoiced frames', () => {
+  const t = makeTracker({ medianWindow: 5, defaultF0: 60 })
+  assert.equal(t.median, 60, 'seeded default before any voiced frame')
+
+  for (const f of [118, 122, 120, 119, 121]) t.estimate(sawFrame(f))
+  assert.ok(Math.abs(t.median - 120) < 3, `median ${t.median}`)
+
+  // Unvoiced frames must not enter the history.
+  const before = t.median
+  t.estimate(new Float64Array(FRAME))
+  t.estimate(new Float64Array(FRAME))
+  assert.equal(t.median, before, 'silence should not shift the median')
+})
+
+test('median window is bounded', () => {
+  const t = makeTracker({ medianWindow: 4 })
+  for (const f of [100, 100, 100, 100]) t.estimate(sawFrame(f))
+  for (const f of [300, 300, 300, 300]) t.estimate(sawFrame(f))
+  assert.ok(Math.abs(t.median - 300) < 10, `stale values retained: median ${t.median}`)
+})
+
+test('lag range brackets the configured F0 limits', () => {
+  const t = makeTracker()
+  assert.equal(t.lagMin, Math.floor(SR / F0_MAX_HZ))
+  assert.equal(t.lagMax, Math.floor(SR / F0_MIN_HZ))
+  // A tone below F0_MIN cannot be reported inside the range.
+  const { f0, voiced } = makeTracker().estimate(sawFrame(45))
+  if (voiced) {
+    assert.ok(f0 >= F0_MIN_HZ - 5, `reported ${f0} below the search floor`)
+  }
+})
+
+test('reset clears history', () => {
+  const t = makeTracker({ defaultF0: 60 })
+  t.estimate(sawFrame(200))
+  assert.ok(Math.abs(t.median - 200) < 5)
+  t.reset()
+  assert.equal(t.median, 60)
+})

--- a/test/dsp/fft.test.js
+++ b/test/dsp/fft.test.js
@@ -1,0 +1,153 @@
+/**
+ * Run with:  npm test
+ */
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { FFT, getFFT, rfftBinCount, rfftFreqs } from '../../src/audio/dsp/fft.js'
+
+/** Reference DFT — O(n²), used to pin the fast path at small sizes. */
+function naiveDft(re, im) {
+  const n = re.length
+  const outRe = new Float64Array(n)
+  const outIm = new Float64Array(n)
+  for (let k = 0; k < n; k++) {
+    let sr = 0
+    let si = 0
+    for (let t = 0; t < n; t++) {
+      const ang = (-2 * Math.PI * k * t) / n
+      const c = Math.cos(ang)
+      const s = Math.sin(ang)
+      sr += re[t] * c - im[t] * s
+      si += re[t] * s + im[t] * c
+    }
+    outRe[k] = sr
+    outIm[k] = si
+  }
+  return { outRe, outIm }
+}
+
+function maxAbsDiff(a, b) {
+  let m = 0
+  for (let i = 0; i < a.length; i++) m = Math.max(m, Math.abs(a[i] - b[i]))
+  return m
+}
+
+test('rejects non-power-of-two sizes', () => {
+  assert.throws(() => new FFT(1000), /power of two/)
+  assert.throws(() => new FFT(1), /power of two/)
+})
+
+test('getFFT memoizes per size', () => {
+  assert.equal(getFFT(256), getFFT(256))
+  assert.notEqual(getFFT(256), getFFT(512))
+})
+
+test('forward matches a naive DFT', () => {
+  const n = 64
+  const re = new Float64Array(n)
+  const im = new Float64Array(n)
+  for (let i = 0; i < n; i++) {
+    re[i] = Math.sin((2 * Math.PI * 5 * i) / n) + 0.3 * Math.cos((2 * Math.PI * 11 * i) / n)
+    im[i] = 0.1 * Math.sin((2 * Math.PI * 3 * i) / n)
+  }
+  const { outRe, outIm } = naiveDft(re, im)
+
+  const fft = new FFT(n)
+  fft.forward(re, im)
+
+  assert.ok(maxAbsDiff(re, outRe) < 1e-10, `real diff ${maxAbsDiff(re, outRe)}`)
+  assert.ok(maxAbsDiff(im, outIm) < 1e-10, `imag diff ${maxAbsDiff(im, outIm)}`)
+})
+
+test('inverse undoes forward', () => {
+  const n = 256
+  const fft = new FFT(n)
+  const re = new Float64Array(n)
+  const im = new Float64Array(n)
+  const re0 = new Float64Array(n)
+  const im0 = new Float64Array(n)
+  for (let i = 0; i < n; i++) {
+    re0[i] = re[i] = Math.random() * 2 - 1
+    im0[i] = im[i] = Math.random() * 2 - 1
+  }
+  fft.forward(re, im)
+  fft.inverse(re, im)
+  assert.ok(maxAbsDiff(re, re0) < 1e-12)
+  assert.ok(maxAbsDiff(im, im0) < 1e-12)
+})
+
+test('rfft of a pure tone puts all energy in one bin', () => {
+  const n = 1024
+  const sampleRate = 44100
+  const bin = 64
+  const freq = (bin * sampleRate) / n
+  const x = new Float64Array(n)
+  for (let i = 0; i < n; i++) x[i] = Math.sin((2 * Math.PI * freq * i) / sampleRate)
+
+  const fft = new FFT(n)
+  const bins = rfftBinCount(n)
+  const re = new Float64Array(bins)
+  const im = new Float64Array(bins)
+  fft.rfft(x, re, im)
+
+  const mag = k => Math.hypot(re[k], im[k])
+  const peak = mag(bin)
+  assert.ok(peak > n / 4, `expected a strong peak, got ${peak}`)
+  for (let k = 0; k < bins; k++) {
+    if (Math.abs(k - bin) <= 1) continue
+    assert.ok(mag(k) < peak * 1e-6, `leakage at bin ${k}: ${mag(k)} vs peak ${peak}`)
+  }
+})
+
+test('rfft/irfft round-trips real signals', () => {
+  const n = 2048
+  const fft = new FFT(n)
+  const bins = rfftBinCount(n)
+  const x = new Float64Array(n)
+  for (let i = 0; i < n; i++) x[i] = Math.random() * 2 - 1
+
+  const re = new Float64Array(bins)
+  const im = new Float64Array(bins)
+  const y = new Float64Array(n)
+  fft.rfft(x, re, im)
+  fft.irfft(re, im, y)
+
+  assert.ok(maxAbsDiff(x, y) < 1e-12, `round-trip error ${maxAbsDiff(x, y)}`)
+})
+
+test('irfft of a real half-spectrum is real and symmetric (the cepstrum path)', () => {
+  // resonance_suppressor.py inverts a real-valued log-magnitude spectrum with
+  // no imaginary part, relying on the result being real and symmetric.
+  const n = 512
+  const fft = new FFT(n)
+  const bins = rfftBinCount(n)
+  const magDb = new Float64Array(bins)
+  for (let k = 0; k < bins; k++) magDb[k] = -20 + 10 * Math.sin(k / 7)
+
+  const ceps = new Float64Array(n)
+  fft.irfft(magDb, null, ceps)
+
+  // Symmetric about zero quefrency: c[k] === c[n-k].
+  for (let k = 1; k < n / 2; k++) {
+    assert.ok(
+      Math.abs(ceps[k] - ceps[n - k]) < 1e-12,
+      `asymmetry at ${k}: ${ceps[k]} vs ${ceps[n - k]}`,
+    )
+  }
+
+  // And the round trip back through rfft recovers the input.
+  const re = new Float64Array(bins)
+  const im = new Float64Array(bins)
+  fft.rfft(ceps, re, im)
+  // rfft returns the unscaled transform of a 1/N-scaled sequence, so undo it.
+  for (let k = 0; k < bins; k++) re[k] *= 1
+  assert.ok(maxAbsDiff(re, magDb) < 1e-10, `cepstral round-trip ${maxAbsDiff(re, magDb)}`)
+})
+
+test('rfftFreqs matches numpy rfftfreq', () => {
+  const f = rfftFreqs(2048, 44100)
+  assert.equal(f.length, 1025)
+  assert.equal(f[0], 0)
+  assert.ok(Math.abs(f[1] - 44100 / 2048) < 1e-12)
+  assert.ok(Math.abs(f[1024] - 22050) < 1e-9)
+})

--- a/test/dsp/stft.test.js
+++ b/test/dsp/stft.test.js
@@ -1,0 +1,161 @@
+/**
+ * Run with:  npm test
+ *
+ * The reconstruction and latency tests here are the contract the resonance
+ * suppressor depends on. If latency is not exactly fftSize, the offline apply
+ * path trims the wrong amount and written-back audio is time-shifted.
+ */
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { StftProcessor, hannPeriodic } from '../../src/audio/dsp/stft.js'
+
+function noise(n, seed = 1) {
+  // Deterministic LCG so failures are reproducible.
+  let s = seed
+  const out = new Float64Array(n)
+  for (let i = 0; i < n; i++) {
+    s = (s * 1103515245 + 12345) & 0x7fffffff
+    out[i] = (s / 0x3fffffff) - 1
+  }
+  return out
+}
+
+/** Push `input` through in blocks of `blockSize`, returning the output stream. */
+function runBlocks(stft, input, blockSize, frameFn = null) {
+  const out = new Float64Array(input.length)
+  const inBlk = new Float64Array(blockSize)
+  const outBlk = new Float64Array(blockSize)
+  for (let i = 0; i < input.length; i += blockSize) {
+    const n = Math.min(blockSize, input.length - i)
+    for (let k = 0; k < n; k++) inBlk[k] = input[i + k]
+    stft.process(inBlk, outBlk, n, frameFn)
+    for (let k = 0; k < n; k++) out[i + k] = outBlk[k]
+  }
+  return out
+}
+
+test('hannPeriodic matches the scipy fftbins=True definition', () => {
+  const w = hannPeriodic(8)
+  assert.equal(w[0], 0)
+  // Periodic (not symmetric): w[N/2] is the peak and w[N-1] !== w[1] mirror.
+  assert.ok(Math.abs(w[4] - 1) < 1e-12)
+  for (let i = 0; i < 8; i++) {
+    const expected = 0.5 * (1 - Math.cos((2 * Math.PI * i) / 8))
+    assert.ok(Math.abs(w[i] - expected) < 1e-15)
+  }
+})
+
+test('rejects a hop that does not divide the fft size', () => {
+  assert.throws(() => new StftProcessor({ fftSize: 2048, hopSize: 300 }), /multiple/)
+})
+
+test('reports latency of exactly fftSize', () => {
+  const stft = new StftProcessor({ fftSize: 2048, hopSize: 512 })
+  assert.equal(stft.latencySamples, 2048)
+})
+
+test('pass-through reconstructs the input delayed by exactly fftSize', () => {
+  const fftSize = 2048
+  const hopSize = 512
+  const stft = new StftProcessor({ fftSize, hopSize })
+  const n = 20000
+  const input = noise(n)
+  const output = runBlocks(stft, input, 128)
+
+  // Compare output[i + latency] against input[i] over the fully-overlapped
+  // region, skipping the ramp-in where fewer frames have accumulated.
+  const latency = stft.latencySamples
+  let maxErr = 0
+  for (let i = fftSize; i + latency < n; i++) {
+    maxErr = Math.max(maxErr, Math.abs(output[i + latency] - input[i]))
+  }
+  assert.ok(maxErr < 1e-9, `reconstruction error ${maxErr}`)
+})
+
+test('the measured delay is fftSize, not merely consistent', () => {
+  // Independent check that does not assume the answer: cross-correlate an
+  // impulse response to find where the energy actually lands.
+  const fftSize = 1024
+  const hopSize = 256
+  const stft = new StftProcessor({ fftSize, hopSize })
+  const n = 8192
+  const input = new Float64Array(n)
+  input[3000] = 1
+
+  const output = runBlocks(stft, input, 128)
+  let peakIdx = -1
+  let peak = 0
+  for (let i = 0; i < n; i++) {
+    if (Math.abs(output[i]) > peak) {
+      peak = Math.abs(output[i])
+      peakIdx = i
+    }
+  }
+  assert.ok(peak > 0.5, `impulse should survive, peak was ${peak}`)
+  assert.equal(peakIdx - 3000, fftSize, `measured delay ${peakIdx - 3000}`)
+})
+
+test('output is independent of the block size it was fed in', () => {
+  const n = 12000
+  const input = noise(n, 7)
+  const a = runBlocks(new StftProcessor({ fftSize: 1024, hopSize: 256 }), input, 128)
+  const b = runBlocks(new StftProcessor({ fftSize: 1024, hopSize: 256 }), input, 999)
+  const c = runBlocks(new StftProcessor({ fftSize: 1024, hopSize: 256 }), input, 1)
+  for (let i = 0; i < n; i++) {
+    assert.ok(Math.abs(a[i] - b[i]) < 1e-12, `block-size mismatch at ${i}`)
+    assert.ok(Math.abs(a[i] - c[i]) < 1e-12, `single-sample mismatch at ${i}`)
+  }
+})
+
+test('spectral modification takes effect', () => {
+  // Zero every bin above 100 and confirm a high tone disappears while a low
+  // tone survives — proves frameFn actually reaches the synthesis path.
+  const sampleRate = 44100
+  const fftSize = 2048
+  const stft = new StftProcessor({ fftSize, hopSize: 512 })
+  const n = 16384
+  const input = new Float64Array(n)
+  const lowHz = (40 * sampleRate) / fftSize
+  const highHz = (400 * sampleRate) / fftSize
+  for (let i = 0; i < n; i++) {
+    input[i] =
+      0.5 * Math.sin((2 * Math.PI * lowHz * i) / sampleRate) +
+      0.5 * Math.sin((2 * Math.PI * highHz * i) / sampleRate)
+  }
+
+  const output = runBlocks(stft, input, 128, (re, im, bins) => {
+    for (let k = 100; k < bins; k++) {
+      re[k] = 0
+      im[k] = 0
+    }
+  })
+
+  // Measure residual energy at each tone in the settled region.
+  const settled = output.subarray(4096, 12288)
+  const goertzel = (buf, freq) => {
+    let sr = 0
+    let si = 0
+    for (let i = 0; i < buf.length; i++) {
+      const ang = (2 * Math.PI * freq * (i + 4096)) / sampleRate
+      sr += buf[i] * Math.cos(ang)
+      si += buf[i] * Math.sin(ang)
+    }
+    return (2 * Math.hypot(sr, si)) / buf.length
+  }
+  const lowAmp = goertzel(settled, lowHz)
+  const highAmp = goertzel(settled, highHz)
+
+  assert.ok(lowAmp > 0.4, `low tone should survive, amplitude ${lowAmp}`)
+  assert.ok(highAmp < 0.01, `high tone should be removed, amplitude ${highAmp}`)
+})
+
+test('reset restores identical behaviour', () => {
+  const input = noise(6000, 3)
+  const stft = new StftProcessor({ fftSize: 1024, hopSize: 256 })
+  const a = runBlocks(stft, input, 128)
+  stft.reset()
+  const b = runBlocks(stft, input, 128)
+  for (let i = 0; i < input.length; i++) {
+    assert.ok(Math.abs(a[i] - b[i]) < 1e-15, `mismatch after reset at ${i}`)
+  }
+})

--- a/test/dsp/vocalSat.test.js
+++ b/test/dsp/vocalSat.test.js
@@ -1,0 +1,261 @@
+/**
+ * Run with:  npm test
+ */
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  VocalSatKernel,
+  VOCAL_SAT_KERNEL_DEFAULTS,
+  processVocalSatBuffer,
+} from '../../src/audio/vocalSatProcessor.js'
+import { getFFT, rfftBinCount } from '../../src/audio/dsp/fft.js'
+
+const SR = 44100
+
+function rms(buf, from = 0) {
+  let s = 0
+  for (let i = from; i < buf.length; i++) s += buf[i] * buf[i]
+  return Math.sqrt(s / (buf.length - from))
+}
+
+function tone(n, freqHz, amp = 0.4) {
+  const out = new Float32Array(n)
+  for (let i = 0; i < n; i++) out[i] = amp * Math.sin((2 * Math.PI * freqHz * i) / SR)
+  return out
+}
+
+test('is transparent at zero drive and zero bias', () => {
+  // transfer(0*x + 0) === 0, so wet is silent and the blend collapses to dry.
+  const n = 8192
+  const sig = tone(n, 220)
+  const { channelData } = processVocalSatBuffer([sig], SR, {
+    drive: 0, bias: 0, wetDry: 0.5,
+  })
+  let maxErr = 0
+  for (let i = 1000; i < n; i++) maxErr = Math.max(maxErr, Math.abs(channelData[0][i] - sig[i]))
+  assert.ok(maxErr < 1e-5, `not transparent: max error ${maxErr}`)
+})
+
+test('is transparent at zero wet/dry', () => {
+  const n = 8192
+  const sig = tone(n, 220)
+  const { channelData } = processVocalSatBuffer([sig], SR, { wetDry: 0 })
+  let maxErr = 0
+  for (let i = 1000; i < n; i++) maxErr = Math.max(maxErr, Math.abs(channelData[0][i] - sig[i]))
+  assert.ok(maxErr < 1e-5, `not transparent: max error ${maxErr}`)
+})
+
+test('is level-neutral, which is the point of the double RMS match', () => {
+  const n = SR // one second, well past the 300 ms follower
+  for (const amp of [0.05, 0.2, 0.6]) {
+    const sig = tone(n, 180, amp)
+    const { channelData } = processVocalSatBuffer([sig], SR, VOCAL_SAT_KERNEL_DEFAULTS)
+    const inDb = 20 * Math.log10(rms(sig, SR / 2))
+    const outDb = 20 * Math.log10(rms(channelData[0], SR / 2))
+    assert.ok(
+      Math.abs(outDb - inDb) < 0.6,
+      `amp ${amp}: in ${inDb.toFixed(2)} dB, out ${outDb.toFixed(2)} dB`,
+    )
+  }
+})
+
+test('primed followers keep the opening of a region level-matched', () => {
+  // Without RmsFollower priming the first ~300 ms reads far too quiet and the
+  // two gain divisions overshoot, leaving an audible step at a selection edge.
+  const n = SR
+  const sig = tone(n, 180, 0.4)
+  const { channelData } = processVocalSatBuffer([sig], SR, VOCAL_SAT_KERNEL_DEFAULTS)
+
+  // Compare the first 20 ms against the settled tail.
+  const head = rms(channelData[0].subarray(0, Math.floor(SR * 0.02)))
+  const tail = rms(channelData[0].subarray(Math.floor(SR * 0.7)))
+  const stepDb = 20 * Math.log10(head / tail)
+  assert.ok(
+    Math.abs(stepDb) < 1.5,
+    `region opens ${stepDb.toFixed(2)} dB away from its settled level`,
+  )
+})
+
+test('actually adds harmonics', () => {
+  const n = 32768
+  const f0 = 220
+  const sig = tone(n, f0, 0.4)
+  const { channelData } = processVocalSatBuffer([sig], SR, {
+    ...VOCAL_SAT_KERNEL_DEFAULTS,
+    drive: 3,
+    wetDry: 0.8,
+  })
+
+  const fft = getFFT(n)
+  const bins = rfftBinCount(n)
+  const re = new Float64Array(bins)
+  const im = new Float64Array(bins)
+  fft.rfft(channelData[0], re, im)
+
+  const at = f => {
+    const k = Math.round((f * n) / SR)
+    return Math.hypot(re[k], im[k])
+  }
+  const fundamental = at(f0)
+  const second = at(f0 * 2)
+  const third = at(f0 * 3)
+  assert.ok(second / fundamental > 1e-3, `no 2nd harmonic (${second / fundamental})`)
+  assert.ok(third / fundamental > 1e-3, `no 3rd harmonic (${third / fundamental})`)
+})
+
+test('bias asymmetry produces even harmonics', () => {
+  // A symmetric transfer generates odd harmonics only; the bias term is what
+  // gives the "tube" second harmonic.
+  const n = 32768
+  const f0 = 220
+  const sig = tone(n, f0, 0.4)
+
+  const measureSecond = biasValue => {
+    const { channelData } = processVocalSatBuffer([sig], SR, {
+      ...VOCAL_SAT_KERNEL_DEFAULTS, drive: 3, wetDry: 0.8, bias: biasValue,
+    })
+    const fft = getFFT(n)
+    const bins = rfftBinCount(n)
+    const re = new Float64Array(bins)
+    const im = new Float64Array(bins)
+    fft.rfft(channelData[0], re, im)
+    const at = f => {
+      const k = Math.round((f * n) / SR)
+      return Math.hypot(re[k], im[k])
+    }
+    return at(f0 * 2) / at(f0)
+  }
+
+  assert.ok(
+    measureSecond(0.5) > measureSecond(0) * 5,
+    'bias should raise the second harmonic substantially',
+  )
+})
+
+/**
+ * Alias-to-signal ratio in dB for a bin-centred tone.
+ *
+ * The tone must complete exactly `cycles` periods in the FFT length. That
+ * gives zero spectral leakage, so every bin that is not a multiple of `cycles`
+ * is genuinely alias energy rather than a smeared harmonic. Measuring with a
+ * non-bin-centred tone reads ~80 dB worse purely from leakage.
+ *
+ * Analysis runs on a settled window, past the filter and follower warmup.
+ */
+function aliasToSignalDb(params, cycles, amp = 0.4) {
+  const n = 32768
+  const f0 = (cycles * SR) / n
+  const total = n * 3
+  const sig = new Float32Array(total)
+  for (let i = 0; i < total; i++) sig[i] = amp * Math.sin((2 * Math.PI * f0 * i) / SR)
+
+  const { channelData } = processVocalSatBuffer([sig], SR, params)
+  const settled = channelData[0].subarray(total - n)
+
+  const fft = getFFT(n)
+  const bins = rfftBinCount(n)
+  const re = new Float64Array(bins)
+  const im = new Float64Array(bins)
+  fft.rfft(settled, re, im)
+
+  let harmonic = 0
+  let alias = 0
+  for (let k = 1; k < bins; k++) {
+    const p = re[k] * re[k] + im[k] * im[k]
+    if (k % cycles === 0) harmonic += p
+    else alias += p
+  }
+  return 10 * Math.log10(alias / harmonic)
+}
+
+test('aliasing stays inaudible without oversampling', () => {
+  // The Python oversamples 2x whenever a band's effective drive reaches 0.5,
+  // and at default settings the low band runs at 10. This kernel does not
+  // oversample, because a streaming 2x up/down pair costs 7 samples of latency
+  // and would make this a latent effect. These numbers are what that decision
+  // actually costs — all far below anything audible.
+  //
+  // Measured: -91.8 dB at defaults, -87.2 dB on a 122 Hz tone, -92.6 dB even
+  // at drive 5 (low band effective drive 25), -79.1 dB fully wet.
+  const D = VOCAL_SAT_KERNEL_DEFAULTS
+  const cases = [
+    ['defaults', D, 235, 0.4],
+    ['low tone', D, 91, 0.4],
+    ['hot input', D, 235, 0.8],
+    ['drive 5', { ...D, drive: 5 }, 235, 0.4],
+    ['fully wet', { ...D, wetDry: 1 }, 235, 0.4],
+    ['mid-band tone', D, 1486, 0.4],
+  ]
+  for (const [label, params, cycles, amp] of cases) {
+    const db = aliasToSignalDb(params, cycles, amp)
+    assert.ok(
+      db < -70,
+      `${label}: alias/signal ${db.toFixed(1)} dB — oversampling may now be needed`,
+    )
+  }
+})
+
+test('a near-linear band produces essentially no aliasing', () => {
+  // Sanity check on the measurement itself: drop the low band's drive below
+  // the point where the transfer curves and the number should fall away.
+  const db = aliasToSignalDb(
+    { ...VOCAL_SAT_KERNEL_DEFAULTS, lowDriveMult: 0.1 }, 235, 0.4,
+  )
+  assert.ok(db < -120, `expected near-nothing, measured ${db.toFixed(1)} dB`)
+})
+
+test('block size does not change the result', () => {
+  const n = 6000
+  const sig = tone(n, 180)
+  const oneShot = processVocalSatBuffer([sig], SR, VOCAL_SAT_KERNEL_DEFAULTS).channelData[0]
+
+  const kernel = new VocalSatKernel(SR)
+  kernel.setParams(VOCAL_SAT_KERNEL_DEFAULTS)
+  const chunked = new Float32Array(n)
+  let off = 0
+  while (off < n) {
+    const len = Math.min(off % 2 === 0 ? 37 : 211, n - off)
+    kernel.process(
+      [sig.subarray(off, off + len)],
+      [chunked.subarray(off, off + len)],
+      len,
+    )
+    off += len
+  }
+  let maxErr = 0
+  for (let i = 0; i < n; i++) maxErr = Math.max(maxErr, Math.abs(oneShot[i] - chunked[i]))
+  assert.ok(maxErr < 1e-6, `block-size dependence: max error ${maxErr}`)
+})
+
+test('channels are processed independently', () => {
+  const n = 4096
+  const sig = tone(n, 180)
+  const silence = new Float32Array(n)
+  const { channelData } = processVocalSatBuffer([sig, silence], SR, VOCAL_SAT_KERNEL_DEFAULTS)
+  for (let i = 0; i < n; i++) {
+    assert.ok(Math.abs(channelData[1][i]) < 1e-9, `silent channel leaked at ${i}`)
+  }
+})
+
+test('output stays inside [-1, 1]', () => {
+  const n = 8192
+  const sig = tone(n, 120, 0.99)
+  const { channelData } = processVocalSatBuffer([sig], SR, {
+    ...VOCAL_SAT_KERNEL_DEFAULTS, drive: 5, wetDry: 1,
+  })
+  for (let i = 0; i < n; i++) {
+    assert.ok(Math.abs(channelData[0][i]) <= 1, `clipped past unity at ${i}`)
+  }
+})
+
+test('survives silence without producing NaN', () => {
+  // The two RMS divisions are the risk: an unguarded follower reaching zero
+  // would turn the whole buffer into NaN.
+  const n = 4096
+  const { channelData } = processVocalSatBuffer(
+    [new Float32Array(n)], SR, VOCAL_SAT_KERNEL_DEFAULTS,
+  )
+  for (let i = 0; i < n; i++) {
+    assert.ok(Number.isFinite(channelData[0][i]), `non-finite output at ${i}`)
+  }
+})


### PR DESCRIPTION
## Summary

Implements two new real-time audio effects as AudioWorklet kernels with full offline apply support: Air Band (Maag-style parametric EQ) and Vocal Saturation (three-band saturation with blended transfer functions). Both effects run sample-identical in preview and offline contexts, with supporting DSP infrastructure (FFT, STFT, F0 tracking, envelope followers, biquad filters).

## Key Changes

**New DSP Infrastructure** (`src/audio/dsp/`)
- `biquad.js`: RBJ biquad coefficient builders (peaking, high/low shelf, high/low pass, notch) with FFmpeg-compatible width parameterization (Q, octaves, slope). Includes `BiquadCascade` for efficient multi-section processing and `magnitudeResponseDb` for analytic frequency response.
- `fft.js`: Radix-2 FFT with precomputed twiddle tables and bit-reversal, supporting both complex and real-input transforms. Memoized per size to avoid recomputation.
- `stft.js`: Streaming STFT processor with overlap-add reconstruction, periodic Hann windowing, and exact latency reporting (fftSize samples).
- `f0.js`: Per-frame F0 estimation via FFT autocorrelation with rolling median voicing tracking, ported from Python reference implementation.
- `envelope.js`: One-pole RMS followers and attack-release envelopes with dual coefficient conventions (decay/rise) matching Python and existing compressor kernels.
- `clipGainEnvelope.js`: Clip-gain envelope renderer for de-esser integration (verbatim server port).

**Air Band Effect** (`src/audio/airBandProcessor.js`, `src/audio/effects/airBand.js`)
- Realtime port of server's `airBoost` stage: five overlapping parametric bells + wide high shelf modeling the Maag EQ4 Air Band.
- Single `air` knob (0–24 dB) scales all band gains linearly from a reference plateau.
- `AirBandKernel` processes audio; `processAirBandBuffer` handles offline rendering.
- Worklet loader (`airBandWorkletLoader.js`) bundles the kernel with its DSP dependencies via `?worker&url`.

**Vocal Saturation Effect** (`src/audio/vocalSatProcessor.js`, `src/audio/effects/vocalSat.js`)
- Realtime port of server's `vocal_saturation.py`: complementary three-band split (lowpass/highpass crossovers), blended tanh/arctan transfer with per-band drive, gain-neutral parallel blend.
- Parameters: `drive`, `wetDry`, `bias`, `softness`, `lowCrossover`, `midCrossover`, `lowDriveMult`, `midDriveMult`, `highDriveMult`.
- Level matching via one-pole RMS followers (300 ms time constant) primed from first sample to avoid opening-edge under-normalization.
- No oversampling (measured alias-to-signal < -79 dB at defaults, inaudible).
- `VocalSatKernel` processes audio; `processVocalSatBuffer` handles offline rendering.
- Worklet loader (`vocalSatWorkletLoader.js`) bundles the kernel with its DSP dependencies.

**UI Integration**
- `AirBandModal.vue`: Floating panel with response curve drawn from live coefficient builders, input/output level meters, knobs for air and output trim.
- `VocalSaturationWindow.vue`: Refactored from server-based modal to use new `useVocalSaturation()` composable; now runs in-browser with preview and offline apply.
- `useAirBand.js`, `useVocalSaturation.js`: Composables managing effect chain initialization, parameter sync, metering, preview toggle, and offline apply.
- Registry entries in `src/ui/registry.js` and icon definitions in `src/ui/icons.js`.

**Processing Pipeline** (`src/audio/processing.js`)
- Added `applyA

https://claude.ai/code/session_019b1Nt95cB9aGTecubKbo9L