### PR TITLE
Add Hum Remover — client-side detection plus realtime notches (Phase 3)

### DIFF
--- a/src/audio/dsp/humDetect.js
+++ b/src/audio/dsp/humDetect.js
@@ -1,0 +1,459 @@
+/**
+ * Mains hum detection.
+ *
+ * Direct port of `analyzeHum` from server/pipeline/humEQ.js, which was already
+ * pure JavaScript — only the audio source changes, from an FFmpeg pipe to an
+ * AudioBuffer. Runs in a Worker (src/workers/humWorker.js); the FFT is large
+ * enough to block a frame or two on the main thread.
+ *
+ * Method: one very large FFT over the first few seconds, then a two-pass
+ * anchored coherence test across the harmonic series.
+ *
+ * The detector anchors on the SECOND harmonic (120 Hz for 60 Hz mains, 100 Hz
+ * for 50 Hz) rather than the fundamental, because user-applied high-pass
+ * filters routinely suppress 60 Hz while leaving 120 Hz untouched — and
+ * 120 Hz hum from transformer cores and magnetic coupling is in practice more
+ * common on modern gear than pure 60 Hz.
+ *
+ * The anchored coherence test is only the FIRST line of defence against
+ * mistaking a voice for hum, and it has a known blind spot: a speaker whose
+ * fundamental is near the mains frequency or one of its harmonics puts real
+ * vocal energy exactly on the grid being tested. A 120 Hz voice is
+ * indistinguishable from 60 Hz hum by spectrum shape alone — its harmonics land
+ * on 120, 240, 360.
+ *
+ * The server closes that hole with an F0 veto (stages.js:481) that drops any
+ * candidate overlapping the speaker's voiced pitch, using an F0 contour and
+ * Silero VAD labels. The same check runs here against F0Tracker, with an
+ * energy gate standing in for Silero. It differs in what it does with the
+ * answer: the server discards the candidate silently, whereas this reports
+ * `matchesVoicePitch` and leaves the row visible and tickable. A narrator whose
+ * voice really does sit on 120 Hz can still hear the difference in preview and
+ * decide — which is more informative than a silent drop, and safer than the
+ * label-only warning this originally shipped with.
+ */
+
+import { getFFT } from './fft.js'
+import { F0Tracker } from './f0.js'
+
+/** Analysis window. Hum is stationary, so a few seconds is plenty. */
+export const MAX_ANALYSIS_SECONDS = 10
+
+/**
+ * Below this the FFT's effective resolution is coarser than the ±5 Hz
+ * exclusion zone the floor estimate relies on, and detection is unreliable
+ * regardless of how much the input is zero-padded.
+ */
+export const MIN_ANALYSIS_SECONDS = 1.0
+
+/** 2^19 — about 0.084 Hz per bin at 44.1 kHz. Matches the server. */
+export const FFT_SIZE = 524288
+
+export const HUM_DETECT_DEFAULTS = {
+  fundamental: 60,
+  harmonics: [1, 2, 3, 4, 5],
+  detectionThreshold: 8,
+  minHarmonicsToTrigger: 2,
+  analysisWindow: 50, // ± Hz for the floor estimate
+  excludeHz: 5, // ± Hz excluded from the floor around the target
+  peakHalfWidthHz: 2,
+  minAbsoluteLevel: -80,
+  anchorMultiplier: 2,
+  anchorMinDeltaDb: 6,
+  coherenceSlackDb: 3,
+  strictSlackDb: { 3: 1 },
+  voicePitchCheck: true,
+}
+
+/**
+ * Frequencies where a flagged harmonic could plausibly be a voice fundamental
+ * rather than hum. Only used to decide whether the F0 check is worth running
+ * for a given harmonic; the verdict comes from the measured pitch.
+ */
+const VOICE_F0_RANGE_HZ = [80, 300]
+
+// F0 veto tolerance and minimum evidence, matching F0_VETO_* in
+// server/pipeline/stages.js.
+const F0_VETO_HALF_WIDTH_HZ = 15
+const F0_VETO_MIN_FRAMES = 10
+
+/**
+ * Fraction of voiced frames that must cluster around the median pitch before
+ * the pitch estimate is trusted at all.
+ *
+ * The server tests each candidate against the raw F0 histogram, which is safe
+ * there because Silero has already excluded frames that are not speech. Without
+ * Silero the tracker also runs on hum-only frames, and hum is periodic — an
+ * autocorrelation tracker happily locks onto multiples of 60 Hz. Measured on a
+ * pure 60 Hz hum series it yields scattered estimates spread across 60–330 Hz
+ * with a concentration around 0.07, where a real speaker sits at 1.0. Requiring
+ * concentration is what separates "a voice is present" from "the tracker is
+ * chasing a tone", and without it a genuine hum harmonic gets vetoed as voice.
+ */
+const VOICE_PITCH_CONCENTRATION_MIN = 0.5
+
+/**
+ * A candidate is also treated as voice when it lands on a harmonic of the
+ * speaker's pitch — a 120 Hz speaker puts real energy on 240 Hz too, and
+ * notching that thins the voice just as badly as notching the fundamental.
+ */
+const MAX_VOICE_HARMONIC = 3
+
+/** Pitch jitter multiplies up the harmonic series, so the window widens. */
+function voiceToleranceHz(harmonic) {
+  return Math.min(harmonic * F0_VETO_HALF_WIDTH_HZ, 40)
+}
+
+// STFT geometry for the pitch pass — the grid estimate_f0_contour.py uses.
+const F0_FRAME_SIZE = 2048
+const F0_HOP = 512
+
+/** Voiced frames must clear the noise floor by this much to count. */
+const VOICING_GATE_DB = 8
+
+/**
+ * Per-frame F0 over the analysis window, with an energy gate standing in for
+ * Silero. Returns the speaker's median pitch and how tightly the estimates
+ * cluster around it — see VOICE_PITCH_CONCENTRATION_MIN for why the second
+ * number matters.
+ */
+function measureVoicePitch(samples, sampleRate) {
+  const none = { pitchHz: null, concentration: 0, voicedFrames: 0 }
+  const nFrames = Math.floor((samples.length - F0_FRAME_SIZE) / F0_HOP) + 1
+  if (nFrames < 1) return none
+
+  // Frame energies first, so the gate has a noise floor to work from.
+  const frameDb = new Float64Array(nFrames)
+  for (let f = 0; f < nFrames; f++) {
+    const off = f * F0_HOP
+    let sumSq = 0
+    for (let i = 0; i < F0_FRAME_SIZE; i++) {
+      const x = samples[off + i]
+      sumSq += x * x
+    }
+    frameDb[f] = 10 * Math.log10(sumSq / F0_FRAME_SIZE + 1e-20)
+  }
+  const sorted = Array.from(frameDb).sort((a, b) => a - b)
+  const p10 = sorted[Math.floor(sorted.length * 0.1)]
+  const p95 = sorted[Math.min(sorted.length - 1, Math.floor(sorted.length * 0.95))]
+  // `p10 + 8` is the speech gate reference_eq.py uses, and it is right for
+  // material with real dynamic range. It collapses on steady content, though —
+  // when every frame sits at the same level the 10th percentile IS that level,
+  // so nothing clears the gate and the pitch pass sees no voiced frames at all.
+  // Falling back to just under the loud end keeps steady material analysable.
+  const gateDb = Math.min(p10 + VOICING_GATE_DB, p95 - 3)
+
+  const tracker = new F0Tracker({ sampleRate, frameSize: F0_FRAME_SIZE })
+  const frame = new Float64Array(F0_FRAME_SIZE)
+  const pitches = []
+  for (let f = 0; f < nFrames; f++) {
+    const off = f * F0_HOP
+    for (let i = 0; i < F0_FRAME_SIZE; i++) frame[i] = samples[off + i]
+    const { f0, voiced } = tracker.estimate(frame, frameDb[f] > gateDb)
+    if (voiced) pitches.push(f0)
+  }
+  if (pitches.length < F0_VETO_MIN_FRAMES) return none
+
+  pitches.sort((a, b) => a - b)
+  const mid = pitches.length >> 1
+  const pitchHz = pitches.length % 2
+    ? pitches[mid]
+    : 0.5 * (pitches[mid - 1] + pitches[mid])
+
+  let near = 0
+  for (const p of pitches) {
+    if (Math.abs(p - pitchHz) <= F0_VETO_HALF_WIDTH_HZ) near++
+  }
+
+  return {
+    pitchHz,
+    concentration: near / pitches.length,
+    voicedFrames: pitches.length,
+  }
+}
+
+/**
+ * Is this frequency the speaker's pitch, or a harmonic of it?
+ * Returns the matching harmonic number, or 0 for no match.
+ */
+function voiceHarmonicOf(frequency, pitchHz) {
+  for (let h = 1; h <= MAX_VOICE_HARMONIC; h++) {
+    if (Math.abs(frequency - h * pitchHz) <= voiceToleranceHz(h)) return h
+  }
+  return 0
+}
+
+function round2(n) {
+  return n === null || n === undefined || !Number.isFinite(n)
+    ? null
+    : Math.round(n * 100) / 100
+}
+
+function freqToIndex(freq, sampleRate, fftSize) {
+  return Math.round((freq * fftSize) / sampleRate)
+}
+
+/**
+ * Hann-windowed magnitude spectrum in dBFS.
+ *
+ * Scaling matches the server exactly (magnitude divided by fftSize, floor at
+ * -300 dB) because `minAbsoluteLevel` is an absolute threshold — a different
+ * normalisation would silently move the detection bar.
+ */
+function computeMagnitudeSpectrum(samples, fftSize, fft) {
+  const windowed = new Float64Array(fftSize)
+  const n = Math.min(samples.length, fftSize)
+  for (let i = 0; i < n; i++) {
+    const w = 0.5 * (1 - Math.cos((2 * Math.PI * i) / (n - 1)))
+    windowed[i] = samples[i] * w
+  }
+
+  const bins = (fftSize >>> 1) + 1
+  const re = new Float64Array(bins)
+  const im = new Float64Array(bins)
+  fft.rfft(windowed, re, im)
+
+  const halfSize = fftSize >>> 1
+  const magnitudeDb = new Float64Array(halfSize)
+  for (let k = 0; k < halfSize; k++) {
+    const mag = Math.sqrt(re[k] * re[k] + im[k] * im[k]) / fftSize
+    magnitudeDb[k] = mag > 0 ? 20 * Math.log10(mag) : -300
+  }
+  return magnitudeDb
+}
+
+/** Peak magnitude within ±halfWidthHz of centerHz. */
+function getPeakInBand(magnitudeDb, centerHz, halfWidthHz, sampleRate, fftSize) {
+  const freqRes = sampleRate / fftSize
+  const center = freqToIndex(centerHz, sampleRate, fftSize)
+  const halfBins = Math.ceil(halfWidthHz / freqRes)
+  const lo = Math.max(0, center - halfBins)
+  const hi = Math.min(magnitudeDb.length - 1, center + halfBins)
+
+  let peak = -Infinity
+  for (let i = lo; i <= hi; i++) {
+    if (magnitudeDb[i] > peak) peak = magnitudeDb[i]
+  }
+  return peak
+}
+
+/**
+ * Median magnitude in a ±windowHz band, excluding ±excludeHz at the target.
+ * Median rather than mean so other tonal content in the window cannot drag the
+ * floor estimate up and mask a real peak.
+ */
+function getMedianFloor(magnitudeDb, centerHz, windowHz, excludeHz, sampleRate, fftSize) {
+  const freqRes = sampleRate / fftSize
+  const center = freqToIndex(centerHz, sampleRate, fftSize)
+  const windowBins = Math.ceil(windowHz / freqRes)
+  const excludeBins = Math.ceil(excludeHz / freqRes)
+  const lo = Math.max(0, center - windowBins)
+  const hi = Math.min(magnitudeDb.length - 1, center + windowBins)
+
+  const values = []
+  for (let i = lo; i <= hi; i++) {
+    if (Math.abs(i - center) > excludeBins) values.push(magnitudeDb[i])
+  }
+  if (values.length === 0) return -Infinity
+
+  values.sort((a, b) => a - b)
+  const mid = values.length >> 1
+  return values.length % 2 === 0
+    ? (values[mid - 1] + values[mid]) / 2
+    : values[mid]
+}
+
+/**
+ * Detect mains hum in a mono sample buffer.
+ *
+ * @param {Float32Array|Float64Array} samples mono; only the first
+ *   MAX_ANALYSIS_SECONDS are examined
+ * @param {number} sampleRate
+ * @param {Partial<typeof HUM_DETECT_DEFAULTS>} [options]
+ * @returns {{
+ *   triggered: boolean,
+ *   tooShort: boolean,
+ *   analyzedSeconds: number,
+ *   anchorFrequency: number,
+ *   anchorDeltaDb: number|null,
+ *   flaggedHarmonics: number[],
+ *   detectionDetail: Array<{
+ *     frequency: number, multiplier: number, peakDb: number|null,
+ *     floorDb: number|null, deltaDb: number|null, flagged: boolean,
+ *     rejectionReason: string|null, looksLikeVoice: boolean,
+ *   }>,
+ * }}
+ */
+export function detectHum(samples, sampleRate, options = {}) {
+  const opts = { ...HUM_DETECT_DEFAULTS, ...options }
+  const {
+    fundamental, harmonics, detectionThreshold, minHarmonicsToTrigger,
+    analysisWindow, excludeHz, peakHalfWidthHz, minAbsoluteLevel,
+    anchorMultiplier, anchorMinDeltaDb, coherenceSlackDb, strictSlackDb,
+  } = opts
+
+  const anchorFrequency = fundamental * anchorMultiplier
+  if (!harmonics.includes(anchorMultiplier)) {
+    throw new Error(
+      `anchorMultiplier (${anchorMultiplier}) must be in the harmonics list`,
+    )
+  }
+
+  const maxSamples = Math.min(samples.length, MAX_ANALYSIS_SECONDS * sampleRate)
+  const analyzedSeconds = maxSamples / sampleRate
+  const empty = {
+    triggered: false,
+    tooShort: true,
+    analyzedSeconds,
+    anchorFrequency,
+    anchorDeltaDb: null,
+    flaggedHarmonics: [],
+    detectionDetail: harmonics.map(multiplier => ({
+      frequency: fundamental * multiplier,
+      multiplier,
+      peakDb: null,
+      floorDb: null,
+      deltaDb: null,
+      flagged: false,
+      rejectionReason: 'selection-too-short',
+      looksLikeVoice: false,
+      matchesVoicePitch: false,
+      voiceOverlapFraction: 0,
+    })),
+  }
+  if (analyzedSeconds < MIN_ANALYSIS_SECONDS) return empty
+
+  const view = samples.subarray(0, maxSamples)
+  const fft = getFFT(FFT_SIZE)
+  const magnitudeDb = computeMagnitudeSpectrum(view, FFT_SIZE, fft)
+
+  // Second line of defence, only worth the pitch pass if some candidate could
+  // plausibly be a voice fundamental.
+  const anyInVoiceRange = harmonics.some(m => {
+    const f = fundamental * m
+    return f >= VOICE_F0_RANGE_HZ[0] && f <= VOICE_F0_RANGE_HZ[1]
+  })
+  const voice =
+    opts.voicePitchCheck && anyInVoiceRange
+      ? measureVoicePitch(view, sampleRate)
+      : { pitchHz: null, concentration: 0, voicedFrames: 0 }
+  // Only trust the pitch when the estimates actually cluster; a scattered
+  // contour means the tracker was chasing a tone, not following a speaker.
+  const voicePitchTrusted =
+    voice.pitchHz !== null && voice.concentration >= VOICE_PITCH_CONCENTRATION_MIN
+
+  // First pass: measure every harmonic, flag nothing yet.
+  const measurements = harmonics.map(multiplier => {
+    const frequency = fundamental * multiplier
+    const peakDb = getPeakInBand(magnitudeDb, frequency, peakHalfWidthHz, sampleRate, FFT_SIZE)
+    const floorDb = getMedianFloor(
+      magnitudeDb, frequency, analysisWindow, excludeHz, sampleRate, FFT_SIZE,
+    )
+    return { multiplier, frequency, peakDb, floorDb, deltaDb: peakDb - floorDb }
+  })
+
+  const anchor = measurements.find(m => m.multiplier === anchorMultiplier)
+  const anchorDelta = anchor.deltaDb
+  const anchorPasses = anchorDelta >= anchorMinDeltaDb
+
+  // Second pass: coherence rules.
+  const detectionDetail = []
+  const flaggedHarmonics = []
+
+  for (const m of measurements) {
+    const { multiplier, frequency, peakDb, floorDb, deltaDb } = m
+
+    let flagged = false
+    let rejectionReason = null
+
+    if (!anchorPasses) {
+      rejectionReason = 'anchor-failed'
+    } else if (peakDb < minAbsoluteLevel) {
+      rejectionReason = 'below-absolute-floor'
+    } else if (multiplier === anchorMultiplier) {
+      // Anchor coherence IS the bar for the anchor itself, so deltas between
+      // anchorMinDeltaDb and detectionThreshold still count toward the trigger.
+      flagged = true
+    } else if (deltaDb < detectionThreshold) {
+      rejectionReason = 'below-threshold'
+    } else if (multiplier === 1) {
+      // Fundamental: no upper bound against the anchor. High-pass filters push
+      // it arbitrarily low, and an unfiltered one can sit above the anchor.
+      flagged = true
+    } else {
+      const slack = strictSlackDb[multiplier] ?? coherenceSlackDb
+      if (deltaDb <= anchorDelta + slack) flagged = true
+      else rejectionReason = 'anchor-coherence'
+    }
+
+    const inVoiceRange =
+      frequency >= VOICE_F0_RANGE_HZ[0] && frequency <= VOICE_F0_RANGE_HZ[1]
+    const voiceHarmonic = voicePitchTrusted
+      ? voiceHarmonicOf(frequency, voice.pitchHz)
+      : 0
+
+    detectionDetail.push({
+      frequency,
+      multiplier,
+      peakDb: round2(peakDb),
+      floorDb: round2(floorDb),
+      deltaDb: round2(deltaDb),
+      flagged,
+      rejectionReason,
+      looksLikeVoice: inVoiceRange,
+      voiceHarmonic,
+      // Filled in below, once the whole flagged set can be weighed.
+      matchesVoicePitch: false,
+    })
+
+    if (flagged) flaggedHarmonics.push(frequency)
+  }
+
+  // Weigh the two explanations for the flagged set before vetoing anything.
+  //
+  // A pitch match on its own is not enough. Hum whose fundamental has been
+  // high-passed away — energy at 120, 180 and 240 — has a true period of 60 Hz,
+  // below the tracker's floor, so it locks onto 120 Hz with a rock-steady
+  // contour and looks exactly like a 120 Hz speaker. What separates them is
+  // 180 Hz: it sits on the mains grid but is nowhere in a 120 Hz harmonic
+  // series. So the voice hypothesis only wins when it accounts for EVERY
+  // flagged harmonic; a single one off the series means the mains grid is the
+  // better explanation and nothing is vetoed.
+  //
+  // When both are genuinely present — a 120 Hz speaker over real 60 Hz hum —
+  // the grid wins and the shared harmonics get notched. That is the right call
+  // by default: no notch can separate hum from a voice at the same frequency,
+  // and the row stays tickable either way.
+  const flaggedDetails = detectionDetail.filter(d => d.flagged)
+  const voiceExplainsAll =
+    flaggedDetails.length > 0 && flaggedDetails.every(d => d.voiceHarmonic > 0)
+  if (voiceExplainsAll) {
+    for (const d of detectionDetail) {
+      d.matchesVoicePitch = d.voiceHarmonic > 0
+    }
+  }
+
+  // What the detector would notch once the pitch check has had its say. A
+  // single remaining harmonic is more likely musical content or a room
+  // resonance than mains hum, so it does not trigger on its own.
+  const recommendedHarmonics = detectionDetail
+    .filter(d => d.flagged && !d.matchesVoicePitch)
+    .map(d => d.frequency)
+  const triggered = recommendedHarmonics.length >= minHarmonicsToTrigger
+
+  return {
+    triggered,
+    tooShort: false,
+    analyzedSeconds,
+    anchorFrequency,
+    anchorDeltaDb: round2(anchorDelta),
+    /** Everything the spectral test flagged, before the pitch check. */
+    flaggedHarmonics,
+    /** What to actually notch — flagged, minus anything that is the speaker. */
+    recommendedHarmonics,
+    /** Measured speaker pitch, or null when none was found or trusted. */
+    voicePitchHz: voicePitchTrusted ? round2(voice.pitchHz) : null,
+    voicePitchConcentration: round2(voice.concentration),
+    detectionDetail,
+  }
+}

