### PR TITLE
Add Resonance Suppressor and latency compensation (Phases 0.3 + 4)

### DIFF
--- a/src/audio/dsp/stft.js
+++ b/src/audio/dsp/stft.js
@@ -51,6 +51,12 @@ export class StftProcessor {
 
     // Scratch, so steady-state processing allocates nothing.
     this.frame = new Float64Array(fftSize)
+    /**
+     * The same frame before the analysis window is applied. Pitch estimation
+     * wants this: estimate_f0_contour.py autocorrelates unwindowed frames, and
+     * a Hann taper would bias the autocorrelation toward shorter lags.
+     */
+    this.rawFrame = new Float64Array(fftSize)
     this.specRe = new Float64Array(this.binCount)
     this.specIm = new Float64Array(this.binCount)
 
@@ -120,13 +126,16 @@ export class StftProcessor {
   }
 
   _processFrame(frameFn) {
-    const { fftSize, hopSize, window, inRing, frame, ola, olaWin, specRe, specIm } =
-      this
+    const { fftSize, hopSize, window, inRing, frame, rawFrame, ola, olaWin,
+      specRe, specIm } = this
 
-    // Gather the ring into linear order (oldest first) and window it.
+    // Gather the ring into linear order (oldest first), keeping both the raw
+    // frame and the windowed one.
     let r = this.inWrite // oldest sample sits at the write cursor
     for (let i = 0; i < fftSize; i++) {
-      frame[i] = inRing[r] * window[i]
+      const x = inRing[r]
+      rawFrame[i] = x
+      frame[i] = x * window[i]
       r = r + 1 === fftSize ? 0 : r + 1
     }
 

--- a/src/audio/effects/resonance.js
+++ b/src/audio/effects/resonance.js
@@ -1,0 +1,145 @@
+/**
+ * Resonance Suppressor — real-time effect chain wrapper.
+ *
+ * The DSP lives in ../resonanceProcessor.js (cepstral reference envelope,
+ * spike detection, per-bin attack/release) and runs in an AudioWorklet. The
+ * offline apply path renders through the same worklet in an
+ * OfflineAudioContext, so the preview is sample-identical to what gets written
+ * to the timeline.
+ *
+ * THIS IS THE FIRST LATENT EFFECT. Its STFT holds back a full fftSize before a
+ * sample is fully reconstructed, so `latencySamples` is non-zero and the apply
+ * path has to render long and trim — see applyWorkletRegion in ../processing.js.
+ * Everything shipped before this was zero-latency, which is why that code path
+ * had never needed the compensation.
+ *
+ * The worklet module loads asynchronously; until it's ready the effect passes
+ * audio through unprocessed, then splices the worklet node in.
+ */
+
+import { ensureResonanceWorklet } from '../resonanceWorkletLoader.js'
+import { createLevelTap } from './levelTap.js'
+
+/** Matches FFT_SIZE in resonanceProcessor.js. */
+export const RESONANCE_LATENCY_SAMPLES = 2048
+
+// Defaults are the acx_audiobook preset's resonanceSuppressor block
+// (src/audio/presets.js), which is the tuning these were chosen against.
+export const RESONANCE_DEFAULTS = {
+  depth: 0.67,
+  sharpness: 0.8,
+  selectivity: 8,
+  attack: 15, // ms
+  release: 80, // ms
+  maxReduction: 36, // dB
+  freqFloor: 40, // Hz
+  freqCeil: 20000, // Hz
+  mode: 'soft', // 'soft' | 'hard'
+  preserveHarmonics: true,
+}
+
+/** Map UI param names to kernel param names. */
+export function toKernelParams(params) {
+  return {
+    depth: params.depth,
+    sharpness: params.sharpness,
+    selectivity: params.selectivity,
+    attackMs: params.attack,
+    releaseMs: params.release,
+    maxReductionDb: params.maxReduction,
+    freqFloorHz: params.freqFloor,
+    freqCeilHz: params.freqCeil,
+    mode: params.mode,
+    preserveHarmonics: params.preserveHarmonics,
+  }
+}
+
+export function createResonance(audioContext) {
+  const input = audioContext.createGain()
+  // preOutput is a stable internal hand-off — see the note in airBand.js.
+  const preOutput = audioContext.createGain()
+  const output = audioContext.createGain()
+
+  let params = { ...RESONANCE_DEFAULTS }
+  let worklet = null
+  let destroyed = false
+  let grDb = 0
+
+  input.connect(preOutput)
+  preOutput.connect(output)
+
+  ensureResonanceWorklet(audioContext)
+    .then(() => {
+      if (destroyed) return
+      worklet = new AudioWorkletNode(audioContext, 'resonance-processor', {
+        processorOptions: { params: toKernelParams(params) },
+      })
+      worklet.port.onmessage = (e) => {
+        if (e.data?.type === 'gr') grDb = e.data.grDb
+      }
+      input.disconnect(preOutput)
+      input.connect(worklet)
+      worklet.connect(preOutput)
+    })
+    .catch((err) => {
+      console.error('Resonance Suppressor worklet failed to load, running bypassed:', err)
+    })
+
+  const inputMonitor = audioContext.createGain()
+  input.connect(inputMonitor)
+  const outputMonitor = audioContext.createGain()
+  preOutput.connect(outputMonitor)
+
+  const inputTap = createLevelTap(audioContext, inputMonitor)
+  const outputTap = createLevelTap(audioContext, outputMonitor)
+
+  return {
+    input,
+    output,
+
+    setParam(name, value) {
+      if (name in params) {
+        params[name] = value
+        worklet?.port.postMessage({ type: 'params', params: toKernelParams(params) })
+      }
+    },
+
+    getParam(name) {
+      return params[name]
+    },
+
+    // Negative dB, matching DynamicsCompressorNode.reduction conventions.
+    getReduction() {
+      return -grDb
+    },
+
+    getInputLevelDb() {
+      return inputTap.getLevelDb()
+    },
+
+    getOutputLevelDb() {
+      return outputTap.getLevelDb()
+    },
+
+    destroy() {
+      destroyed = true
+      input.disconnect()
+      worklet?.disconnect()
+      preOutput.disconnect()
+      output.disconnect()
+      inputMonitor.disconnect()
+      outputMonitor.disconnect()
+      inputTap.destroy()
+      outputTap.destroy()
+    },
+  }
+}
+
+export const resonanceEffect = {
+  id: 'resonance-suppressor',
+  name: 'Resonance Suppressor',
+  latencySamples: RESONANCE_LATENCY_SAMPLES,
+  createNodes(audioContext) {
+    return createResonance(audioContext)
+  },
+}

--- a/src/audio/processing.js
+++ b/src/audio/processing.js
@@ -16,6 +16,12 @@ import {
   VOCAL_SAT_DEFAULTS,
   toKernelParams as toVocalSatKernelParams,
 } from './effects/vocalSat.js'
+import { ensureResonanceWorklet } from './resonanceWorkletLoader.js'
+import {
+  RESONANCE_DEFAULTS,
+  RESONANCE_LATENCY_SAMPLES,
+  toKernelParams as toResonanceKernelParams,
+} from './effects/resonance.js'
 
 /**
  * Render a region of the timeline to a flat PCM buffer.
@@ -271,26 +277,53 @@ export function computeFET1176AutoMakeup(segments, start, end, kernelParams, sam
 }
 
 /**
- * Render a region through a compressor worklet in an OfflineAudioContext.
+ * Render a region through an effect's worklet in an OfflineAudioContext.
  *
- * Both compressors apply this way, running the exact same worklet module as
- * the real-time preview, so the applied result is sample-identical to what
- * the user heard.
+ * Every effect applies this way, running the exact same worklet module as the
+ * real-time preview, so the applied result is sample-identical to what the
+ * user heard.
+ *
+ * LATENCY. An effect that reports `latencySamples > 0` emits output that lags
+ * its input — the resonance suppressor's STFT holds back a full fftSize before
+ * a sample is fully reconstructed. Rendering exactly `numSamples` would then
+ * write back audio shifted late by that much, with the tail cut off: silence
+ * spliced in at the head of the region and the last `latency` samples of real
+ * audio lost. So the render is extended, the region is extended to match (real
+ * audio where the timeline has it, silence past the end), and the leading
+ * `latency` samples are dropped from the result.
+ *
+ * Zero-latency effects take the original path untouched — no extra render, no
+ * copy.
  */
 async function applyWorkletRegion(
   segments, start, end, sampleRate, channels,
-  { ensureWorklet, processorName, kernelParams },
+  { ensureWorklet, processorName, kernelParams, latencySamples = 0 },
 ) {
-  const channelData = renderRegionToBuffer(segments, start, end, sampleRate, channels)
   const duration = end - start
   const numSamples = Math.ceil(duration * sampleRate)
+  const latency = Math.max(0, Math.round(latencySamples))
+  const renderSamples = numSamples + latency
 
-  const offlineCtx = new OfflineAudioContext(channels, numSamples, sampleRate)
+  // Pull `latency` extra samples of real audio from past the region where the
+  // timeline has them, so the tail is reconstructed from context rather than
+  // from silence. renderRegionToBuffer zero-fills beyond the end of the
+  // timeline, which is exactly what we want there.
+  const channelData = renderRegionToBuffer(
+    segments, start, end + latency / sampleRate, sampleRate, channels,
+  )
+
+  const offlineCtx = new OfflineAudioContext(channels, renderSamples, sampleRate)
   await ensureWorklet(offlineCtx)
 
-  const inputBuffer = offlineCtx.createBuffer(channels, numSamples, sampleRate)
+  const inputBuffer = offlineCtx.createBuffer(channels, renderSamples, sampleRate)
   for (let ch = 0; ch < channels; ch++) {
-    inputBuffer.copyToChannel(channelData[ch], ch)
+    // renderRegionToBuffer sizes to ceil() of the extended duration, which can
+    // differ from renderSamples by a sample; copy only what fits.
+    const src = channelData[ch]
+    inputBuffer.copyToChannel(
+      src.length > renderSamples ? src.subarray(0, renderSamples) : src,
+      ch,
+    )
   }
 
   const source = offlineCtx.createBufferSource()
@@ -307,7 +340,20 @@ async function applyWorkletRegion(
   node.connect(offlineCtx.destination)
   source.start(0)
 
-  return await offlineCtx.startRendering()
+  const rendered = await offlineCtx.startRendering()
+  if (latency === 0) return rendered
+
+  // Drop the leading `latency` samples so output sample 0 corresponds to input
+  // sample 0, and hand back a buffer of exactly the region's length — that is
+  // what replaceRegion expects to splice in.
+  const trimmed = offlineCtx.createBuffer(channels, numSamples, sampleRate)
+  for (let ch = 0; ch < channels; ch++) {
+    trimmed.copyToChannel(
+      rendered.getChannelData(ch).subarray(latency, latency + numSamples),
+      ch,
+    )
+  }
+  return trimmed
 }
 
 /** Apply OptoSmooth (LA-2A) compression to a region. */
@@ -343,6 +389,21 @@ export function applyVocalSatRegion(segments, start, end, params, sampleRate, ch
     ensureWorklet: ensureVocalSatWorklet,
     processorName: 'vocal-sat-processor',
     kernelParams: toVocalSatKernelParams({ ...VOCAL_SAT_DEFAULTS, ...params }),
+  })
+}
+
+/**
+ * Apply Resonance Suppression to a region.
+ *
+ * The only caller so far that passes a non-zero latency — its STFT delays the
+ * output by a full frame, which applyWorkletRegion renders long and trims.
+ */
+export function applyResonanceRegion(segments, start, end, params, sampleRate, channels) {
+  return applyWorkletRegion(segments, start, end, sampleRate, channels, {
+    ensureWorklet: ensureResonanceWorklet,
+    processorName: 'resonance-processor',
+    kernelParams: toResonanceKernelParams({ ...RESONANCE_DEFAULTS, ...params }),
+    latencySamples: RESONANCE_LATENCY_SAMPLES,
   })
 }
 

--- a/src/audio/resonanceProcessor.js
+++ b/src/audio/resonanceProcessor.js
@@ -215,8 +215,8 @@ export class ResonanceKernel {
       ? Math.exp(-this.frameRateMs / p.releaseMs)
       : 0
 
-    // Harmonic geometry changed, so cached masks no longer apply.
-    this.maskCache.clear()
+    // Harmonic geometry changed (band limits), so cached masks no longer apply.
+    if ('freqFloorHz' in partial || 'freqCeilHz' in partial) this.maskCache.clear()
   }
 
   reset() {

--- a/src/audio/resonanceProcessor.js
+++ b/src/audio/resonanceProcessor.js
@@ -1,0 +1,497 @@
+/**
+ * Resonance Suppressor — worklet kernel.
+ *
+ * A realtime port of the server's `resonanceSuppressor` stage
+ * (server/scripts/resonance_suppressor.py). Soothe-style dynamic suppression:
+ * per STFT frame, build a reference envelope that sits at the inter-harmonic
+ * floor, treat whatever protrudes above it as a resonance, and duck it.
+ *
+ * This file is BOTH a normal ES module (exports ResonanceKernel and
+ * processResonanceBuffer) AND an AudioWorklet module (registers
+ * 'resonance-processor').
+ *
+ * THE ALGORITHM IS ALREADY CAUSAL. That is the whole reason this port is
+ * possible without an analysis pass. Per frame:
+ *
+ *   1. magnitude in dB
+ *   2. cepstral lifter → reference envelope at the inter-harmonic floor
+ *   3. spike = magnitude − envelope, thresholded at `selectivity`, soft-kneed,
+ *      scaled by `depth`, clipped to `maxReductionDb`
+ *   4. harmonic-protected bins zeroed, Gaussian spread along the bin axis,
+ *      zeroed again, out-of-band zeroed
+ *   5. per-bin attack/release IIR at the frame rate
+ *   6. gain applied to the complex spectrum, inverse FFT, overlap-add
+ *
+ * The 1394-line Python is mostly machinery this port does not need: multi-pass
+ * chains, `sibilant_only` gating, band-summary reporting, and the pitch
+ * transition detector (a ±5-frame lookahead that would cost another 58 ms of
+ * latency and is outside the core parameter set).
+ *
+ * HARMONIC PROTECTION IS NOT OPTIONAL. Cepstral liftering puts the reference at
+ * the inter-harmonic floor, so vocal harmonics protrude above it and read as
+ * resonances. Without the mask the suppressor eats the voice — the server
+ * refuses to run the stage at all when `preserve_harmonics` is on and no F0 is
+ * available. Here F0Tracker supplies a per-frame pitch, which is what makes the
+ * mask possible live.
+ *
+ * THREE APPROXIMATIONS vs. the server, all consequences of streaming:
+ *
+ *   - Lifter cutoff comes from a rolling median pitch rather than the whole
+ *     file's median.
+ *   - Voicing comes from the pitch tracker's correlation gate plus an absolute
+ *     energy floor, in place of Silero labels. Non-voiced frames get a zero
+ *     target so the IIR decays through them.
+ *   - The cepstral reference is computed over the full spectrum rather than the
+ *     server's band-restricted variant. Band restriction exists for passes with
+ *     a very small lifter cutoff (L≈3, the sibilant-only passes), where the
+ *     kept coefficients collapse onto the band mean; at the cutoffs this
+ *     parameter set produces (L≈150–300) it makes little difference, and the
+ *     band-restricted transform length is not a power of two. Detection and
+ *     reduction are still band-limited — only the reference differs, and only
+ *     for frequency ranges much narrower than the default 40 Hz–20 kHz.
+ */
+
+import { StftProcessor } from './dsp/stft.js'
+import { F0Tracker } from './dsp/f0.js'
+import { getFFT } from './dsp/fft.js'
+
+const FFT_SIZE = 2048
+const HOP_SIZE = 512
+
+/** Matches `eps` in resonance_suppressor.py's process(). */
+const MAG_EPS = 1e-10
+
+/** Lifter cutoff before any pitch has been measured. */
+const DEFAULT_F0_HZ = 60
+
+// Harmonic protection geometry — DEFAULT_PARAMS in resonance_suppressor.py.
+const HARMONIC_WIDTH_BINS = 2
+const HARMONIC_WIDTH_PCT = 0.01
+const MAX_HARMONIC = 100
+
+/** Bound the per-pitch mask cache so a long session cannot grow it forever. */
+const MASK_CACHE_LIMIT = 256
+
+/**
+ * Absolute energy floor for the voicing decision, in dB of frame mean-square.
+ *
+ * Voicing is decided by F0Tracker's correlation-ratio gate, which already
+ * rejects noise and silence; this only stops the tracker chasing a pitch in
+ * near-silence. It is deliberately absolute rather than relative to a measured
+ * noise floor: a floor tracker rises toward the signal, so on continuous speech
+ * with no silence in it the floor converges on the speech level and the gate
+ * never opens at all.
+ */
+const VOICING_FLOOR_DB = -60
+
+export const RESONANCE_KERNEL_DEFAULTS = {
+  depth: 0.67,
+  sharpness: 0.8,
+  selectivity: 8,
+  attackMs: 15,
+  releaseMs: 80,
+  maxReductionDb: 36,
+  freqFloorHz: 40,
+  freqCeilHz: 20000,
+  mode: 'soft', // 'soft' | 'hard'
+  preserveHarmonics: true,
+}
+
+function clamp(v, lo, hi) {
+  return v < lo ? lo : v > hi ? hi : v
+}
+
+export class ResonanceKernel {
+  constructor(sampleRate) {
+    this.sampleRate = sampleRate
+    this.binCount = (FFT_SIZE >>> 1) + 1
+    this.binWidth = sampleRate / FFT_SIZE
+    this.frameRateMs = (HOP_SIZE / sampleRate) * 1000
+
+    this.fft = getFFT(FFT_SIZE)
+    this.f0 = new F0Tracker({
+      sampleRate,
+      frameSize: FFT_SIZE,
+      defaultF0: DEFAULT_F0_HZ,
+    })
+
+    // One STFT per channel. Detection runs on channel 0 and the resulting gain
+    // is applied to every channel: a spectral cut computed independently per
+    // channel would move the stereo image around on correlated material, and
+    // for mono — what narrators actually record — it is identical to the
+    // server either way.
+    this.stfts = []
+
+    const bins = this.binCount
+    this.magDb = new Float64Array(bins)
+    this.envDb = new Float64Array(bins)
+    this.cepstrum = new Float64Array(FFT_SIZE)
+    this.envRe = new Float64Array(bins)
+    this.envIm = new Float64Array(bins)
+    this.reduction = new Float64Array(bins)
+    this.spread = new Float64Array(bins)
+    this.prevGr = new Float64Array(bins)
+    this.gain = new Float64Array(bins)
+    this.activeBins = new Uint8Array(bins)
+
+    this.maskCache = new Map()
+    this.currentMask = null
+
+    this.frameIndex = 0
+
+    // Metering — peak reduction seen since the last read.
+    this.maxReductionSeen = 0
+
+    // Bound once so the hot path passes a stable reference rather than
+    // allocating a closure per block.
+    this._analyzeAndApply = (re, im, bins) => {
+      this._analyzeFrame(re, im)
+      this._applyGain(re, im, bins)
+    }
+    this._applyGain = (re, im, bins) => {
+      const g = this.gain
+      for (let k = 0; k < bins; k++) {
+        re[k] *= g[k]
+        im[k] *= g[k]
+      }
+    }
+
+    this.params = { ...RESONANCE_KERNEL_DEFAULTS }
+    this.setParams({})
+  }
+
+  /** Algorithmic latency, in samples. Reported to the offline apply path. */
+  get latencySamples() {
+    return FFT_SIZE
+  }
+
+  /** Merge a partial param update and recompute derived state. */
+  setParams(partial) {
+    const p = { ...this.params, ...partial }
+    this.params = p
+
+    this.depth = clamp(p.depth, 0, 1)
+    this.selectivity = Math.max(0, p.selectivity)
+    this.maxReductionDb = Math.max(0, p.maxReductionDb)
+    this.softKnee = p.mode !== 'hard'
+    this.kneeWidth = Math.max(this.selectivity * 0.5, 1e-6)
+    this.preserveHarmonics = !!p.preserveHarmonics
+
+    const nyquist = this.sampleRate / 2
+    this.freqFloorHz = clamp(p.freqFloorHz, 0, nyquist)
+    this.freqCeilHz = clamp(p.freqCeilHz, this.freqFloorHz, nyquist)
+    for (let k = 0; k < this.binCount; k++) {
+      const f = k * this.binWidth
+      this.activeBins[k] = f >= this.freqFloorHz && f <= this.freqCeilHz ? 1 : 0
+    }
+
+    // Gaussian spread kernel, width set by sharpness.
+    // spread_bins = int(30 * (1 - sharpness)); sigma = spread_bins / 3.
+    const sharpness = clamp(p.sharpness, 0, 1)
+    const spreadBins = Math.trunc(30 * (1 - sharpness))
+    if (spreadBins >= 2) {
+      const sigma = spreadBins / 3
+      const half = spreadBins
+      const kernel = new Float64Array(2 * half + 1)
+      let peak = 0
+      for (let i = -half; i <= half; i++) {
+        const v = Math.exp(-0.5 * (i / sigma) ** 2)
+        kernel[i + half] = v
+        if (v > peak) peak = v
+      }
+      for (let i = 0; i < kernel.length; i++) kernel[i] /= peak
+      this.spreadKernel = kernel
+      this.spreadHalf = half
+    } else {
+      this.spreadKernel = null
+      this.spreadHalf = 0
+    }
+
+    // Attack/release at the frame rate: exp(-frame_period / tau).
+    this.attackCoeff = p.attackMs > 0
+      ? Math.exp(-this.frameRateMs / p.attackMs)
+      : 0
+    this.releaseCoeff = p.releaseMs > 0
+      ? Math.exp(-this.frameRateMs / p.releaseMs)
+      : 0
+
+    // Harmonic geometry changed, so cached masks no longer apply.
+    this.maskCache.clear()
+  }
+
+  reset() {
+    for (const s of this.stfts) s.reset()
+    this.f0.reset()
+    this.prevGr.fill(0)
+    this.frameIndex = 0
+    this.maskCache.clear()
+  }
+
+  /**
+   * Boolean protection mask for one pitch: bins belonging to a harmonic of f0.
+   * Cached per rounded pitch, as the Python does.
+   */
+  _harmonicMask(f0) {
+    if (!f0 || f0 <= 0) return null
+    const key = Math.round(f0)
+    const cached = this.maskCache.get(key)
+    if (cached) return cached
+
+    if (this.maskCache.size >= MASK_CACHE_LIMIT) this.maskCache.clear()
+
+    const mask = new Uint8Array(this.binCount)
+    const nyquist = this.sampleRate / 2
+    for (let h = 1; h <= MAX_HARMONIC; h++) {
+      const freq = h * f0
+      if (freq > this.freqCeilHz || freq >= nyquist) break
+      const center = Math.round(freq / this.binWidth)
+      const pctHalf = Math.round((freq * HARMONIC_WIDTH_PCT) / this.binWidth)
+      const half = Math.max(HARMONIC_WIDTH_BINS, pctHalf)
+      const lo = Math.max(0, center - half)
+      const hi = Math.min(this.binCount - 1, center + half)
+      for (let k = lo; k <= hi; k++) mask[k] = 1
+    }
+    this.maskCache.set(key, mask)
+    return mask
+  }
+
+  /**
+   * Cepstral reference envelope: treat the log-magnitude spectrum as a signal,
+   * invert it, zero the high-quefrency middle (where the pitch peak and every
+   * overtone live), and transform back. What is left sits at the inter-harmonic
+   * floor rather than riding the harmonic peaks, so a resonance is visible at
+   * its true prominence even when it sits next to a harmonic.
+   */
+  _cepstralEnvelope(lifterCutoff) {
+    const { fft, magDb, cepstrum, envRe, envIm, envDb, binCount } = this
+
+    fft.irfft(magDb, null, cepstrum)
+
+    // Zero indices [L, FFT_SIZE - L] inclusive, matching
+    // `liftered[:, L : n_fft - L + 1] = 0`.
+    const L = Math.max(1, Math.min(lifterCutoff, FFT_SIZE >>> 1))
+    for (let i = L; i <= FFT_SIZE - L; i++) cepstrum[i] = 0
+
+    fft.rfft(cepstrum, envRe, envIm)
+    for (let k = 0; k < binCount; k++) envDb[k] = envRe[k]
+  }
+
+  /** One analysis frame: measure, decide a per-bin gain, leave it in `gain`. */
+  _analyzeFrame(specRe, specIm) {
+    const {
+      magDb, envDb, reduction, spread, prevGr, gain, activeBins, binCount,
+      selectivity, depth, maxReductionDb, softKnee, kneeWidth,
+    } = this
+
+    for (let k = 0; k < binCount; k++) {
+      const mag = Math.hypot(specRe[k], specIm[k])
+      magDb[k] = 20 * Math.log10(mag + MAG_EPS)
+    }
+
+    // Pitch drives both the lifter cutoff and the protection mask, so it is
+    // measured from the unwindowed frame the STFT kept for us.
+    const raw = this.stfts[0].rawFrame
+    let sumSq = 0
+    for (let i = 0; i < FFT_SIZE; i++) sumSq += raw[i] * raw[i]
+    const frameDb = 10 * Math.log10(sumSq / FFT_SIZE + 1e-20)
+
+    const { f0, voiced } = this.f0.estimate(raw, frameDb > VOICING_FLOOR_DB)
+    const medianF0 = this.f0.median ?? DEFAULT_F0_HZ
+
+    // lifter_cutoff = max(20, int(0.40 * sr / f0))
+    const lifterCutoff = medianF0 > 0
+      ? Math.max(20, Math.trunc((0.4 * this.sampleRate) / medianF0))
+      : 60
+
+    this._cepstralEnvelope(lifterCutoff)
+
+    const mask = this.preserveHarmonics && voiced ? this._harmonicMask(f0) : null
+
+    // Spike detection → soft knee → depth → clip.
+    for (let k = 0; k < binCount; k++) {
+      if (!activeBins[k]) {
+        reduction[k] = 0
+        continue
+      }
+      const above = magDb[k] - envDb[k] - selectivity
+      if (above <= 0) {
+        reduction[k] = 0
+        continue
+      }
+      const curve = softKnee && above < kneeWidth
+        ? (above * above) / (2 * kneeWidth)
+        : above
+      const r = curve * depth
+      reduction[k] = r > maxReductionDb ? maxReductionDb : r
+    }
+
+    // Harmonic protection, pre-spread: zero these before the kernel runs so a
+    // harmonic's own prominence is never smeared into the gaps beside it.
+    if (mask) {
+      for (let k = 0; k < binCount; k++) if (mask[k]) reduction[k] = 0
+    }
+
+    // Gaussian spread along the bin axis.
+    if (this.spreadKernel) {
+      const kern = this.spreadKernel
+      const half = this.spreadHalf
+      for (let k = 0; k < binCount; k++) {
+        let acc = 0
+        const lo = Math.max(0, k - half)
+        const hi = Math.min(binCount - 1, k + half)
+        for (let j = lo; j <= hi; j++) acc += reduction[j] * kern[j - k + half]
+        spread[k] = acc > maxReductionDb ? maxReductionDb : acc
+      }
+      // Post-spread: re-protect harmonics that neighbouring spikes bled into,
+      // and hard-limit the reduction to the active band. Without a spread
+      // kernel neither is needed — the pre-spread pass already zeroed the mask,
+      // and the detection loop never wrote outside the active band.
+      for (let k = 0; k < binCount; k++) {
+        reduction[k] = (mask && mask[k]) || !activeBins[k] ? 0 : spread[k]
+      }
+    }
+
+    // Non-voiced frames target zero, so the IIR decays through silence rather
+    // than holding a cut across it.
+    if (!voiced) reduction.fill(0)
+
+    // Per-bin attack/release at the frame rate.
+    const { attackCoeff, releaseCoeff } = this
+    let frameMax = 0
+    for (let k = 0; k < binCount; k++) {
+      const target = reduction[k]
+      const c = target >= prevGr[k] ? attackCoeff : releaseCoeff
+      const v = c * prevGr[k] + (1 - c) * target
+      prevGr[k] = v
+      if (v > frameMax) frameMax = v
+      gain[k] = Math.pow(10, -v / 20)
+    }
+    if (frameMax > this.maxReductionSeen) this.maxReductionSeen = frameMax
+
+    this.frameIndex++
+  }
+
+  _ensureChannels(n) {
+    while (this.stfts.length < n) {
+      this.stfts.push(new StftProcessor({ fftSize: FFT_SIZE, hopSize: HOP_SIZE }))
+    }
+  }
+
+  /**
+   * Process one block.
+   *
+   * @param {Float32Array[]} inputChannels
+   * @param {Float32Array[]} outputChannels
+   * @param {number} n
+   */
+  process(inputChannels, outputChannels, n) {
+    const nIn = inputChannels.length
+    const nOut = outputChannels.length
+    if (nIn === 0 || n === 0) {
+      for (let ch = 0; ch < nOut; ch++) outputChannels[ch].fill(0, 0, n)
+      return
+    }
+
+    this._ensureChannels(nOut)
+
+    // Walk the block in pieces no longer than one hop, so at most one STFT
+    // frame completes per piece. Channel 0 computes the gain for that frame and
+    // the other channels reuse it; without the cap a block spanning two frames
+    // would leave every channel but the first applying the LAST frame's gain to
+    // both. Web Audio's 128-sample quantum never spans a frame, but the offline
+    // path and any future caller are free to hand over larger blocks.
+    let off = 0
+    while (off < n) {
+      const len = Math.min(HOP_SIZE, n - off)
+      const whole = off === 0 && len === n
+      for (let ch = 0; ch < nOut; ch++) {
+        const source = inputChannels[ch < nIn ? ch : nIn - 1]
+        const target = outputChannels[ch]
+        this.stfts[ch].process(
+          whole ? source : source.subarray(off, off + len),
+          whole ? target : target.subarray(off, off + len),
+          len,
+          ch === 0 ? this._analyzeAndApply : this._applyGain,
+        )
+      }
+      off += len
+    }
+  }
+
+  /** Peak reduction since the last call, in dB. */
+  readMetering() {
+    const v = this.maxReductionSeen
+    this.maxReductionSeen = 0
+    return v
+  }
+}
+
+/**
+ * One-shot offline convenience: process a whole buffer through a fresh kernel.
+ *
+ * Note the output is delayed by `latencySamples` relative to the input, exactly
+ * as the worklet's is — this returns the raw stream without trimming, so a
+ * caller comparing against the worklet render sees the same thing.
+ */
+export function processResonanceBuffer(channelData, sampleRate, params = {}) {
+  const kernel = new ResonanceKernel(sampleRate)
+  kernel.setParams(params)
+
+  const n = channelData[0].length
+  const output = channelData.map(() => new Float32Array(n))
+  const BLOCK = 128
+  for (let off = 0; off < n; off += BLOCK) {
+    const len = Math.min(BLOCK, n - off)
+    kernel.process(
+      channelData.map(c => c.subarray(off, off + len)),
+      output.map(c => c.subarray(off, off + len)),
+      len,
+    )
+  }
+  return { channelData: output, latencySamples: kernel.latencySamples }
+}
+
+// ── AudioWorklet registration (worklet scope only) ──────────────────────────
+
+if (typeof registerProcessor === 'function') {
+  // ~21 ms at 44.1 kHz — enough for a smooth meter without flooding the port.
+  const METER_INTERVAL_SAMPLES = 1024
+
+  class ResonanceWorkletProcessor extends AudioWorkletProcessor {
+    constructor(options) {
+      super()
+      this.kernel = new ResonanceKernel(sampleRate)
+      if (options?.processorOptions?.params) {
+        this.kernel.setParams(options.processorOptions.params)
+      }
+      this.sinceMeter = 0
+      this.port.onmessage = (e) => {
+        if (e.data?.type === 'params') this.kernel.setParams(e.data.params)
+        else if (e.data?.type === 'reset') this.kernel.reset()
+      }
+    }
+
+    process(inputs, outputs) {
+      const input = inputs[0]
+      const output = outputs[0]
+      if (!output || output.length === 0) return true
+
+      const n = output[0].length
+      if (!input || input.length === 0) {
+        for (const ch of output) ch.fill(0)
+        return true
+      }
+
+      this.kernel.process(input, output, n)
+
+      this.sinceMeter += n
+      if (this.sinceMeter >= METER_INTERVAL_SAMPLES) {
+        this.sinceMeter = 0
+        this.port.postMessage({ type: 'gr', grDb: this.kernel.readMetering() })
+      }
+      return true
+    }
+  }
+
+  registerProcessor('resonance-processor', ResonanceWorkletProcessor)
+}

--- a/src/audio/resonanceWorkletLoader.js
+++ b/src/audio/resonanceWorkletLoader.js
@@ -1,0 +1,17 @@
+/**
+ * Load the Resonance Suppressor worklet module into an AudioContext or
+ * OfflineAudioContext, once per context. See la2aWorkletLoader.js for why
+ * these go through `?worker&url` rather than a raw asset URL.
+ */
+import workletUrl from './resonanceProcessor.js?worker&url'
+
+const loadPromises = new WeakMap()
+
+export function ensureResonanceWorklet(context) {
+  let promise = loadPromises.get(context)
+  if (!promise) {
+    promise = context.audioWorklet.addModule(workletUrl)
+    loadPromises.set(context, promise)
+  }
+  return promise
+}

--- a/src/components/panels/ResonanceModal.vue
+++ b/src/components/panels/ResonanceModal.vue
@@ -1,0 +1,220 @@
+<script setup>
+import { computed, onMounted } from 'vue'
+import { useResonance } from '../../composables/useResonance.js'
+import { useEditorState } from '../../composables/useEditorState.js'
+import Knob from '../knobs/Knob.vue'
+import SegmentedSwitch from '../knobs/SegmentedSwitch.vue'
+import DeviceSlider from '../knobs/DeviceSlider.vue'
+import LevelMeter from '../meters/LevelMeter.vue'
+import GainReductionBar from '../meters/GainReductionBar.vue'
+import FloatingWindow from './FloatingWindow.vue'
+import ApplyAction from '../ui/ApplyAction.vue'
+
+defineProps({ z: { type: Number, default: 500 } })
+
+const {
+  resDepth, resSharpness, resSelectivity, resAttack, resRelease,
+  resMaxReduction, resFreqFloor, resFreqCeil, resMode, resPreserveHarmonics,
+  resPreview, resReduction, resInputDb, resOutputDb, hasSelection,
+  togglePreview, syncDepth, syncSharpness, syncSelectivity, syncAttack,
+  syncRelease, syncMaxReduction, syncFreqFloor, syncFreqCeil, syncMode,
+  togglePreserveHarmonics, apply, teardown, closeModal,
+} = useResonance()
+
+const { state } = useEditorState()
+
+onMounted(() => {
+  if (!resPreview.value) togglePreview()
+})
+
+const ACCENT = '#8de0a8'
+
+const MODE_OPTIONS = [
+  { value: 'soft', label: 'SOFT', title: 'Gradual knee above the threshold' },
+  { value: 'hard', label: 'HARD', title: 'Linear above the threshold' },
+]
+
+const percent = v => `${Math.round(v * 100)}`
+const oneDp = v => v.toFixed(1)
+const ms = v => `${Math.round(v)}`
+const hz = v => (v >= 1000 ? `${(v / 1000).toFixed(1)}k` : `${Math.round(v)}`)
+const db = v => `${Math.round(v)}`
+
+const modeCaption = computed(() =>
+  resMode.value === 'soft' ? 'gradual knee' : 'linear above threshold',
+)
+
+function togglePlayback() {
+  window.dispatchEvent(new CustomEvent('wavely:toggle-play'))
+}
+
+function close() {
+  teardown()
+}
+
+async function applyAndClose() {
+  await apply()
+  teardown()
+  closeModal()
+}
+</script>
+
+<template>
+  <FloatingWindow
+    window-id="resonance-suppressor"
+    :z="z"
+    :width="660"
+    :accent="ACCENT"
+    brand-lead="RESO"
+    brand-tail="TAME"
+    :engaged="resPreview"
+    @toggle-engaged="togglePreview"
+    @close="close"
+  >
+    <div class="px-[26px] pt-[22px] pb-[24px]">
+      <GainReductionBar :reduction-db="resReduction" :accent="ACCENT" />
+
+      <div class="flex items-center justify-between gap-[22px] mt-[22px]">
+        <LevelMeter :db="resInputDb" label="IN" :height="150" />
+
+        <div class="flex-1 flex justify-center gap-[34px]">
+          <div class="w-[124px]">
+            <Knob
+              :model-value="resDepth" @update:model-value="syncDepth"
+              :min="0" :max="1" :step="0.01"
+              label="Depth" :accent="ACCENT" :format-value="percent"
+              :disabled="!resPreview"
+            />
+          </div>
+          <div class="w-[124px]">
+            <Knob
+              :model-value="resSelectivity" @update:model-value="syncSelectivity"
+              :min="3" :max="24" :step="0.5"
+              label="Selectivity" :accent="ACCENT" :format-value="oneDp"
+              :disabled="!resPreview"
+            />
+          </div>
+          <div class="w-[124px]">
+            <Knob
+              :model-value="resSharpness" @update:model-value="syncSharpness"
+              :min="0" :max="1" :step="0.01"
+              label="Sharpness" :accent="ACCENT" :format-value="percent"
+              :disabled="!resPreview"
+            />
+          </div>
+        </div>
+
+        <LevelMeter :db="resOutputDb" label="OUT" :height="150" />
+      </div>
+
+      <!-- Timing + ceiling -->
+      <div class="flex items-center justify-between mt-[18px] pt-[16px]"
+           style="border-top:1px solid rgba(255,255,255,.06)">
+        <SegmentedSwitch
+          :model-value="resMode"
+          @update:model-value="syncMode"
+          :options="MODE_OPTIONS"
+          :accent="ACCENT"
+          :disabled="!resPreview"
+          :caption="modeCaption"
+        />
+
+        <div class="flex gap-[24px]">
+          <div class="w-[74px]">
+            <Knob
+              :model-value="resAttack" @update:model-value="syncAttack"
+              :min="1" :max="100" :step="1" :value-font-px="13"
+              label="Attack ms" :accent="ACCENT" :format-value="ms"
+              :disabled="!resPreview"
+            />
+          </div>
+          <div class="w-[74px]">
+            <Knob
+              :model-value="resRelease" @update:model-value="syncRelease"
+              :min="10" :max="500" :step="5" :value-font-px="13"
+              label="Release ms" :accent="ACCENT" :format-value="ms"
+              :disabled="!resPreview"
+            />
+          </div>
+          <div class="w-[74px]">
+            <Knob
+              :model-value="resMaxReduction" @update:model-value="syncMaxReduction"
+              :min="3" :max="48" :step="1" :value-font-px="13"
+              label="Max Cut dB" :accent="ACCENT" :format-value="db"
+              :disabled="!resPreview"
+            />
+          </div>
+        </div>
+      </div>
+
+      <!-- Range + harmonic protection -->
+      <div class="mt-[18px] pt-[16px]" style="border-top:1px solid rgba(255,255,255,.06)">
+        <div class="flex items-start gap-[30px]">
+          <div class="flex-1 grid grid-cols-2 gap-x-[26px] gap-y-[12px]">
+            <DeviceSlider
+              :model-value="resFreqFloor" @update:model-value="syncFreqFloor"
+              :min="20" :max="1000" :step="10"
+              label="Low Limit" :accent="ACCENT" :format-value="hz"
+              :disabled="!resPreview"
+            />
+            <DeviceSlider
+              :model-value="resFreqCeil" @update:model-value="syncFreqCeil"
+              :min="2000" :max="20000" :step="100"
+              label="High Limit" :accent="ACCENT" :format-value="hz"
+              :disabled="!resPreview"
+            />
+          </div>
+
+          <!-- Harmonic protection is the safety mechanism, not a flavour
+               control: without it the cepstral reference sits at the
+               inter-harmonic floor and the suppressor eats vocal harmonics. -->
+          <button
+            class="shrink-0 px-3 py-[9px] rounded-lg cursor-pointer transition-all text-left disabled:cursor-default"
+            :style="{
+              width: '186px',
+              background: resPreserveHarmonics ? 'rgba(141,224,168,.14)' : 'rgba(255,178,122,.12)',
+              border: `1px solid ${resPreserveHarmonics ? 'rgba(141,224,168,.4)' : 'rgba(255,178,122,.45)'}`,
+              opacity: resPreview ? 1 : 0.4,
+            }"
+            :disabled="!resPreview"
+            title="Protects the speaker's harmonics from being treated as resonances. Turning it off is a diagnostic aid — it will thin the voice."
+            @click="togglePreserveHarmonics"
+          >
+            <span
+              class="block"
+              :style="{
+                font: `700 8.5px 'JetBrains Mono',monospace`,
+                letterSpacing: '.12em',
+                color: resPreserveHarmonics ? '#8de0a8' : '#ffb27a',
+              }"
+            >{{ resPreserveHarmonics ? 'HARMONICS PROTECTED' : 'PROTECTION OFF' }}</span>
+            <span
+              class="block mt-[3px]"
+              style="font:500 9px/1.4 'Inter';color:rgba(255,255,255,.35)"
+            >{{ resPreserveHarmonics
+              ? 'Vocal harmonics are left alone.'
+              : 'Diagnostic only — this will thin the voice.' }}</span>
+          </button>
+        </div>
+      </div>
+
+      <div class="mt-[16px]">
+        <ApplyAction
+          size="md"
+          show-preview
+          previewable
+          :previewing="state.isPlaying"
+          :accent="ACCENT"
+          text-color="#0c1f14"
+          :met="hasSelection"
+          message="Make a selection to tame resonances"
+          label="Apply Resonance Suppression"
+          :disabled="!resPreview"
+          disabled-hint="Turn ResoTame on to apply it"
+          @toggle-preview="togglePlayback"
+          @apply="applyAndClose"
+        />
+      </div>
+    </div>
+  </FloatingWindow>
+</template>