--- a/src/audio/effects/humNotch.js
+++ b/src/audio/effects/humNotch.js
@@ -1,0 +1,113 @@
+/**
+ * Hum Remover — real-time effect chain wrapper.
+ *
+ * The DSP lives in ../humNotchProcessor.js (narrow peaking cuts at the mains
+ * frequency and its harmonics) and runs in an AudioWorklet. The offline apply
+ * path renders through the same worklet in an OfflineAudioContext, so the
+ * preview is sample-identical to what gets written to the timeline.
+ *
+ * Unlike the other effects, this one has an analysis step: which frequencies
+ * to notch comes from src/audio/dsp/humDetect.js, run once in a Worker behind
+ * the panel's Analyze button. The effect itself stays a plain filter chain.
+ *
+ * The worklet module loads asynchronously; until it's ready the effect passes
+ * audio through unprocessed, then splices the worklet node in.
+ */
+
+import { ensureHumNotchWorklet } from '../humNotchWorkletLoader.js'
+import { createLevelTap } from './levelTap.js'
+
+export const HUM_NOTCH_DEFAULTS = {
+  frequencies: [], // Hz, chosen by the user from the detection result
+  q: 30,
+  depth: 18, // dB of cut
+}
+
+/** Map UI param names to kernel param names. */
+export function toKernelParams(params) {
+  return {
+    frequencies: params.frequencies,
+    q: params.q,
+    depthDb: params.depth,
+  }
+}
+
+export function createHumNotch(audioContext) {
+  const input = audioContext.createGain()
+  // preOutput is a stable internal hand-off — see the note in airBand.js.
+  const preOutput = audioContext.createGain()
+  const output = audioContext.createGain()
+
+  let params = { ...HUM_NOTCH_DEFAULTS }
+  let worklet = null
+  let destroyed = false
+
+  input.connect(preOutput)
+  preOutput.connect(output)
+
+  ensureHumNotchWorklet(audioContext)
+    .then(() => {
+      if (destroyed) return
+      worklet = new AudioWorkletNode(audioContext, 'hum-notch-processor', {
+        processorOptions: { params: toKernelParams(params) },
+      })
+      input.disconnect(preOutput)
+      input.connect(worklet)
+      worklet.connect(preOutput)
+    })
+    .catch((err) => {
+      console.error('Hum Remover worklet failed to load, running bypassed:', err)
+    })
+
+  const inputMonitor = audioContext.createGain()
+  input.connect(inputMonitor)
+  const outputMonitor = audioContext.createGain()
+  preOutput.connect(outputMonitor)
+
+  const inputTap = createLevelTap(audioContext, inputMonitor)
+  const outputTap = createLevelTap(audioContext, outputMonitor)
+
+  return {
+    input,
+    output,
+
+    setParam(name, value) {
+      if (name in params) {
+        params[name] = value
+        worklet?.port.postMessage({ type: 'params', params: toKernelParams(params) })
+      }
+    },
+
+    getParam(name) {
+      return params[name]
+    },
+
+    getInputLevelDb() {
+      return inputTap.getLevelDb()
+    },
+
+    getOutputLevelDb() {
+      return outputTap.getLevelDb()
+    },
+
+    destroy() {
+      destroyed = true
+      input.disconnect()
+      worklet?.disconnect()
+      preOutput.disconnect()
+      output.disconnect()
+      inputMonitor.disconnect()
+      outputMonitor.disconnect()
+      inputTap.destroy()
+      outputTap.destroy()
+    },
+  }
+}
+
+export const humNotchEffect = {
+  id: 'hum-notch',
+  name: 'Hum Remover',
+  createNodes(audioContext) {
+    return createHumNotch(audioContext)
+  },
+}

--- a/src/audio/humNotchProcessor.js
+++ b/src/audio/humNotchProcessor.js
@@ -1,0 +1,178 @@
+/**
+ * Hum Remover — worklet kernel.
+ *
+ * The apply half of the server's `humDetect` stage (server/pipeline/stages.js:404),
+ * which builds an FFmpeg chain of narrow peaking cuts:
+ *
+ *   equalizer=f=<hz>:width_type=q:width=30:g=-18
+ *
+ * Nothing more than that — a handful of very narrow biquads at the mains
+ * frequency and its harmonics. Zero latency, no analysis of its own: which
+ * frequencies to notch comes from src/audio/dsp/humDetect.js, run once behind
+ * the panel's Analyze button.
+ *
+ * This file is BOTH a normal ES module (exports HumNotchKernel and
+ * processHumNotchBuffer) AND an AudioWorklet module (registers
+ * 'hum-notch-processor'). It imports from ./dsp/, so its loader pulls it
+ * through `?worker&url` — see humNotchWorkletLoader.js.
+ *
+ * Section count is fixed at MAX_NOTCHES and unused slots are set to a
+ * pass-through biquad rather than reallocating the cascade. Rebuilding it on
+ * every change to the notch list would reset filter state and click.
+ */
+
+import { peaking, BiquadCascade } from './dsp/biquad.js'
+
+/** Enough for a mains fundamental plus harmonics well past the useful range. */
+export const MAX_NOTCHES = 8
+
+// Server constants: HUM_NOTCH_Q and HUM_NOTCH_DEPTH_DB in stages.js.
+export const HUM_NOTCH_KERNEL_DEFAULTS = {
+  frequencies: [],
+  q: 30,
+  depthDb: 18,
+}
+
+/** Unity biquad, for slots with no notch assigned. */
+const PASS_THROUGH = { b0: 1, b1: 0, b2: 0, a1: 0, a2: 0 }
+
+function clamp(v, lo, hi) {
+  return v < lo ? lo : v > hi ? hi : v
+}
+
+/**
+ * Coefficients for a notch set — shared with the response curve in the panel.
+ *
+ * The server uses FFmpeg's `equalizer` (a peaking filter at negative gain)
+ * rather than a true notch, so a finite depth is reproduced rather than an
+ * infinitely deep null. Matching that matters: an 18 dB cut leaves the
+ * surrounding spectrum far more intact than a true null would.
+ */
+export function humNotchSections(sampleRate, frequencies, q, depthDb) {
+  const nyquist = sampleRate / 2
+  const sections = []
+  for (const f of frequencies.slice(0, MAX_NOTCHES)) {
+    if (!Number.isFinite(f) || f <= 0 || f >= nyquist) continue
+    // A peaking filter at negative gain, which is exactly what FFmpeg's
+    // `equalizer` realises — not a true notch, so the cut has finite depth and
+    // leaves the surrounding spectrum far more intact than a null would.
+    sections.push(peaking(sampleRate, f, q, -depthDb, 'q'))
+  }
+  return sections
+}
+
+export class HumNotchKernel {
+  constructor(sampleRate) {
+    this.sampleRate = sampleRate
+    this.cascade = new BiquadCascade(MAX_NOTCHES, 2)
+    this.params = { ...HUM_NOTCH_KERNEL_DEFAULTS }
+    this.activeCount = 0
+    this.setParams({})
+  }
+
+  /** Merge a partial param update and rebuild coefficients. */
+  setParams(partial) {
+    const p = { ...this.params, ...partial }
+    this.params = p
+
+    const q = clamp(p.q, 0.5, 100)
+    const depthDb = clamp(p.depthDb, 0, 60)
+    const sections = humNotchSections(this.sampleRate, p.frequencies ?? [], q, depthDb)
+    this.activeCount = sections.length
+
+    for (let i = 0; i < MAX_NOTCHES; i++) {
+      this.cascade.setSection(i, i < sections.length ? sections[i] : PASS_THROUGH)
+    }
+  }
+
+  /** True when at least one notch is active — drives the panel's status text. */
+  get isActive() {
+    return this.activeCount > 0
+  }
+
+  /**
+   * Process one block.
+   *
+   * @param {Float32Array[]} inputChannels
+   * @param {Float32Array[]} outputChannels
+   * @param {number} n
+   */
+  process(inputChannels, outputChannels, n) {
+    const nIn = inputChannels.length
+    const nOut = outputChannels.length
+    if (nIn === 0 || n === 0) {
+      for (let ch = 0; ch < nOut; ch++) outputChannels[ch].fill(0, 0, n)
+      return
+    }
+
+    this.cascade.ensureChannels(nOut)
+
+    for (let ch = 0; ch < nOut; ch++) {
+      const input = inputChannels[ch < nIn ? ch : nIn - 1]
+      const out = outputChannels[ch]
+      if (this.activeCount === 0) {
+        // Nothing selected — copy rather than running eight unity biquads.
+        for (let i = 0; i < n; i++) out[i] = input[i]
+      } else {
+        this.cascade.process(input, out, n, ch)
+      }
+    }
+  }
+}
+
+/**
+ * One-shot offline convenience: process a whole buffer through a fresh kernel.
+ * Used by verification scripts; the app renders through an OfflineAudioContext
+ * running the worklet so preview and apply share the same code path.
+ */
+export function processHumNotchBuffer(channelData, sampleRate, params = {}) {
+  const kernel = new HumNotchKernel(sampleRate)
+  kernel.setParams(params)
+
+  const n = channelData[0].length
+  const output = channelData.map(() => new Float32Array(n))
+  const BLOCK = 128
+  for (let off = 0; off < n; off += BLOCK) {
+    const len = Math.min(BLOCK, n - off)
+    kernel.process(
+      channelData.map(c => c.subarray(off, off + len)),
+      output.map(c => c.subarray(off, off + len)),
+      len,
+    )
+  }
+  return { channelData: output }
+}
+
+// ── AudioWorklet registration (worklet scope only) ──────────────────────────
+
+if (typeof registerProcessor === 'function') {
+  class HumNotchWorkletProcessor extends AudioWorkletProcessor {
+    constructor(options) {
+      super()
+      this.kernel = new HumNotchKernel(sampleRate)
+      if (options?.processorOptions?.params) {
+        this.kernel.setParams(options.processorOptions.params)
+      }
+      this.port.onmessage = (e) => {
+        if (e.data?.type === 'params') this.kernel.setParams(e.data.params)
+      }
+    }
+
+    process(inputs, outputs) {
+      const input = inputs[0]
+      const output = outputs[0]
+      if (!output || output.length === 0) return true
+
+      const n = output[0].length
+      if (!input || input.length === 0) {
+        for (const ch of output) ch.fill(0)
+        return true
+      }
+
+      this.kernel.process(input, output, n)
+      return true
+    }
+  }
+
+  registerProcessor('hum-notch-processor', HumNotchWorkletProcessor)
+}