--- a/src/composables/useResonance.js
+++ b/src/composables/useResonance.js
@@ -1,0 +1,203 @@
+import { ref } from 'vue'
+import { useEditorState } from './useEditorState.js'
+import { useWindows } from './useWindows.js'
+import { applyResonanceRegion, computePeakCache } from '../audio/processing.js'
+import { getEffectChain } from '../audio/effectChain.js'
+import { resonanceEffect, RESONANCE_DEFAULTS } from '../audio/effects/resonance.js'
+
+// Registry id of this plugin's window. Must match the entry in src/ui/registry.js.
+export const RESONANCE_WINDOW_ID = 'resonance-suppressor'
+
+// Singleton reactive state shared between the sidebar trigger and the modal.
+const resDepth = ref(RESONANCE_DEFAULTS.depth)
+const resSharpness = ref(RESONANCE_DEFAULTS.sharpness)
+const resSelectivity = ref(RESONANCE_DEFAULTS.selectivity)
+const resAttack = ref(RESONANCE_DEFAULTS.attack)
+const resRelease = ref(RESONANCE_DEFAULTS.release)
+const resMaxReduction = ref(RESONANCE_DEFAULTS.maxReduction)
+const resFreqFloor = ref(RESONANCE_DEFAULTS.freqFloor)
+const resFreqCeil = ref(RESONANCE_DEFAULTS.freqCeil)
+const resMode = ref(RESONANCE_DEFAULTS.mode)
+const resPreserveHarmonics = ref(RESONANCE_DEFAULTS.preserveHarmonics)
+
+const resPreview = ref(false)
+const resReduction = ref(0)
+const resInputDb = ref(-Infinity)
+const resOutputDb = ref(-Infinity)
+let meterId = null
+
+function currentParams() {
+  return {
+    depth: resDepth.value,
+    sharpness: resSharpness.value,
+    selectivity: resSelectivity.value,
+    attack: resAttack.value,
+    release: resRelease.value,
+    maxReduction: resMaxReduction.value,
+    freqFloor: resFreqFloor.value,
+    freqCeil: resFreqCeil.value,
+    mode: resMode.value,
+    preserveHarmonics: resPreserveHarmonics.value,
+  }
+}
+
+export function useResonance() {
+  const {
+    state, getAudioContext, hasSelection, replaceRegion, setPeakCache,
+    startProcessing, endProcessing, showToast,
+  } = useEditorState()
+  const { openWindow, closeWindow } = useWindows()
+
+  function initChain() {
+    const ctx = getAudioContext()
+    const chain = getEffectChain(ctx)
+    if (!chain.effects.find(e => e.id === resonanceEffect.id)) {
+      chain.addEffect(resonanceEffect)
+    }
+    return chain
+  }
+
+  function startMeters(chain) {
+    stopMeters()
+    function tick() {
+      const nodes = chain.effects.find(e => e.id === resonanceEffect.id)?.nodes
+      if (nodes) {
+        resReduction.value = nodes.getReduction()
+        resInputDb.value = nodes.getInputLevelDb()
+        resOutputDb.value = nodes.getOutputLevelDb()
+      }
+      meterId = requestAnimationFrame(tick)
+    }
+    meterId = requestAnimationFrame(tick)
+  }
+
+  function stopMeters() {
+    if (meterId !== null) {
+      cancelAnimationFrame(meterId)
+      meterId = null
+    }
+    resReduction.value = 0
+    resInputDb.value = -Infinity
+    resOutputDb.value = -Infinity
+  }
+
+  function pushAllParams(chain) {
+    for (const [name, value] of Object.entries(currentParams())) {
+      chain.updateParam(resonanceEffect.id, name, value)
+    }
+  }
+
+  function togglePreview() {
+    const chain = initChain()
+    resPreview.value = !resPreview.value
+    chain.setEnabled(resonanceEffect.id, resPreview.value)
+
+    if (resPreview.value) {
+      pushAllParams(chain)
+      startMeters(chain)
+    } else {
+      stopMeters()
+    }
+  }
+
+  function pushParam(name, value) {
+    if (!resPreview.value) return
+    const chain = getEffectChain(getAudioContext())
+    chain.updateParam(resonanceEffect.id, name, value)
+  }
+
+  function syncParam(name, refVar, value) {
+    refVar.value = value
+    pushParam(name, value)
+  }
+
+  const syncDepth = v => syncParam('depth', resDepth, v)
+  const syncSharpness = v => syncParam('sharpness', resSharpness, v)
+  const syncSelectivity = v => syncParam('selectivity', resSelectivity, v)
+  const syncAttack = v => syncParam('attack', resAttack, v)
+  const syncRelease = v => syncParam('release', resRelease, v)
+  const syncMaxReduction = v => syncParam('maxReduction', resMaxReduction, v)
+  const syncFreqFloor = v => syncParam('freqFloor', resFreqFloor, v)
+  const syncFreqCeil = v => syncParam('freqCeil', resFreqCeil, v)
+  const syncMode = v => syncParam('mode', resMode, v)
+
+  function togglePreserveHarmonics() {
+    syncParam('preserveHarmonics', resPreserveHarmonics, !resPreserveHarmonics.value)
+  }
+
+  async function apply() {
+    if (!state.selection) return
+    const { start, end } = state.selection
+
+    const wasPreviewing = resPreview.value
+    if (wasPreviewing) togglePreview()
+
+    startProcessing('Suppressing resonances...')
+    try {
+      const buffer = await applyResonanceRegion(
+        state.segments, start, end,
+        currentParams(),
+        state.currentFile.sampleRate, state.currentFile.channels,
+      )
+      const bufferId = replaceRegion(start, end, buffer)
+      const cache = await computePeakCache(buffer, 256)
+      setPeakCache(bufferId, cache)
+      showToast('Resonance suppression applied')
+    } catch (err) {
+      console.error('Resonance suppression failed:', err)
+      showToast('Resonance suppression failed')
+    } finally {
+      endProcessing()
+    }
+  }
+
+  function teardown() {
+    stopMeters()
+    if (resPreview.value) {
+      const chain = getEffectChain(getAudioContext())
+      chain.setEnabled(resonanceEffect.id, false)
+      resPreview.value = false
+    }
+  }
+
+  function openModal() {
+    openWindow(RESONANCE_WINDOW_ID)
+  }
+
+  function closeModal() {
+    closeWindow(RESONANCE_WINDOW_ID)
+  }
+
+  return {
+    resDepth,
+    resSharpness,
+    resSelectivity,
+    resAttack,
+    resRelease,
+    resMaxReduction,
+    resFreqFloor,
+    resFreqCeil,
+    resMode,
+    resPreserveHarmonics,
+    resPreview,
+    resReduction,
+    resInputDb,
+    resOutputDb,
+    hasSelection,
+    togglePreview,
+    syncDepth,
+    syncSharpness,
+    syncSelectivity,
+    syncAttack,
+    syncRelease,
+    syncMaxReduction,
+    syncFreqFloor,
+    syncFreqCeil,
+    syncMode,
+    togglePreserveHarmonics,
+    apply,
+    teardown,
+    openModal,
+    closeModal,
+  }
+}