--- a/src/audio/humNotchWorkletLoader.js
+++ b/src/audio/humNotchWorkletLoader.js
@@ -1,0 +1,17 @@
+/**
+ * Load the Hum Remover worklet module into an AudioContext or
+ * OfflineAudioContext, once per context. See la2aWorkletLoader.js for why
+ * these go through `?worker&url` rather than a raw asset URL.
+ */
+import workletUrl from './humNotchProcessor.js?worker&url'
+
+const loadPromises = new WeakMap()
+
+export function ensureHumNotchWorklet(context) {
+  let promise = loadPromises.get(context)
+  if (!promise) {
+    promise = context.audioWorklet.addModule(workletUrl)
+    loadPromises.set(context, promise)
+  }
+  return promise
+}

--- a/src/audio/processing.js
+++ b/src/audio/processing.js
@@ -21,6 +21,7 @@ import {
   HUM_NOTCH_DEFAULTS,
   toKernelParams as toHumNotchKernelParams,
 } from './effects/humNotch.js'
+import { MAX_ANALYSIS_SECONDS as HUM_MAX_ANALYSIS_SECONDS } from './dsp/humDetect.js'
 
 /**
  * Render a region of the timeline to a flat PCM buffer.
@@ -363,13 +364,32 @@ export function applyHumNotchRegion(segments, start, end, params, sampleRate, ch
 /**
  * Analyse a region for mains hum in a Worker.
  *
+ * Only a bounded window is rendered. detectHum examines at most
+ * MAX_ANALYSIS_SECONDS regardless of what it is handed, so rendering the whole
+ * selection would make memory scale with selection length for no benefit —
+ * selecting a whole chapter and analysing would allocate hundreds of MB
+ * (a 60-minute mono selection is ~635 MB for the render plus as much again for
+ * the mixdown) to then throw all but ten seconds of it away.
+ *
+ * The window is centred rather than taken from the head, matching
+ * computeAutoMakeup above: hum is stationary so any representative stretch
+ * will do, and the middle of a selection is less likely to be lead-in silence.
+ *
  * Mono mixdown happens here rather than in the worker so only one channel of
  * samples crosses the boundary, and it is transferred rather than copied.
  *
  * @returns {Promise<object>} the detectHum() result — see src/audio/dsp/humDetect.js
  */
 export function analyzeHumRegion(segments, start, end, sampleRate, channels, options = {}) {
-  const channelData = renderRegionToBuffer(segments, start, end, sampleRate, channels)
+  let aStart = start
+  let aEnd = end
+  if (end - start > HUM_MAX_ANALYSIS_SECONDS) {
+    const mid = (start + end) / 2
+    aStart = mid - HUM_MAX_ANALYSIS_SECONDS / 2
+    aEnd = mid + HUM_MAX_ANALYSIS_SECONDS / 2
+  }
+
+  const channelData = renderRegionToBuffer(segments, aStart, aEnd, sampleRate, channels)
 
   // Mono mixdown — hum is common-mode, and the detector expects one channel.
   const n = channelData[0].length

--- a/src/audio/processing.js
+++ b/src/audio/processing.js
@@ -16,6 +16,11 @@ import {
   VOCAL_SAT_DEFAULTS,
   toKernelParams as toVocalSatKernelParams,
 } from './effects/vocalSat.js'
+import { ensureHumNotchWorklet } from './humNotchWorkletLoader.js'
+import {
+  HUM_NOTCH_DEFAULTS,
+  toKernelParams as toHumNotchKernelParams,
+} from './effects/humNotch.js'
 
 /**
  * Render a region of the timeline to a flat PCM buffer.
@@ -343,6 +348,55 @@ export function applyVocalSatRegion(segments, start, end, params, sampleRate, ch
     ensureWorklet: ensureVocalSatWorklet,
     processorName: 'vocal-sat-processor',
     kernelParams: toVocalSatKernelParams({ ...VOCAL_SAT_DEFAULTS, ...params }),
+  })
+}
+
+/** Apply Hum Remover notches to a region. */
+export function applyHumNotchRegion(segments, start, end, params, sampleRate, channels) {
+  return applyWorkletRegion(segments, start, end, sampleRate, channels, {
+    ensureWorklet: ensureHumNotchWorklet,
+    processorName: 'hum-notch-processor',
+    kernelParams: toHumNotchKernelParams({ ...HUM_NOTCH_DEFAULTS, ...params }),
+  })
+}
+
+/**
+ * Analyse a region for mains hum in a Worker.
+ *
+ * Mono mixdown happens here rather than in the worker so only one channel of
+ * samples crosses the boundary, and it is transferred rather than copied.
+ *
+ * @returns {Promise<object>} the detectHum() result — see src/audio/dsp/humDetect.js
+ */
+export function analyzeHumRegion(segments, start, end, sampleRate, channels, options = {}) {
+  const channelData = renderRegionToBuffer(segments, start, end, sampleRate, channels)
+
+  // Mono mixdown — hum is common-mode, and the detector expects one channel.
+  const n = channelData[0].length
+  const mono = new Float32Array(n)
+  for (const ch of channelData) {
+    for (let i = 0; i < n; i++) mono[i] += ch[i]
+  }
+  if (channels > 1) {
+    const scale = 1 / channels
+    for (let i = 0; i < n; i++) mono[i] *= scale
+  }
+
+  return new Promise((resolve, reject) => {
+    const worker = new Worker(
+      new URL('../workers/humWorker.js', import.meta.url),
+      { type: 'module' },
+    )
+    worker.onmessage = (e) => {
+      worker.terminate()
+      if (e.data.type === 'done') resolve(e.data.result)
+      else reject(new Error(e.data.message))
+    }
+    worker.onerror = (err) => {
+      worker.terminate()
+      reject(err)
+    }
+    worker.postMessage({ samples: mono, sampleRate, options }, [mono.buffer])
   })
 }
 

--- a/src/components/panels/HumRemoverModal.vue
+++ b/src/components/panels/HumRemoverModal.vue
@@ -72,6 +72,19 @@ function deltaWidth(deltaDb) {
   return Math.max(0, Math.min(100, (deltaDb / DELTA_FULL_SCALE_DB) * 100))
 }
 
+/**
+ * Accessible name for a harmonic's toggle. The visible row is a bar and a
+ * number, so the label has to carry the frequency, how prominent it is, and
+ * whether the pitch check thinks it is the voice — everything a sighted user
+ * reads off the row before deciding.
+ */
+function harmonicToggleLabel(h) {
+  if (h.deltaDb === null) return `${h.frequency} Hz — not analysed`
+  const prominence = `${h.deltaDb.toFixed(1)} dB above the surrounding floor`
+  if (h.matchesVoicePitch) return `${h.frequency} Hz, ${prominence}, matches the speaker's pitch`
+  return `${h.frequency} Hz, ${prominence}`
+}
+
 /** Why a harmonic was marked as the speaker rather than hum. */
 function voiceTooltip(h) {
   const pitch = humAnalysis.value?.voicePitchHz
@@ -171,19 +184,25 @@ async function applyAndClose() {
               class="grid items-center gap-x-[10px] py-[7px]"
               style="grid-template-columns:26px 62px 1fr 58px;border-bottom:1px solid rgba(255,255,255,.04)"
             >
+              <!-- Reads as a checkbox to assistive tech: the visual tick and
+                   the accent fill are the only other cue that a row is on. -->
               <button
                 class="w-[16px] h-[16px] rounded-[4px] cursor-pointer transition-all"
                 :style="{
                   background: h.enabled ? ACCENT : 'transparent',
                   border: `1px solid ${h.enabled ? ACCENT : 'rgba(255,255,255,.22)'}`,
                 }"
+                role="checkbox"
+                :aria-checked="h.enabled"
+                :aria-label="harmonicToggleLabel(h)"
                 :title="h.enabled ? 'Notching this frequency' : 'Leave this frequency alone'"
                 :disabled="h.deltaDb === null"
                 @click="toggleHarmonic(h.frequency)"
               >
                 <svg v-if="h.enabled" viewBox="0 0 24 24" class="w-full h-full"
                      fill="none" stroke="#1a1024" stroke-width="4"
-                     stroke-linecap="round" stroke-linejoin="round">
+                     stroke-linecap="round" stroke-linejoin="round"
+                     aria-hidden="true">
                   <polyline points="20 6 9 17 4 12" />
                 </svg>
               </button>

--- a/src/components/panels/HumRemoverModal.vue
+++ b/src/components/panels/HumRemoverModal.vue
@@ -1,0 +1,287 @@
+<script setup>
+import { computed, onMounted } from 'vue'
+import { useHumRemover } from '../../composables/useHumRemover.js'
+import { useEditorState } from '../../composables/useEditorState.js'
+import Knob from '../knobs/Knob.vue'
+import SegmentedSwitch from '../knobs/SegmentedSwitch.vue'
+import LevelMeter from '../meters/LevelMeter.vue'
+import FloatingWindow from './FloatingWindow.vue'
+import ApplyAction from '../ui/ApplyAction.vue'
+
+defineProps({ z: { type: Number, default: 500 } })
+
+const {
+  humFundamental, humQ, humDepth, humHarmonics, humAnalysis, humAnalyzing,
+  humPreview, humInputDb, humOutputDb, isStale, hasEnabledNotches, hasSelection,
+  togglePreview, analyze, toggleHarmonic, setFundamental, syncQ, syncDepth,
+  apply, teardown, closeModal,
+} = useHumRemover()
+
+const { state } = useEditorState()
+
+onMounted(() => {
+  if (!humPreview.value) togglePreview()
+})
+
+const ACCENT = '#c9a7ff'
+
+const MAINS_OPTIONS = [
+  { value: 60, label: '60 Hz', title: 'US, Canada, Japan (east)' },
+  { value: 50, label: '50 Hz', title: 'Europe, UK, Australia, Asia' },
+]
+
+const enabledCount = computed(() => humHarmonics.value.filter(h => h.enabled).length)
+
+const statusLine = computed(() => {
+  if (humAnalyzing.value) return 'Analysing…'
+  if (!humAnalysis.value) return 'Analyse the selection to find mains hum.'
+  if (humAnalysis.value.tooShort) {
+    return 'Selection too short — analyse at least one second.'
+  }
+  if (isStale.value) return 'Audio changed since analysis — analyse again.'
+  const a = humAnalysis.value
+  const vetoed = a.detectionDetail.filter(d => d.flagged && d.matchesVoicePitch)
+  if (!a.triggered && enabledCount.value === 0) {
+    if (vetoed.length > 0) {
+      const list = vetoed.map(d => `${d.frequency} Hz`).join(', ')
+      return `Energy at ${list} tracks the voice (${a.voicePitchHz} Hz), not mains hum.`
+    }
+    return `No hum found. Anchor ${a.anchorFrequency} Hz was ${a.anchorDeltaDb} dB above the floor.`
+  }
+  const suffix = vetoed.length > 0 ? ` ${vetoed.length} left out as voice.` : ''
+  return `${enabledCount.value} notch${enabledCount.value === 1 ? '' : 'es'} active.${suffix}`
+})
+
+function formatQ(v) {
+  return String(Math.round(v))
+}
+
+function formatDepth(v) {
+  return `−${v.toFixed(0)}`
+}
+
+/**
+ * Bar width for a harmonic's prominence. Full scale is 48 dB: real hum sits
+ * roughly 20–50 dB above the local noise floor, so a narrower scale pins every
+ * detection to the end of the track and stops conveying anything.
+ */
+const DELTA_FULL_SCALE_DB = 48
+
+function deltaWidth(deltaDb) {
+  if (deltaDb === null) return 0
+  return Math.max(0, Math.min(100, (deltaDb / DELTA_FULL_SCALE_DB) * 100))
+}
+
+/** Why a harmonic was marked as the speaker rather than hum. */
+function voiceTooltip(h) {
+  const pitch = humAnalysis.value?.voicePitchHz
+  if (!pitch) return 'This looks like the voice rather than hum.'
+  const which = h.voiceHarmonic === 1
+    ? `the speaker's pitch (${pitch} Hz)`
+    : `harmonic ${h.voiceHarmonic} of the speaker's pitch (${pitch} Hz)`
+  return `${h.frequency} Hz is ${which}, so this energy is probably the voice, not hum. Notching it will thin the recording. Tick it anyway if you can hear hum here.`
+}
+
+function rejectionLabel(h) {
+  if (h.flagged) return null
+  switch (h.rejectionReason) {
+    case 'anchor-failed': return 'no hum signature'
+    case 'below-absolute-floor': return 'too quiet'
+    case 'below-threshold': return 'not prominent enough'
+    case 'anchor-coherence': return 'louder than the hum pattern'
+    case 'selection-too-short': return '—'
+    default: return null
+  }
+}
+
+function togglePlayback() {
+  window.dispatchEvent(new CustomEvent('wavely:toggle-play'))
+}
+
+function close() {
+  teardown()
+}
+
+async function applyAndClose() {
+  await apply()
+  teardown()
+  closeModal()
+}
+</script>
+
+<template>
+  <FloatingWindow
+    window-id="hum-remover"
+    :z="z"
+    :width="620"
+    :accent="ACCENT"
+    brand-lead="HUM"
+    brand-tail="REMOVER"
+    :engaged="humPreview"
+    @toggle-engaged="togglePreview"
+    @close="close"
+  >
+    <div class="px-[26px] pt-[22px] pb-[24px]">
+      <div class="flex items-start justify-between gap-[20px]">
+        <LevelMeter :db="humInputDb" label="IN" :height="176" />
+
+        <div class="flex-1">
+          <!-- Mains frequency + analyse -->
+          <div class="flex items-center justify-between gap-[16px]">
+            <SegmentedSwitch
+              :model-value="humFundamental"
+              @update:model-value="setFundamental"
+              :options="MAINS_OPTIONS"
+              :accent="ACCENT"
+              :disabled="humAnalyzing"
+              caption="Mains frequency"
+            />
+            <button
+              class="px-[18px] py-[9px] rounded-lg cursor-pointer transition-all disabled:cursor-default"
+              :style="{
+                background: humAnalyzing ? 'rgba(255,255,255,.05)' : 'rgba(201,167,255,.16)',
+                border: `1px solid ${humAnalyzing ? 'rgba(255,255,255,.09)' : 'rgba(201,167,255,.42)'}`,
+                color: humAnalyzing ? 'rgba(255,255,255,.4)' : '#dcc7ff',
+                font: `700 10px 'JetBrains Mono',monospace`,
+                letterSpacing: '.1em',
+                opacity: hasSelection ? 1 : 0.4,
+              }"
+              :disabled="humAnalyzing || !hasSelection"
+              @click="analyze"
+            >{{ humAnalyzing ? 'ANALYSING…' : 'ANALYSE' }}</button>
+          </div>
+
+          <!-- Harmonic table -->
+          <div class="mt-[16px]">
+            <div
+              class="grid items-center gap-x-[10px] pb-[6px] uppercase"
+              style="grid-template-columns:26px 62px 1fr 58px;font:700 8.5px/1 'JetBrains Mono',monospace;letter-spacing:.16em;color:rgba(255,255,255,.28);border-bottom:1px solid rgba(255,255,255,.06)"
+            >
+              <span></span><span>Freq</span><span>Above floor</span><span class="text-right">Δ dB</span>
+            </div>
+
+            <div v-if="humHarmonics.length === 0"
+                 class="py-[22px] text-center"
+                 style="font:500 10.5px 'Inter';color:rgba(255,255,255,.3)">
+              No analysis yet.
+            </div>
+
+            <div
+              v-for="h in humHarmonics" :key="h.frequency"
+              class="grid items-center gap-x-[10px] py-[7px]"
+              style="grid-template-columns:26px 62px 1fr 58px;border-bottom:1px solid rgba(255,255,255,.04)"
+            >
+              <button
+                class="w-[16px] h-[16px] rounded-[4px] cursor-pointer transition-all"
+                :style="{
+                  background: h.enabled ? ACCENT : 'transparent',
+                  border: `1px solid ${h.enabled ? ACCENT : 'rgba(255,255,255,.22)'}`,
+                }"
+                :title="h.enabled ? 'Notching this frequency' : 'Leave this frequency alone'"
+                :disabled="h.deltaDb === null"
+                @click="toggleHarmonic(h.frequency)"
+              >
+                <svg v-if="h.enabled" viewBox="0 0 24 24" class="w-full h-full"
+                     fill="none" stroke="#1a1024" stroke-width="4"
+                     stroke-linecap="round" stroke-linejoin="round">
+                  <polyline points="20 6 9 17 4 12" />
+                </svg>
+              </button>
+
+              <span style="font:600 11px 'JetBrains Mono',monospace;color:rgba(255,255,255,.72)">
+                {{ h.frequency }}
+              </span>
+
+              <!-- Prominence bar, plus why a harmonic was left unticked -->
+              <div class="flex items-center gap-[8px]">
+                <div class="flex-1 h-[5px] rounded-full overflow-hidden"
+                     style="background:rgba(255,255,255,.06)">
+                  <div
+                    class="h-full rounded-full transition-all"
+                    :style="{
+                      width: `${deltaWidth(h.deltaDb)}%`,
+                      background: h.flagged ? ACCENT : 'rgba(255,255,255,.2)',
+                    }"
+                  />
+                </div>
+                <span
+                  v-if="h.matchesVoicePitch"
+                  :title="voiceTooltip(h)"
+                  style="font:700 7.5px 'JetBrains Mono',monospace;letter-spacing:.08em;color:#ffb27a;white-space:nowrap"
+                >IS VOICE</span>
+                <span
+                  v-else-if="rejectionLabel(h)"
+                  style="font:500 8.5px 'Inter';color:rgba(255,255,255,.26);white-space:nowrap"
+                >{{ rejectionLabel(h) }}</span>
+              </div>
+
+              <span class="text-right"
+                    style="font:600 11px 'JetBrains Mono',monospace;color:rgba(255,255,255,.55)">
+                {{ h.deltaDb === null ? '—' : h.deltaDb.toFixed(1) }}
+              </span>
+            </div>
+          </div>
+
+          <p
+            class="mt-[12px]"
+            :style="{
+              font: `500 10px/1.5 'Inter'`,
+              color: isStale ? '#ffb27a' : 'rgba(255,255,255,.35)',
+            }"
+          >{{ statusLine }}</p>
+        </div>
+
+        <LevelMeter :db="humOutputDb" label="OUT" :height="176" />
+      </div>
+
+      <!-- Notch shape -->
+      <div class="flex items-center justify-between mt-[18px] pt-[16px]"
+           style="border-top:1px solid rgba(255,255,255,.06)">
+        <p style="font:500 10px/1.5 'Inter';color:rgba(255,255,255,.3);max-width:320px">
+          Narrow cuts at the mains frequency and its harmonics. Deeper and wider
+          removes more hum but takes more of the voice with it.
+        </p>
+        <div class="flex gap-[26px]">
+          <div class="w-[80px]">
+            <Knob
+              :model-value="humQ"
+              @update:model-value="syncQ"
+              :min="5" :max="60" :step="1" :value-font-px="13"
+              label="Width Q" :accent="ACCENT" :format-value="formatQ"
+              :disabled="!humPreview"
+            />
+          </div>
+          <div class="w-[80px]">
+            <Knob
+              :model-value="humDepth"
+              @update:model-value="syncDepth"
+              :min="0" :max="40" :step="1" :value-font-px="13"
+              label="Depth dB" :accent="ACCENT" :format-value="formatDepth"
+              :disabled="!humPreview"
+            />
+          </div>
+        </div>
+      </div>
+
+      <div class="mt-[16px]">
+        <ApplyAction
+          size="md"
+          show-preview
+          previewable
+          :previewing="state.isPlaying"
+          :accent="ACCENT"
+          text-color="#1a1024"
+          :met="hasSelection"
+          message="Make a selection to remove hum"
+          label="Apply Hum Removal"
+          :disabled="!humPreview || !hasEnabledNotches"
+          :disabled-hint="!humPreview
+            ? 'Turn Hum Remover on to apply it'
+            : 'Analyse and select at least one frequency to notch'"
+          @toggle-preview="togglePlayback"
+          @apply="applyAndClose"
+        />
+      </div>
+    </div>
+  </FloatingWindow>
+</template>