--- a/src/ui/icons.js
+++ b/src/ui/icons.js
@@ -44,6 +44,9 @@ export const ICONS = {
   saturation: '<path d="M12 3a6 6 0 00-3.6 10.8c1 .8 1.6 1.8 1.8 3.2h3.6c.2-1.4.8-2.4 1.8-3.2A6 6 0 0012 3z"/><path d="M9 17h6"/><path d="M9.5 20h5"/><path d="M10 11l2 2 2-2"/>',
   // A rising shelf: flat, then a gentle knee up to a plateau — the air curve.
   air: '<path d="M2 17c5 0 8 0 11-5s5-5 9-5"/><path d="M2 21h20" opacity=".35"/>',
+  // Resonance: a spectrum with one peak protruding, and the cut being taken
+  // out of it — a narrow notch pushed down onto the spike.
+  resonance: '<path d="M2 18c3 0 3.5-3 5-3s2 3 4 3"/><path d="M11 18c1-6 2-12 4-12s3 6 4 12"/><path d="M19 18c1 0 1.5-2 3-2"/><path d="M15 3v6" stroke-dasharray="2 2" opacity=".5"/>',
   noise: '<path d="M12 2a3 3 0 013 3v7a3 3 0 01-6 0V5a3 3 0 013-3z"/><path d="M19 10v2a7 7 0 01-14 0v-2M12 19v3M8 23h8"/>',
   // Waveform, flat stretch, waveform — the gap being targeted. Was a second
   // copy of the `cut` scissors, which is the clipboard verb's glyph.

--- a/src/ui/registry.js
+++ b/src/ui/registry.js
@@ -8,6 +8,7 @@ import PresetsPanel from '../components/panels/PresetsPanel.vue'
 import LA2AModal from '../components/panels/LA2AModal.vue'
 import FET1176Modal from '../components/panels/FET1176Modal.vue'
 import AirBandModal from '../components/panels/AirBandModal.vue'
+import ResonanceModal from '../components/panels/ResonanceModal.vue'
 import NormalizeWindow from '../components/panels/windows/NormalizeWindow.vue'
 import VocalSaturationWindow from '../components/panels/windows/VocalSaturationWindow.vue'
 import NoiseReductionWindow from '../components/panels/windows/NoiseReductionWindow.vue'
@@ -263,6 +264,18 @@ export const OPERATIONS = [
     requires: 'selection',
     surface: 'window',
     component: AirBandModal,
+  },
+  {
+    id: 'resonance-suppressor',
+    label: 'ResoTame',
+    desc: 'Tame harsh resonant peaks',
+    category: 'effects',
+    group: 'Tone',
+    icon: 'resonance',
+    keywords: ['resonance', 'soothe', 'harsh', 'ring', 'room mode', 'dynamic eq', 'peak'],
+    requires: 'selection',
+    surface: 'window',
+    component: ResonanceModal,
   },
   {
     id: 'noise-reduction',

--- a/test/dsp/resonance.test.js
+++ b/test/dsp/resonance.test.js
@@ -1,0 +1,308 @@
+/**
+ * Run with:  npm test
+ */
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  ResonanceKernel,
+  RESONANCE_KERNEL_DEFAULTS,
+  processResonanceBuffer,
+} from '../../src/audio/resonanceProcessor.js'
+import { peaking, BiquadCascade } from '../../src/audio/dsp/biquad.js'
+import { getFFT, rfftBinCount } from '../../src/audio/dsp/fft.js'
+
+const SR = 44100
+const LATENCY = 2048
+
+/**
+ * Voiced signal: a harmonic stack with slow pitch wobble over a broadband
+ * floor. The stack matters — non-voiced frames target zero reduction by
+ * design, so the suppressor does nothing at all to pure noise.
+ */
+function voice({
+  seconds = 3, f0 = 150, jitterHz = 3, amp = 0.2, noiseDb = -45,
+} = {}) {
+  const n = Math.round(seconds * SR)
+  const out = new Float32Array(n)
+  const noiseAmp = Math.pow(10, noiseDb / 20)
+  let phase = 0
+  let s = 4242
+  for (let i = 0; i < n; i++) {
+    const t = i / SR
+    const pitch = f0 + jitterHz * Math.sin(2 * Math.PI * 2.7 * t)
+    phase += (2 * Math.PI * pitch) / SR
+    let v = 0
+    for (let k = 1; k <= 30; k++) {
+      if (pitch * k >= SR / 2) break
+      v += (amp / k) * Math.sin(k * phase + k * 0.9)
+    }
+    s = (s * 1103515245 + 12345) & 0x7fffffff
+    out[i] = v + noiseAmp * (s / 0x3fffffff - 1)
+  }
+  return out
+}
+
+/** Apply a resonant peaking boost — what a room mode or mic resonance does. */
+function resonate(sig, freqHz, q, gainDb) {
+  const cascade = new BiquadCascade(1, 1)
+  cascade.setSections([peaking(SR, freqHz, q, gainDb)])
+  const out = new Float32Array(sig.length)
+  cascade.process(sig, out, sig.length, 0)
+  return out
+}
+
+/**
+ * Mean power in dB across a band, measured on a Hann-windowed segment.
+ *
+ * The window is not optional: a rectangular window lets a strong harmonic leak
+ * 30 dB into the inter-harmonic gaps, which swamps whatever is actually being
+ * measured there.
+ */
+function bandDb(buf, freqHz, from, halfHz = 60) {
+  const n = 16384
+  const fft = getFFT(n)
+  const bins = rfftBinCount(n)
+  const windowed = new Float64Array(n)
+  for (let i = 0; i < n; i++) {
+    const w = 0.5 * (1 - Math.cos((2 * Math.PI * i) / n))
+    windowed[i] = buf[from + i] * w
+  }
+  const re = new Float64Array(bins)
+  const im = new Float64Array(bins)
+  fft.rfft(windowed, re, im)
+
+  const binHz = SR / n
+  const lo = Math.max(0, Math.round((freqHz - halfHz) / binHz))
+  const hi = Math.min(bins - 1, Math.round((freqHz + halfHz) / binHz))
+  let power = 0
+  for (let k = lo; k <= hi; k++) power += re[k] * re[k] + im[k] * im[k]
+  return 10 * Math.log10(power / (hi - lo + 1) / (n * n) + 1e-20)
+}
+
+/**
+ * How much of a resonant boost the suppressor took back out, in dB.
+ * Measured against the un-boosted signal so the voice itself cancels.
+ */
+function boostRemoved(dry, freqHz, q, gainDb, params) {
+  const wet = resonate(dry, freqHz, q, gainDb)
+  const out = processResonanceBuffer([wet], SR, params).channelData[0]
+  const before = bandDb(wet, freqHz, SR) - bandDb(dry, freqHz, SR)
+  const after = bandDb(out, freqHz, SR + LATENCY) - bandDb(dry, freqHz, SR)
+  return before - after
+}
+
+/**
+ * Parametric tests run with harmonic protection OFF so they measure detection
+ * and reduction rather than the mask. With it on, protection covers 60–100% of
+ * the spectrum (see the coverage test below) and whether a given probe
+ * frequency is reachable depends on where the measured pitch put its harmonics
+ * that frame — which makes for a flaky test of the wrong thing.
+ */
+const UNPROTECTED = { ...RESONANCE_KERNEL_DEFAULTS, preserveHarmonics: false }
+
+test('reports a latency of exactly one FFT frame', () => {
+  assert.equal(new ResonanceKernel(SR).latencySamples, LATENCY)
+})
+
+test('passes audio through delayed, not mangled, at zero depth', () => {
+  const sig = voice({ seconds: 2 })
+  const { channelData } = processResonanceBuffer([sig], SR, { depth: 0 })
+  let maxErr = 0
+  for (let i = LATENCY; i + LATENCY < sig.length; i++) {
+    maxErr = Math.max(maxErr, Math.abs(channelData[0][i + LATENCY] - sig[i]))
+  }
+  assert.ok(maxErr < 1e-5, `reconstruction error ${maxErr}`)
+})
+
+test('the delay is measurable, not merely advertised', () => {
+  // applyWorkletRegion trims by exactly this number; a mismatch would
+  // time-shift every applied region.
+  const n = SR
+  const sig = new Float32Array(n)
+  for (let i = 2000; i < 2400; i++) {
+    sig[i] = Math.sin((2 * Math.PI * 800 * i) / SR) * Math.sin((Math.PI * (i - 2000)) / 400)
+  }
+  const out = processResonanceBuffer([sig], SR, { depth: 0 }).channelData[0]
+
+  const argmax = buf => {
+    let idx = -1
+    let peak = 0
+    for (let i = 0; i < buf.length; i++) {
+      if (Math.abs(buf[i]) > peak) {
+        peak = Math.abs(buf[i])
+        idx = i
+      }
+    }
+    return idx
+  }
+  assert.equal(argmax(out) - argmax(sig), LATENCY)
+})
+
+test('harmonic mask matches the Python bin for bin', () => {
+  // Golden bin counts from _compute_harmonic_mask_for_f0 in
+  // resonance_suppressor.py, reproduced with its exact geometry
+  // (harmonic_width_bins 2, harmonic_width_pct 0.01, max_harmonic 100,
+  // freq_ceil 20 kHz). Verified equal as full index lists, not just counts.
+  const kernel = new ResonanceKernel(SR)
+  const golden = { 100: 467, 120.5: 538, 150: 632, 154.7: 645, 220: 755, 300: 654 }
+  for (const [f0, expected] of Object.entries(golden)) {
+    const mask = kernel._harmonicMask(parseFloat(f0))
+    let count = 0
+    for (let i = 0; i < mask.length; i++) if (mask[i]) count++
+    assert.equal(count, expected, `f0 ${f0}: ${count} bins masked, expected ${expected}`)
+  }
+})
+
+test('harmonic protection covers most of the spectrum, and all of it up high', () => {
+  // Surprising enough to pin. Protection half-width is
+  // max(2 bins, 1% of the harmonic frequency), so once 2% of a harmonic's
+  // frequency exceeds the pitch — above roughly 50x F0 — adjacent protection
+  // zones touch and nothing is reachable. For a 150 Hz speaker that is about
+  // 7.5 kHz. This is the server's own geometry, not a divergence, and it is
+  // why the effect works mainly on narrow resonances at low and mid
+  // frequencies.
+  const kernel = new ResonanceKernel(SR)
+  const binHz = SR / 2048
+  const coverage = (f0, loHz, hiHz) => {
+    const mask = kernel._harmonicMask(f0)
+    let total = 0
+    let covered = 0
+    for (let b = 0; b < mask.length; b++) {
+      const f = b * binHz
+      if (f >= loHz && f < hiHz) {
+        total++
+        if (mask[b]) covered++
+      }
+    }
+    return covered / total
+  }
+  assert.ok(coverage(150, 500, 1500) < 0.9, 'mid band should still have gaps')
+  assert.ok(coverage(150, 8000, 12000) > 0.99, 'high band should be fully protected')
+  assert.ok(coverage(220, 500, 1500) < coverage(150, 500, 1500) + 0.01,
+    'a higher pitch leaves at least as much room')
+})
+
+test('suppresses a narrow resonance', () => {
+  const dry = voice()
+  const removed = boostRemoved(dry, 3000, 40, 12, UNPROTECTED)
+  assert.ok(removed > 6, `only ${removed.toFixed(1)} dB of a 12 dB resonance came out`)
+})
+
+
+test('depth scales how much comes out', () => {
+  const dry = voice()
+  const light = boostRemoved(dry, 3000, 40, 12, { ...UNPROTECTED, depth: 0.2 })
+  const heavy = boostRemoved(dry, 3000, 40, 12, { ...UNPROTECTED, depth: 1.0 })
+  assert.ok(heavy > light + 2, `depth barely mattered: ${light.toFixed(1)} vs ${heavy.toFixed(1)}`)
+})
+
+test('selectivity gates what counts as a resonance', () => {
+  const dry = voice()
+  const removed = boostRemoved(dry, 3000, 40, 12, { ...UNPROTECTED, selectivity: 60 })
+  assert.ok(removed < 2, `expected almost nothing at selectivity 60, got ${removed.toFixed(1)} dB`)
+})
+
+test('max reduction caps the cut', () => {
+  const dry = voice()
+  const capped = boostRemoved(dry, 3000, 40, 18, { ...UNPROTECTED, maxReductionDb: 3 })
+  const uncapped = boostRemoved(dry, 3000, 40, 18, UNPROTECTED)
+  assert.ok(capped < uncapped - 4, `cap had no effect: ${capped.toFixed(1)} vs ${uncapped.toFixed(1)}`)
+})
+
+test('band limits confine the reduction', () => {
+  const dry = voice()
+  const inBand = boostRemoved(dry, 3000, 40, 12, UNPROTECTED)
+  const outOfBand = boostRemoved(dry, 3000, 40, 12, { ...UNPROTECTED, freqCeilHz: 2000 })
+  assert.ok(inBand > 6, `in-band removal was only ${inBand.toFixed(1)} dB`)
+  assert.ok(outOfBand < 1.5, `above the ceiling should be untouched, got ${outOfBand.toFixed(1)} dB`)
+})
+
+test('harmonic protection holds the suppressor off the voice', () => {
+  // The mask is the safety mechanism the server refuses to run without. With
+  // it on, a signal that is nothing but voice should come through close to
+  // untouched; with it off the suppressor starts eating harmonics.
+  const sig = voice()
+  const withMask = processResonanceBuffer([sig], SR, RESONANCE_KERNEL_DEFAULTS).channelData[0]
+  const without = processResonanceBuffer([sig], SR, UNPROTECTED).channelData[0]
+
+  const departure = out => {
+    let sum = 0
+    for (let i = LATENCY + 2000; i < sig.length - 2000; i++) {
+      sum += Math.abs(out[i] - sig[i - LATENCY])
+    }
+    return sum / (sig.length - LATENCY - 4000)
+  }
+  const guarded = departure(withMask)
+  const unguarded = departure(without)
+  assert.ok(
+    unguarded > guarded * 3,
+    `mask made little difference: ${guarded.toExponential(2)} vs ${unguarded.toExponential(2)}`,
+  )
+})
+
+test('output is independent of the block size it was fed in', () => {
+  // The kernel walks a block in hop-sized pieces so a block spanning two
+  // frames cannot leave later channels applying the wrong frame's gain.
+  const sig = voice({ seconds: 1.5 })
+  const n = sig.length
+  const oneShot = processResonanceBuffer([sig], SR, RESONANCE_KERNEL_DEFAULTS).channelData[0]
+
+  const kernel = new ResonanceKernel(SR)
+  kernel.setParams(RESONANCE_KERNEL_DEFAULTS)
+  const chunked = new Float32Array(n)
+  const sizes = [1, 128, 999, 2048, 37]
+  let off = 0
+  let i = 0
+  while (off < n) {
+    const len = Math.min(sizes[i++ % sizes.length], n - off)
+    kernel.process([sig.subarray(off, off + len)], [chunked.subarray(off, off + len)], len)
+    off += len
+  }
+
+  let maxErr = 0
+  for (let k = 0; k < n; k++) maxErr = Math.max(maxErr, Math.abs(oneShot[k] - chunked[k]))
+  assert.ok(maxErr < 1e-6, `block-size dependence: max error ${maxErr}`)
+})
+
+test('stereo channels share one gain, so the image cannot wander', () => {
+  const sig = voice({ seconds: 1.5 })
+  const { channelData } = processResonanceBuffer(
+    [sig.slice(), sig.slice()], SR, RESONANCE_KERNEL_DEFAULTS,
+  )
+  let maxErr = 0
+  for (let i = 0; i < sig.length; i++) {
+    maxErr = Math.max(maxErr, Math.abs(channelData[0][i] - channelData[1][i]))
+  }
+  assert.ok(maxErr < 1e-9, `channels diverged by ${maxErr}`)
+})
+
+test('survives silence without producing NaN', () => {
+  const { channelData } = processResonanceBuffer(
+    [new Float32Array(SR)], SR, RESONANCE_KERNEL_DEFAULTS,
+  )
+  for (let i = 0; i < channelData[0].length; i++) {
+    assert.ok(Number.isFinite(channelData[0][i]), `non-finite output at ${i}`)
+  }
+})
+
+test('reset returns the kernel to its initial behaviour', () => {
+  const sig = voice({ seconds: 1 })
+  const kernel = new ResonanceKernel(SR)
+  kernel.setParams(RESONANCE_KERNEL_DEFAULTS)
+
+  const run = () => {
+    const out = new Float32Array(sig.length)
+    for (let off = 0; off < sig.length; off += 128) {
+      const len = Math.min(128, sig.length - off)
+      kernel.process([sig.subarray(off, off + len)], [out.subarray(off, off + len)], len)
+    }
+    return out
+  }
+
+  const a = run()
+  kernel.reset()
+  const b = run()
+  let maxErr = 0
+  for (let i = 0; i < sig.length; i++) maxErr = Math.max(maxErr, Math.abs(a[i] - b[i]))
+  assert.ok(maxErr < 1e-9, `reset did not restore state: ${maxErr}`)
+})


### PR DESCRIPTION
Ports the server's resonanceSuppressor stage: per STFT frame, build a cepstral reference that sits at the inter-harmonic floor, treat what protrudes above it as a resonance, and duck it with a per-bin attack/release. The 1394-line Python is mostly machinery this does not need — multi-pass chains, sibilant_only gating, band-summary reporting, and the pitch-transition detector, which is a +-5 frame lookahead that would cost another 58 ms of latency.

This is the first latent effect, so it brings Phase 0.3 with it.

LATENCY COMPENSATION. applyWorkletRegion rendered exactly numSamples, which was correct only because every effect so far was zero-latency. A latent effect would have written back audio shifted late by its latency, with silence spliced in at the head of the region and the last samples of real audio lost. It now renders long, pulls real tail context from past the region where the timeline has it, and trims the leading latency. Zero-latency effects keep the original path with no extra render and no copy.

Verified in Chromium: the trimmed worklet render is bit-identical to the direct kernel render offset by the latency, cross-correlation against the source finds an alignment lag of exactly 0, and the head and tail of the applied region carry real audio rather than silence.

HARMONIC PROTECTION is what makes this port possible at all. Cepstral liftering puts the reference at the inter-harmonic floor, so vocal harmonics protrude and read as resonances; without the mask the suppressor eats the voice, and the server refuses to run the stage without an F0 contour. F0Tracker supplies the per-frame pitch live. The mask is verified equal to the Python's bin for bin at six pitches, and its coverage is pinned in a test because it is surprising: the protection half-width is max(2 bins, 1% of the harmonic frequency), so above roughly 50x F0 adjacent zones touch and nothing is reachable. That is the server's own geometry, and it is why the effect works mainly on narrow resonances at low and mid frequencies.

Two fixes to my own earlier work, both the same mistake:

  - The voicing gate first used a running noise floor. A floor tracker rises toward the signal, so on continuous speech with no silence in it the floor converged on the speech level and the gate never opened — no frame was ever voiced and the suppressor did nothing at all. It is now an absolute floor, with F0Tracker's correlation gate doing the real work. Same class of bug as the hum detector's voicing gate.

  - The kernel walked a whole block per channel, so a block spanning two frames left every channel but the first applying the last frame's gain to both. It now walks in hop-sized pieces. Web Audio's 128-sample quantum never spans a frame, but the offline path is free to hand over larger blocks.

StftProcessor now also exposes the unwindowed frame, which pitch estimation needs — a Hann taper biases autocorrelation toward shorter lags.

Detection runs on channel 0 and the gain applies to every channel, so a spectral cut cannot move the stereo image; for mono it is identical to the server either way.

Adds 15 tests.


Claude-Session: https://claude.ai/code/session_019b1Nt95cB9aGTecubKbo9L