--- a/src/composables/useHumRemover.js
+++ b/src/composables/useHumRemover.js
@@ -1,0 +1,287 @@
+import { computed, ref } from 'vue'
+import { useEditorState } from './useEditorState.js'
+import { useWindows } from './useWindows.js'
+import {
+  analyzeHumRegion,
+  applyHumNotchRegion,
+  computePeakCache,
+} from '../audio/processing.js'
+import { getEffectChain } from '../audio/effectChain.js'
+import { humNotchEffect, HUM_NOTCH_DEFAULTS } from '../audio/effects/humNotch.js'
+
+// Registry id of this plugin's window. Must match the entry in src/ui/registry.js.
+export const HUM_REMOVER_WINDOW_ID = 'hum-remover'
+
+// Singleton reactive state shared between the sidebar trigger and the modal.
+const humFundamental = ref(60) // 50 Hz (EU) or 60 Hz (US/JP)
+const humQ = ref(HUM_NOTCH_DEFAULTS.q)
+const humDepth = ref(HUM_NOTCH_DEFAULTS.depth)
+
+/**
+ * One entry per harmonic from the last analysis, each with its measurement and
+ * an `enabled` flag. This is the replacement for the server's F0 veto: rather
+ * than silently dropping a candidate that sits on the speaker's pitch, the
+ * measurement is shown and the choice is the user's.
+ */
+const humHarmonics = ref([])
+const humAnalysis = ref(null) // full detectHum() result, or null
+const humAnalyzing = ref(false)
+
+/**
+ * Identifies the audio the current analysis was run against. Any edit mints a
+ * new buffer id, so a stale result is easy to spot — notching frequencies
+ * measured from audio that has since been replaced would be quietly wrong.
+ */
+const analyzedKey = ref(null)
+
+const humPreview = ref(false)
+const humInputDb = ref(-Infinity)
+const humOutputDb = ref(-Infinity)
+let meterId = null
+
+/** Frequencies the user currently has ticked. */
+function enabledFrequencies() {
+  return humHarmonics.value.filter(h => h.enabled).map(h => h.frequency)
+}
+
+function currentParams() {
+  return {
+    frequencies: enabledFrequencies(),
+    q: humQ.value,
+    depth: humDepth.value,
+  }
+}
+
+export function useHumRemover() {
+  const {
+    state, getAudioContext, hasSelection, replaceRegion, setPeakCache,
+    startProcessing, endProcessing, showToast,
+  } = useEditorState()
+  const { openWindow, closeWindow } = useWindows()
+
+  /** Key describing the exact audio a result was measured from. */
+  function selectionKey() {
+    if (!state.selection || !state.currentFile) return null
+    const { start, end } = state.selection
+    const ids = state.segments.map(s => s.sourceBufferId ?? 'silence').join(',')
+    return `${start.toFixed(6)}:${end.toFixed(6)}:${ids}`
+  }
+
+  /** True when the analysis no longer describes the current selection. */
+  const isStale = computed(
+    () => humAnalysis.value !== null && analyzedKey.value !== selectionKey(),
+  )
+
+  const hasEnabledNotches = computed(() => humHarmonics.value.some(h => h.enabled))
+
+  function initChain() {
+    const ctx = getAudioContext()
+    const chain = getEffectChain(ctx)
+    if (!chain.effects.find(e => e.id === humNotchEffect.id)) {
+      chain.addEffect(humNotchEffect)
+    }
+    return chain
+  }
+
+  function startMeters(chain) {
+    stopMeters()
+    function tick() {
+      const nodes = chain.effects.find(e => e.id === humNotchEffect.id)?.nodes
+      if (nodes) {
+        humInputDb.value = nodes.getInputLevelDb()
+        humOutputDb.value = nodes.getOutputLevelDb()
+      }
+      meterId = requestAnimationFrame(tick)
+    }
+    meterId = requestAnimationFrame(tick)
+  }
+
+  function stopMeters() {
+    if (meterId !== null) {
+      cancelAnimationFrame(meterId)
+      meterId = null
+    }
+    humInputDb.value = -Infinity
+    humOutputDb.value = -Infinity
+  }
+
+  function pushAllParams(chain) {
+    for (const [name, value] of Object.entries(currentParams())) {
+      chain.updateParam(humNotchEffect.id, name, value)
+    }
+  }
+
+  function togglePreview() {
+    const chain = initChain()
+    humPreview.value = !humPreview.value
+    chain.setEnabled(humNotchEffect.id, humPreview.value)
+
+    if (humPreview.value) {
+      pushAllParams(chain)
+      startMeters(chain)
+    } else {
+      stopMeters()
+    }
+  }
+
+  function pushParam(name, value) {
+    if (!humPreview.value) return
+    const chain = getEffectChain(getAudioContext())
+    chain.updateParam(humNotchEffect.id, name, value)
+  }
+
+  function pushFrequencies() {
+    pushParam('frequencies', enabledFrequencies())
+  }
+
+  function syncQ(v) {
+    humQ.value = v
+    pushParam('q', v)
+  }
+
+  function syncDepth(v) {
+    humDepth.value = v
+    pushParam('depth', v)
+  }
+
+  /** Tick or untick one harmonic. */
+  function toggleHarmonic(frequency) {
+    const h = humHarmonics.value.find(x => x.frequency === frequency)
+    if (!h) return
+    h.enabled = !h.enabled
+    pushFrequencies()
+  }
+
+  /**
+   * Switch mains frequency. The previous analysis was measured against the old
+   * harmonic series, so it is discarded rather than left to look current.
+   */
+  function setFundamental(hz) {
+    if (humFundamental.value === hz) return
+    humFundamental.value = hz
+    clearAnalysis()
+  }
+
+  function clearAnalysis() {
+    humAnalysis.value = null
+    humHarmonics.value = []
+    analyzedKey.value = null
+    pushFrequencies()
+  }
+
+  /** Run detection over the current selection. */
+  async function analyze() {
+    if (!state.selection || !state.currentFile) return
+    const { start, end } = state.selection
+
+    humAnalyzing.value = true
+    try {
+      const result = await analyzeHumRegion(
+        state.segments, start, end,
+        state.currentFile.sampleRate, state.currentFile.channels,
+        { fundamental: humFundamental.value },
+      )
+
+      humAnalysis.value = result
+      analyzedKey.value = selectionKey()
+      // Pre-tick what the detector recommends — flagged, minus anything the
+      // pitch check identified as the speaker's own voice. Every harmonic is
+      // still listed with its measurement so the user can override either way.
+      humHarmonics.value = result.detectionDetail.map(d => ({
+        ...d,
+        enabled: d.flagged && !d.matchesVoicePitch,
+      }))
+      pushFrequencies()
+
+      if (result.tooShort) {
+        showToast('Selection too short to detect hum reliably')
+      } else if (!result.triggered) {
+        const vetoed = result.detectionDetail.filter(d => d.flagged && d.matchesVoicePitch)
+        showToast(
+          vetoed.length > 0
+            ? 'No hum found — the energy there is the voice itself'
+            : 'No mains hum detected',
+        )
+      } else {
+        const n = result.recommendedHarmonics.length
+        showToast(`Hum detected on ${n} harmonic${n === 1 ? '' : 's'}`)
+      }
+    } catch (err) {
+      console.error('Hum analysis failed:', err)
+      showToast('Hum analysis failed')
+    } finally {
+      humAnalyzing.value = false
+    }
+  }
+
+  async function apply() {
+    if (!state.selection) return
+    const { start, end } = state.selection
+
+    const wasPreviewing = humPreview.value
+    if (wasPreviewing) togglePreview()
+
+    startProcessing('Removing hum...')
+    try {
+      const buffer = await applyHumNotchRegion(
+        state.segments, start, end,
+        currentParams(),
+        state.currentFile.sampleRate, state.currentFile.channels,
+      )
+      const bufferId = replaceRegion(start, end, buffer)
+      const cache = await computePeakCache(buffer, 256)
+      setPeakCache(bufferId, cache)
+      showToast('Hum removed')
+      // The audio just changed, so the measurement no longer describes it.
+      clearAnalysis()
+    } catch (err) {
+      console.error('Hum removal failed:', err)
+      showToast('Hum removal failed')
+    } finally {
+      endProcessing()
+    }
+  }
+
+  function teardown() {
+    stopMeters()
+    if (humPreview.value) {
+      const chain = getEffectChain(getAudioContext())
+      chain.setEnabled(humNotchEffect.id, false)
+      humPreview.value = false
+    }
+  }
+
+  function openModal() {
+    openWindow(HUM_REMOVER_WINDOW_ID)
+  }
+
+  function closeModal() {
+    closeWindow(HUM_REMOVER_WINDOW_ID)
+  }
+
+  return {
+    humFundamental,
+    humQ,
+    humDepth,
+    humHarmonics,
+    humAnalysis,
+    humAnalyzing,
+    humPreview,
+    humInputDb,
+    humOutputDb,
+    isStale,
+    hasEnabledNotches,
+    hasSelection,
+    togglePreview,
+    analyze,
+    clearAnalysis,
+    toggleHarmonic,
+    setFundamental,
+    syncQ,
+    syncDepth,
+    apply,
+    teardown,
+    openModal,
+    closeModal,
+  }
+}

--- a/src/ui/icons.js
+++ b/src/ui/icons.js
@@ -45,6 +45,9 @@ export const ICONS = {
   // A rising shelf: flat, then a gentle knee up to a plateau — the air curve.
   air: '<path d="M2 17c5 0 8 0 11-5s5-5 9-5"/><path d="M2 21h20" opacity=".35"/>',
   noise: '<path d="M12 2a3 3 0 013 3v7a3 3 0 01-6 0V5a3 3 0 013-3z"/><path d="M19 10v2a7 7 0 01-14 0v-2M12 19v3M8 23h8"/>',
+  // Hum: a steady sine with a notch taken out of its middle — the mains tone
+  // and the cut being placed on it.
+  hum: '<path d="M2 12c1.5-4 3-4 4.5 0s3 4 4.5 0"/><path d="M13 12c1.5-4 3-4 4.5 0s3 4 4.5 0" opacity=".35"/><path d="M12 4v16" stroke-dasharray="2 2"/>',
   // Waveform, flat stretch, waveform — the gap being targeted. Was a second
   // copy of the `cut` scissors, which is the clipboard verb's glyph.
   removeSilence: '<path d="M3 6v12M7 9v6"/><path d="M9.5 12h5"/><path d="M17 9v6M21 6v12"/>',

--- a/src/ui/registry.js
+++ b/src/ui/registry.js
@@ -8,6 +8,7 @@ import PresetsPanel from '../components/panels/PresetsPanel.vue'
 import LA2AModal from '../components/panels/LA2AModal.vue'
 import FET1176Modal from '../components/panels/FET1176Modal.vue'
 import AirBandModal from '../components/panels/AirBandModal.vue'
+import HumRemoverModal from '../components/panels/HumRemoverModal.vue'
 import NormalizeWindow from '../components/panels/windows/NormalizeWindow.vue'
 import VocalSaturationWindow from '../components/panels/windows/VocalSaturationWindow.vue'
 import NoiseReductionWindow from '../components/panels/windows/NoiseReductionWindow.vue'
@@ -265,13 +266,25 @@ export const OPERATIONS = [
     component: AirBandModal,
   },
   {
+    id: 'hum-remover',
+    label: 'Hum Remover',
+    desc: 'Notch out mains buzz',
+    category: 'effects',
+    group: 'Clean',
+    icon: 'hum',
+    keywords: ['hum', 'buzz', 'mains', 'ground loop', '50hz', '60hz', 'notch', 'electrical'],
+    requires: 'selection',
+    surface: 'window',
+    component: HumRemoverModal,
+  },
+  {
     id: 'noise-reduction',
     label: 'Noise Reduction',
     desc: 'Remove background noise',
     category: 'effects',
     group: 'Clean',
     icon: 'noise',
-    keywords: ['denoise', 'hiss', 'hum', 'background', 'deepfilternet', 'clean'],
+    keywords: ['denoise', 'hiss', 'background', 'deepfilternet', 'clean'],
     requires: 'selection',
     surface: 'window',
     component: NoiseReductionWindow,

--- a/src/workers/humWorker.js
+++ b/src/workers/humWorker.js
@@ -1,0 +1,22 @@
+/**
+ * Hum detection worker.
+ *
+ * The analysis is a single 2^19-point FFT — a few hundred milliseconds of
+ * straight-line arithmetic. Running it on the main thread would drop frames
+ * and freeze the knobs mid-drag, so it lives here.
+ *
+ * Message in:  { samples: Float32Array (mono, transferred), sampleRate, options }
+ * Message out: { type: 'done', result } | { type: 'error', message }
+ */
+
+import { detectHum } from '../audio/dsp/humDetect.js'
+
+self.onmessage = (e) => {
+  const { samples, sampleRate, options } = e.data
+  try {
+    const result = detectHum(samples, sampleRate, options)
+    self.postMessage({ type: 'done', result })
+  } catch (err) {
+    self.postMessage({ type: 'error', message: err?.message ?? String(err) })
+  }
+}

--- a/test/dsp/humDetect.test.js
+++ b/test/dsp/humDetect.test.js
@@ -1,0 +1,303 @@
+/**
+ * Run with:  npm test
+ */
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  detectHum,
+  MIN_ANALYSIS_SECONDS,
+  HUM_DETECT_DEFAULTS,
+} from '../../src/audio/dsp/humDetect.js'
+
+const SR = 44100
+
+/**
+ * Build a test signal: broadband noise floor, an optional voice-like harmonic
+ * stack, and an optional mains hum series.
+ *
+ * `humDb` is the level of the hum fundamental relative to full scale; each
+ * harmonic above it is scaled by `humRolloff^(k-1)`, which is roughly how real
+ * transformer hum behaves.
+ */
+function makeSignal({
+  seconds = 3,
+  noiseDb = -70,
+  humFundamental = null,
+  humDb = -45,
+  humHarmonics = [1, 2, 3, 4, 5],
+  humRolloff = 0.7,
+  voiceF0 = null,
+  voiceDb = -25,
+  voiceJitterHz = 4,
+} = {}) {
+  const n = Math.round(seconds * SR)
+  const out = new Float32Array(n)
+
+  const noiseAmp = Math.pow(10, noiseDb / 20)
+  let s = 987654321
+  for (let i = 0; i < n; i++) {
+    s = (s * 1103515245 + 12345) & 0x7fffffff
+    out[i] = noiseAmp * (s / 0x3fffffff - 1)
+  }
+
+  if (humFundamental) {
+    const base = Math.pow(10, humDb / 20)
+    for (const k of humHarmonics) {
+      const amp = base * Math.pow(humRolloff, k - 1)
+      const f = humFundamental * k
+      const phase = k * 0.7
+      for (let i = 0; i < n; i++) {
+        out[i] += amp * Math.sin((2 * Math.PI * f * i) / SR + phase)
+      }
+    }
+  }
+
+  if (voiceF0) {
+    // Slow pitch wobble, integrated so phase stays continuous. A dead-steady
+    // harmonic stack is not what a voice looks like, and the pitch check keys
+    // off how the contour behaves — so the fixture has to wobble.
+    const base = Math.pow(10, voiceDb / 20)
+    let phase = 0
+    for (let i = 0; i < n; i++) {
+      const f0 = voiceF0 + voiceJitterHz * Math.sin((2 * Math.PI * 3.1 * i) / SR)
+      phase += (2 * Math.PI * f0) / SR
+      for (let k = 1; k <= 8; k++) {
+        if (f0 * k >= SR / 2) break
+        out[i] += (base / k) * 0.8 * Math.sin(k * phase + k * 1.3)
+      }
+    }
+  }
+
+  return out
+}
+
+test('detects a clean 60 Hz hum series', () => {
+  const sig = makeSignal({ humFundamental: 60 })
+  const r = detectHum(sig, SR)
+  assert.equal(r.triggered, true, 'should trigger')
+  assert.equal(r.tooShort, false)
+  assert.equal(r.anchorFrequency, 120, 'anchors on the 2nd harmonic')
+  assert.ok(r.anchorDeltaDb > HUM_DETECT_DEFAULTS.anchorMinDeltaDb)
+  assert.ok(r.flaggedHarmonics.includes(60))
+  assert.ok(r.flaggedHarmonics.includes(120))
+})
+
+test('detects 50 Hz mains when told to look there', () => {
+  const sig = makeSignal({ humFundamental: 50 })
+  const r = detectHum(sig, SR, { fundamental: 50 })
+  assert.equal(r.triggered, true)
+  assert.equal(r.anchorFrequency, 100)
+  assert.ok(r.flaggedHarmonics.includes(100))
+})
+
+test('does not find 60 Hz hum in a 50 Hz recording', () => {
+  // The harmonic series barely overlaps: 50/100/150/200/250 vs 60/120/180/240/300.
+  const sig = makeSignal({ humFundamental: 50 })
+  const r = detectHum(sig, SR, { fundamental: 60 })
+  assert.equal(r.triggered, false, 'wrong mains setting should not trigger')
+})
+
+test('a voice sitting on the mains grid is not mistaken for hum', () => {
+  // The blind spot in the spectral test: a 120 Hz speaker puts real vocal
+  // energy on 120/240/360, exactly where 60 Hz hum harmonics live. The
+  // spectral pass cannot tell them apart — the pitch check is what does.
+  const sig = makeSignal({ voiceF0: 120 })
+  const r = detectHum(sig, SR)
+
+  assert.ok(
+    r.flaggedHarmonics.includes(120),
+    'the spectral test is expected to flag it — that is the blind spot',
+  )
+  assert.ok(r.voicePitchHz !== null, 'a speaker pitch should have been measured')
+  assert.ok(Math.abs(r.voicePitchHz - 120) < 6, `measured pitch ${r.voicePitchHz}`)
+
+  const at120 = r.detectionDetail.find(d => d.frequency === 120)
+  assert.equal(at120.matchesVoicePitch, true, 'pitch check should identify it as voice')
+  assert.equal(at120.voiceHarmonic, 1)
+
+  // 240 Hz is the speaker's second harmonic — real vocal energy, and notching
+  // it thins the voice just as badly as notching the fundamental.
+  const at240 = r.detectionDetail.find(d => d.frequency === 240)
+  assert.equal(at240.matchesVoicePitch, true, 'harmonics of the pitch count too')
+  assert.equal(at240.voiceHarmonic, 2)
+
+  assert.equal(r.triggered, false, `false positive: ${JSON.stringify(r.recommendedHarmonics)}`)
+  assert.deepEqual(r.recommendedHarmonics, [], 'nothing should be recommended')
+})
+
+test('a scattered pitch contour is not trusted', () => {
+  // Pure hum is periodic, so an autocorrelation tracker locks onto multiples of
+  // it and reports a "pitch" that is really nothing of the kind. The
+  // concentration test is what stops that vetoing genuine hum harmonics.
+  const r = detectHum(makeSignal({ humFundamental: 60 }), SR)
+  assert.equal(r.voicePitchHz, null, 'no speaker should be reported on pure hum')
+  assert.ok(
+    r.voicePitchConcentration < 0.5,
+    `contour was unexpectedly tight: ${r.voicePitchConcentration}`,
+  )
+})
+
+test('the pitch check can be turned off', () => {
+  // Confirms the veto is what suppresses the previous case, not something else.
+  const sig = makeSignal({ voiceF0: 120 })
+  const r = detectHum(sig, SR, { voicePitchCheck: false })
+  assert.equal(r.triggered, true, 'without the pitch check this is a false positive')
+  for (const d of r.detectionDetail) {
+    assert.equal(d.matchesVoicePitch, false)
+  }
+})
+
+test('real hum under a voice at a different pitch still gets found', () => {
+  // A 200 Hz speaker over 60 Hz hum: the pitch check must not veto the hum.
+  const sig = makeSignal({ humFundamental: 60, humDb: -40, voiceF0: 200, voiceDb: -26 })
+  const r = detectHum(sig, SR)
+  assert.equal(r.triggered, true, 'hum should survive the pitch check')
+  assert.ok(r.recommendedHarmonics.includes(120), `got ${r.recommendedHarmonics}`)
+  const at120 = r.detectionDetail.find(d => d.frequency === 120)
+  assert.equal(at120.matchesVoicePitch, false, '120 Hz is not this speaker’s pitch')
+})
+
+test('a 180 Hz male fundamental alone does not trigger', () => {
+  // The case the server's F0 veto exists to catch. The anchored coherence
+  // model should already reject it: 180 Hz is prominent but 120 Hz is not, so
+  // the anchor fails and nothing is flagged.
+  const sig = makeSignal({ voiceF0: 180, voiceDb: -20 })
+  const r = detectHum(sig, SR)
+  assert.equal(r.triggered, false)
+  const at180 = r.detectionDetail.find(d => d.frequency === 180)
+  assert.equal(at180.flagged, false)
+})
+
+test('reports which candidates could plausibly be a voice', () => {
+  const r = detectHum(makeSignal({ humFundamental: 60 }), SR)
+  const byFreq = Object.fromEntries(r.detectionDetail.map(d => [d.frequency, d]))
+  assert.equal(byFreq[60].looksLikeVoice, false, '60 Hz is below any voice F0')
+  assert.equal(byFreq[120].looksLikeVoice, true)
+  assert.equal(byFreq[180].looksLikeVoice, true)
+  assert.equal(byFreq[300].looksLikeVoice, true)
+  // Pure hum with no voice present: in range, but no trusted pitch to match.
+  for (const d of r.detectionDetail) {
+    assert.equal(d.matchesVoicePitch, false, `${d.frequency} Hz falsely read as voice`)
+  }
+})
+
+test('a genuine hum harmonic near the speaker is not vetoed', () => {
+  // 200 Hz speaker over 60 Hz hum. A naive per-frame overlap test reads ~14%
+  // of frames within 15 Hz of 180 (the low tail of the pitch wobble) and would
+  // veto a real hum harmonic. Anchoring on the median pitch instead does not.
+  const sig = makeSignal({ humFundamental: 60, humDb: -40, voiceF0: 200, voiceDb: -26, voiceJitterHz: 6 })
+  const r = detectHum(sig, SR)
+  assert.ok(Math.abs(r.voicePitchHz - 200) < 8, `measured pitch ${r.voicePitchHz}`)
+  const at180 = r.detectionDetail.find(d => d.frequency === 180)
+  assert.equal(at180.matchesVoicePitch, false, '180 Hz is hum, not the speaker')
+  assert.ok(r.recommendedHarmonics.includes(180), `got ${r.recommendedHarmonics}`)
+})
+
+test('recommendedHarmonics is flaggedHarmonics minus the voice matches', () => {
+  const r = detectHum(makeSignal({ voiceF0: 120 }), SR)
+  const vetoed = r.detectionDetail.filter(d => d.flagged && d.matchesVoicePitch)
+  assert.ok(vetoed.length > 0, 'this fixture is meant to exercise the veto')
+  assert.deepEqual(
+    r.recommendedHarmonics,
+    r.flaggedHarmonics.filter(f => !vetoed.some(v => v.frequency === f)),
+  )
+})
+
+test('silence does not trigger', () => {
+  const r = detectHum(new Float32Array(SR * 2), SR)
+  assert.equal(r.triggered, false)
+  // Every harmonic should be rejected, not merely unflagged by accident.
+  for (const d of r.detectionDetail) {
+    assert.equal(d.flagged, false)
+    assert.ok(d.rejectionReason, `${d.frequency} Hz had no rejection reason`)
+  }
+})
+
+test('broadband noise alone does not trigger', () => {
+  const r = detectHum(makeSignal({ noiseDb: -40 }), SR)
+  assert.equal(r.triggered, false)
+})
+
+test('a single isolated tone does not trigger', () => {
+  // One flagged harmonic is more likely a resonance than mains hum, so
+  // minHarmonicsToTrigger holds it back.
+  const sig = makeSignal({
+    humFundamental: 60, humHarmonics: [2], humDb: -40, humRolloff: 1,
+  })
+  const r = detectHum(sig, SR)
+  assert.ok(r.flaggedHarmonics.length <= 1, `flagged ${r.flaggedHarmonics}`)
+  assert.equal(r.triggered, false)
+})
+
+test('finds hum whose fundamental has been high-passed away', () => {
+  // The reason the detector anchors on the 2nd harmonic: user HPFs routinely
+  // kill 60 Hz and leave 120 Hz untouched.
+  const sig = makeSignal({ humFundamental: 60, humHarmonics: [2, 3, 4] })
+  const r = detectHum(sig, SR)
+  assert.equal(r.triggered, true, 'should still detect without a fundamental')
+  assert.ok(r.flaggedHarmonics.includes(120))
+  assert.ok(!r.flaggedHarmonics.includes(60), '60 Hz is absent, should not flag')
+})
+
+test('the mains grid wins when the voice cannot explain every flagged harmonic', () => {
+  // High-passed hum (120/180/240) has a true period of 60 Hz, below the
+  // tracker's floor, so it locks onto 120 Hz with a perfectly steady contour —
+  // indistinguishable from a 120 Hz speaker by pitch alone. 180 Hz is what
+  // separates them: on the mains grid, absent from a 120 Hz harmonic series.
+  const r = detectHum(makeSignal({ humFundamental: 60, humHarmonics: [2, 3, 4] }), SR)
+
+  assert.ok(r.voicePitchHz !== null, 'the tracker is expected to report a pitch here')
+  assert.ok(Math.abs(r.voicePitchHz - 120) < 6, `locked onto ${r.voicePitchHz}`)
+  assert.equal(r.voicePitchConcentration, 1, 'and to be entirely confident about it')
+
+  // ...and yet nothing is vetoed, because 180 Hz does not fit that series.
+  for (const d of r.detectionDetail) {
+    assert.equal(d.matchesVoicePitch, false, `${d.frequency} Hz should not be vetoed`)
+  }
+  assert.equal(r.triggered, true)
+  assert.deepEqual(r.recommendedHarmonics, [120, 180, 240])
+})
+
+test('refuses to guess on a selection that is too short', () => {
+  const short = makeSignal({ seconds: MIN_ANALYSIS_SECONDS * 0.5, humFundamental: 60 })
+  const r = detectHum(short, SR)
+  assert.equal(r.tooShort, true)
+  assert.equal(r.triggered, false)
+  assert.ok(r.analyzedSeconds < MIN_ANALYSIS_SECONDS)
+  for (const d of r.detectionDetail) {
+    assert.equal(d.rejectionReason, 'selection-too-short')
+  }
+})
+
+test('caps analysis at MAX_ANALYSIS_SECONDS', () => {
+  const long = makeSignal({ seconds: 14, humFundamental: 60 })
+  const r = detectHum(long, SR)
+  assert.equal(r.analyzedSeconds, 10)
+})
+
+test('reports the measurements the UI displays', () => {
+  const r = detectHum(makeSignal({ humFundamental: 60 }), SR)
+  for (const d of r.detectionDetail) {
+    assert.equal(typeof d.frequency, 'number')
+    assert.equal(typeof d.peakDb, 'number')
+    assert.equal(typeof d.floorDb, 'number')
+    assert.ok(Math.abs(d.deltaDb - (d.peakDb - d.floorDb)) < 0.02, 'delta must be peak - floor')
+    assert.equal(typeof d.flagged, 'boolean')
+  }
+})
+
+test('rejects an anchorMultiplier outside the harmonics list', () => {
+  assert.throws(
+    () => detectHum(makeSignal({ humFundamental: 60 }), SR, { harmonics: [1, 3, 5] }),
+    /anchorMultiplier/,
+  )
+})
+
+test('louder hum reads as more prominent', () => {
+  const quiet = detectHum(makeSignal({ humFundamental: 60, humDb: -60 }), SR)
+  const loud = detectHum(makeSignal({ humFundamental: 60, humDb: -35 }), SR)
+  assert.ok(
+    loud.anchorDeltaDb > quiet.anchorDeltaDb + 10,
+    `expected a clear gap, got ${quiet.anchorDeltaDb} vs ${loud.anchorDeltaDb}`,
+  )
+})


### PR DESCRIPTION
Ports the server's humDetect stage. The apply half is a handful of narrow peaking cuts at the mains frequency and its harmonics, which is exactly what the FFmpeg chain in stages.js does; the detection half was already pure JavaScript in humEQ.js, so it moves to a Worker with the audio source swapped from an FFmpeg pipe to an AudioBuffer. Nothing touches the server.

This is the first effect with an analysis step, and the first to run entirely client-side end to end. Analysis takes 280-500 ms and is capped at 10 s of audio regardless of selection length.

The detector anchors on the 2nd harmonic rather than the fundamental, because user high-pass filters routinely kill 60 Hz while leaving 120 Hz untouched. The mains frequency is now selectable — the server hardcodes 60 Hz, which a manual effect should not.

The interesting part is what replaces the server's F0 veto. That veto silently drops any candidate sitting on the speaker's pitch, using an F0 contour and Silero VAD labels. Here the check runs against F0Tracker with an energy gate standing in for Silero, and reports rather than discards: the row stays visible and tickable, labelled with which harmonic of the speaker's pitch it is.

Getting that right took three passes, each driven by a case that broke the previous one:

  - A 120 Hz speaker puts real vocal energy on 120/240, exactly where 60 Hz hum harmonics live. The spectral test cannot tell them apart at all — this is the blind spot the veto exists to cover.

  - Testing each candidate against the raw F0 histogram, as the server does, is only safe because Silero has already excluded non-speech frames. Without it the tracker also runs on hum-only frames, and hum is periodic: on a pure 60 Hz series it returns estimates scattered from 60-330 Hz with a concentration of 0.07, where a real speaker sits at 1.0. Anchoring on the median pitch and requiring concentration is what separates "a voice is present" from "the tracker is chasing a tone". Without it a genuine hum harmonic at 180 Hz gets vetoed as voice.

  - Even that is not enough. Hum whose fundamental has been high-passed away — 120/180/240 — has a true period of 60 Hz, below the tracker's floor, so it locks onto 120 Hz with a rock-steady contour and looks exactly like a 120 Hz speaker. What separates them is 180 Hz: on the mains grid, absent from a 120 Hz harmonic series. So the voice hypothesis only wins when it accounts for every flagged harmonic.

Also fixes the voicing gate, which used reference_eq.py's `noise floor + 8 dB` and collapsed on steady content: when every frame sits at the same level the 10th percentile IS that level, so nothing cleared the gate and the pitch pass saw no voiced frames at all.

Verified in Chromium that the worklet render is bit-identical to the direct kernel render (maxErr 0, mono and stereo), that the notches cut hum harmonics by 17.8-18.2 dB while leaving voice harmonics within 0.12 dB, that an empty notch list is a true bypass, and that analyse-then-apply works against a loaded file with no console errors.

Adds 20 tests. Synthetic voice fixtures now carry pitch jitter — a dead-steady harmonic stack is not what a voice looks like, and the pitch check keys off how the contour behaves.


Claude-Session: https://claude.ai/code/session_019b1Nt95cB9aGTecubKbo9L