### PR TITLE
Generalize pitch tracking for non-voice sources

### DIFF
--- a/src/audio/dsp/f0.js
+++ b/src/audio/dsp/f0.js
@@ -5,20 +5,28 @@
  *
  * Direct port of server/scripts/estimate_f0_contour.py (`_autocorr_f0_batch`):
  * zero-mean the frame, autocorrelate via |rfft|² → irfft at 2× length, take the
- * peak within the lag range implied by [F0_MIN_HZ, F0_MAX_HZ], gate on
+ * peak within the lag range implied by the search bounds, gate on
  * MIN_CORR_RATIO, then parabolically interpolate the peak.
+ *
+ * The Python hard-codes a speech range; here it is settable per consumer via
+ * `setRange`, because these effects run on whatever the user loaded rather than
+ * on a narrator. F0_MIN_HZ / F0_MAX_HZ remain the speech defaults.
  *
  * The Python runs this over a whole file at once; the algorithm itself is
  * strictly per-frame and causal, which is what makes realtime harmonic
  * protection possible in the resonance suppressor without an analyze pass.
  *
- * Two things the whole-file version has that a streaming tracker cannot:
- *   - a Silero voicing mask. Substituted here by the correlation ratio the
- *     estimator already computes, optionally combined with a caller-supplied
- *     energy gate.
- *   - a whole-file median, used to set the cepstral lifter cutoff. Substituted
- *     by a rolling median over recent voiced frames, matching the deque pattern
- *     sibilance_detector.py already uses for its band tracking.
+ * One thing the whole-file version has that a streaming tracker cannot: a
+ * whole-file median, used to set the cepstral lifter cutoff. Substituted by a
+ * rolling median over recent pitched frames, matching the deque pattern
+ * sibilance_detector.py already uses for its band tracking.
+ *
+ * WHAT THIS IS NOT: a voice activity detector. The server pairs this estimator
+ * with Silero VAD, and the two answer different questions — Silero says "is
+ * someone speaking", this says "is there a periodic component in range". Every
+ * fricative is the first without being the second. Substituting one for the
+ * other silently narrows behaviour, which is a mistake this file has already
+ * caused once (see the note on `pitched` in `estimate`).
  */
 
 import { getFFT } from './fft.js'
@@ -30,6 +38,22 @@ export const MIN_CORR_RATIO = 0.1
 /** Rolling-median window, matching sibilance_detector.py's F0_ROLLING_WINDOW_SIZE. */
 export const DEFAULT_MEDIAN_WINDOW = 10
 
+/**
+ * Longest lag worth searching, as a fraction of the frame.
+ *
+ * Autocorrelation at lag L only has frameSize − L samples of overlap to work
+ * with, so the estimate degrades as L approaches the frame length. Half the
+ * frame is the conventional stopping point; past it the peak is being formed by
+ * a handful of samples and the tracker starts inventing pitches. At 2048
+ * samples / 44.1 kHz this puts the hard floor at 43.07 Hz.
+ */
+const MAX_LAG_FRACTION = 0.5
+
+/** Lowest pitch this frame size can estimate at all. */
+export function pitchFloorHz(sampleRate, frameSize) {
+  return sampleRate / Math.floor(frameSize * MAX_LAG_FRACTION)
+}
+
 export class F0Tracker {
   /**
    * @param {object} opts
@@ -37,12 +61,16 @@ export class F0Tracker {
    * @param {number} [opts.frameSize=2048] must match the consumer's STFT n_fft
    * @param {number} [opts.medianWindow=10]
    * @param {number} [opts.defaultF0=null] seed used before the first voiced frame
+   * @param {number} [opts.minHz=70] low end of the pitch search
+   * @param {number} [opts.maxHz=400] high end of the pitch search
    */
   constructor({
     sampleRate,
     frameSize = 2048,
     medianWindow = DEFAULT_MEDIAN_WINDOW,
     defaultF0 = null,
+    minHz = F0_MIN_HZ,
+    maxHz = F0_MAX_HZ,
   }) {
     this.sampleRate = sampleRate
     this.frameSize = frameSize
@@ -53,8 +81,7 @@ export class F0Tracker {
     this.corrSize = 2 * frameSize
     this.fft = getFFT(this.corrSize)
 
-    this.lagMin = Math.floor(sampleRate / F0_MAX_HZ)
-    this.lagMax = Math.floor(sampleRate / F0_MIN_HZ)
+    this.setRange(minHz, maxHz)
 
     const bins = (this.corrSize >>> 1) + 1
     this._re = new Float64Array(bins)
@@ -67,6 +94,35 @@ export class F0Tracker {
     this.lastF0 = null
   }
 
+  /**
+   * Set the pitch search range, clamped to what this frame size can resolve.
+   *
+   * The server only ever tracked speech, so the range was a constant. A
+   * realtime effect is pointed at whatever the user loaded, and a source
+   * outside the search range does not fail quietly — the peak picker returns
+   * the best lag *within* the range, which for an out-of-range pitch is an
+   * octave artefact reported with full confidence. Widening the range is the
+   * only way to avoid that, and it is nearly free: the FFT is sized from the
+   * frame, not the range, so this only moves the bounds of a linear scan.
+   *
+   * @returns {{ minHz: number, maxHz: number }} the clamped range actually used
+   */
+  setRange(minHz, maxHz) {
+    const floor = pitchFloorHz(this.sampleRate, this.frameSize)
+    const ceil = this.sampleRate / 2
+    let lo = Math.max(floor, Math.min(minHz, ceil))
+    let hi = Math.max(lo, Math.min(maxHz, ceil))
+    // One lag apart at minimum, or the scan below has nothing to look at.
+    if (Math.floor(this.sampleRate / lo) <= Math.floor(this.sampleRate / hi)) {
+      hi = this.sampleRate / Math.max(1, Math.floor(this.sampleRate / lo) - 1)
+    }
+    this.minHz = lo
+    this.maxHz = hi
+    this.lagMin = Math.floor(this.sampleRate / hi)
+    this.lagMax = Math.floor(this.sampleRate / lo)
+    return { minHz: lo, maxHz: hi }
+  }
+
   reset() {
     this._history.length = 0
     this.lastF0 = null
@@ -76,13 +132,19 @@ export class F0Tracker {
    * Estimate F0 for one frame.
    *
    * @param {ArrayLike<number>} frame length === frameSize, unwindowed
-   * @param {boolean} [energyGate=true] caller's voicing gate (e.g. above noise floor)
-   * @returns {{ f0: number|null, voiced: boolean, ratio: number }}
+   * @param {boolean} [energyGate=true] caller's activity gate (e.g. above a noise floor)
+   * @returns {{ f0: number|null, pitched: boolean, ratio: number }}
+   *
+   * `pitched` means a periodic component was found in range — NOT that the
+   * frame contains speech. The distinction matters: Silero, which this stands
+   * in for on the server, labels fricatives and breaths as speech while this
+   * returns false for them. Callers that gate audible behaviour on speech
+   * presence must not use this flag for it.
    */
   estimate(frame, energyGate = true) {
     const n = this.frameSize
     if (n < 64 || this.lagMax >= n || this.lagMin >= this.lagMax) {
-      return { f0: null, voiced: false, ratio: 0 }
+      return { f0: null, pitched: false, ratio: 0 }
     }
 
     // Zero-mean, matching `f64 - f64.mean(axis=1)`.
@@ -116,9 +178,9 @@ export class F0Tracker {
     }
 
     const ratio = corr0 > 0 ? peak / corr0 : 0
-    const voiced = peakLag > 0 && peak > MIN_CORR_RATIO * corr0 && energyGate
-    if (!voiced) {
-      return { f0: null, voiced: false, ratio }
+    const pitched = peakLag > 0 && peak > MIN_CORR_RATIO * corr0 && energyGate
+    if (!pitched) {
+      return { f0: null, pitched: false, ratio }
     }
 
     // Parabolic interpolation around the peak, guarded exactly as the Python is.
@@ -138,12 +200,12 @@ export class F0Tracker {
     this._history.push(f0)
     if (this._history.length > this.medianWindow) this._history.shift()
 
-    return { f0, voiced: true, ratio }
+    return { f0, pitched: true, ratio }
   }
 
   /**
-   * Rolling median of recent voiced estimates, or the seed default before any
-   * voiced frame has been seen. Drives the cepstral lifter cutoff.
+   * Rolling median of recent pitched estimates, or the seed default before any
+   * pitched frame has been seen. Drives the cepstral lifter cutoff.
    */
   get median() {
     const h = this._history

--- a/src/audio/dsp/f0.js
+++ b/src/audio/dsp/f0.js
@@ -60,7 +60,7 @@ export class F0Tracker {
    * @param {number} opts.sampleRate
    * @param {number} [opts.frameSize=2048] must match the consumer's STFT n_fft
    * @param {number} [opts.medianWindow=10]
-   * @param {number} [opts.defaultF0=null] seed used before the first voiced frame
+   * @param {number} [opts.defaultF0=null] seed used before the first pitched frame
    * @param {number} [opts.minHz=70] low end of the pitch search
    * @param {number} [opts.maxHz=400] high end of the pitch search
    */

--- a/src/audio/dsp/humDetect.js
+++ b/src/audio/dsp/humDetect.js
@@ -36,9 +36,10 @@
  *   - The server could assume speech. This effect is pointed at whatever the
  *     user loaded, so the check is described in terms of a *pitched source*
  *     rather than a speaker. The mechanism is identical — an F0 contour with a
- *     concentration test — but a bass guitar, a sustained synth or a hummed note
- *     trip it exactly as a voice does, and calling that "the speaker" in the UI
- *     would be wrong.
+ *     concentration test — but anything sustained and pitched inside the
+ *     tracker's range trips it exactly as a voice does: a bass or cello line in
+ *     its upper register, a held synth note, a hummed pitch. Calling that "the
+ *     speaker" in the UI would be wrong.
  */
 
 import { getFFT } from './fft.js'
@@ -77,8 +78,10 @@ export const HUM_DETECT_DEFAULTS = {
  * Frequencies where a flagged harmonic could plausibly be the fundamental of a
  * wanted pitched source rather than hum. Only used to decide whether the F0
  * check is worth running for a given harmonic; the verdict comes from the
- * measured pitch. Spans speech but is not limited to it — a bass, a cello and a
- * held synth note all live in here.
+ * measured pitch. Nothing about the band is specific to speech — a held synth
+ * note or an instrument playing in this register sits in it just as a narrator
+ * does. Note it is narrower than the tracker's own range, and excludes
+ * fundamentals below 80 Hz such as a bass guitar's bottom strings.
  */
 const PITCHED_F0_RANGE_HZ = [80, 300]
 
@@ -465,7 +468,8 @@ export function detectHum(samples, sampleRate, options = {}) {
     /**
      * Median pitch of the sustained source found in the selection, or null
      * when none was found or the contour was too scattered to trust. Usually a
-     * voice, but a bass, cello or held synth note reads the same way.
+     * voice, but any sustained pitched source inside the tracker's range
+     * reads the same way.
      */
     pitchedSourceHz: pitchTrusted ? round2(source.pitchHz) : null,
     pitchConcentration: round2(source.concentration),

--- a/src/audio/dsp/humDetect.js
+++ b/src/audio/dsp/humDetect.js
@@ -16,21 +16,29 @@
  * common on modern gear than pure 60 Hz.
  *
  * The anchored coherence test is only the FIRST line of defence against
- * mistaking a voice for hum, and it has a known blind spot: a speaker whose
- * fundamental is near the mains frequency or one of its harmonics puts real
- * vocal energy exactly on the grid being tested. A 120 Hz voice is
- * indistinguishable from 60 Hz hum by spectrum shape alone — its harmonics land
- * on 120, 240, 360.
+ * mistaking wanted content for hum, and it has a known blind spot: any sustained
+ * pitched source whose fundamental sits near the mains frequency or one of its
+ * harmonics puts real energy exactly on the grid being tested. A 120 Hz source
+ * is indistinguishable from 60 Hz hum by spectrum shape alone — its harmonics
+ * land on 120, 240, 360.
  *
  * The server closes that hole with an F0 veto (stages.js:481) that drops any
  * candidate overlapping the speaker's voiced pitch, using an F0 contour and
- * Silero VAD labels. The same check runs here against F0Tracker, with an
- * energy gate standing in for Silero. It differs in what it does with the
- * answer: the server discards the candidate silently, whereas this reports
- * `matchesVoicePitch` and leaves the row visible and tickable. A narrator whose
- * voice really does sit on 120 Hz can still hear the difference in preview and
- * decide — which is more informative than a silent drop, and safer than the
- * label-only warning this originally shipped with.
+ * Silero VAD labels. The same check runs here against F0Tracker, with an energy
+ * gate standing in for Silero.
+ *
+ * TWO DELIBERATE DIFFERENCES from the server:
+ *
+ *   - The server discards the candidate silently. This reports
+ *     `matchesPitchedSource` and leaves the row visible and tickable, so a
+ *     narrator who really does sit on 120 Hz can hear the difference in preview
+ *     and decide.
+ *   - The server could assume speech. This effect is pointed at whatever the
+ *     user loaded, so the check is described in terms of a *pitched source*
+ *     rather than a speaker. The mechanism is identical — an F0 contour with a
+ *     concentration test — but a bass guitar, a sustained synth or a hummed note
+ *     trip it exactly as a voice does, and calling that "the speaker" in the UI
+ *     would be wrong.
  */
 
 import { getFFT } from './fft.js'
@@ -62,15 +70,17 @@ export const HUM_DETECT_DEFAULTS = {
   anchorMinDeltaDb: 6,
   coherenceSlackDb: 3,
   strictSlackDb: { 3: 1 },
-  voicePitchCheck: true,
+  pitchSourceCheck: true,
 }
 
 /**
- * Frequencies where a flagged harmonic could plausibly be a voice fundamental
- * rather than hum. Only used to decide whether the F0 check is worth running
- * for a given harmonic; the verdict comes from the measured pitch.
+ * Frequencies where a flagged harmonic could plausibly be the fundamental of a
+ * wanted pitched source rather than hum. Only used to decide whether the F0
+ * check is worth running for a given harmonic; the verdict comes from the
+ * measured pitch. Spans speech but is not limited to it — a bass, a cello and a
+ * held synth note all live in here.
  */
-const VOICE_F0_RANGE_HZ = [80, 300]
+const PITCHED_F0_RANGE_HZ = [80, 300]
 
 // F0 veto tolerance and minimum evidence, matching F0_VETO_* in
 // server/pipeline/stages.js.
@@ -78,7 +88,7 @@ const F0_VETO_HALF_WIDTH_HZ = 15
 const F0_VETO_MIN_FRAMES = 10
 
 /**
- * Fraction of voiced frames that must cluster around the median pitch before
+ * Fraction of pitched frames that must cluster around the median pitch before
  * the pitch estimate is trusted at all.
  *
  * The server tests each candidate against the raw F0 histogram, which is safe
@@ -86,21 +96,22 @@ const F0_VETO_MIN_FRAMES = 10
  * Silero the tracker also runs on hum-only frames, and hum is periodic — an
  * autocorrelation tracker happily locks onto multiples of 60 Hz. Measured on a
  * pure 60 Hz hum series it yields scattered estimates spread across 60–330 Hz
- * with a concentration around 0.07, where a real speaker sits at 1.0. Requiring
- * concentration is what separates "a voice is present" from "the tracker is
- * chasing a tone", and without it a genuine hum harmonic gets vetoed as voice.
+ * with a concentration around 0.07, where a real sustained source sits at 1.0.
+ * Requiring concentration is what separates "something pitched is present" from
+ * "the tracker is chasing the hum", and without it a genuine hum harmonic gets
+ * vetoed.
  */
-const VOICE_PITCH_CONCENTRATION_MIN = 0.5
+const PITCH_CONCENTRATION_MIN = 0.5
 
 /**
- * A candidate is also treated as voice when it lands on a harmonic of the
- * speaker's pitch — a 120 Hz speaker puts real energy on 240 Hz too, and
- * notching that thins the voice just as badly as notching the fundamental.
+ * A candidate is also treated as wanted content when it lands on a harmonic of
+ * the measured pitch — a 120 Hz source puts real energy on 240 Hz too, and
+ * notching that thins the recording just as badly as notching the fundamental.
  */
-const MAX_VOICE_HARMONIC = 3
+const MAX_TRACKED_HARMONIC = 3
 
 /** Pitch jitter multiplies up the harmonic series, so the window widens. */
-function voiceToleranceHz(harmonic) {
+function pitchToleranceHz(harmonic) {
   return Math.min(harmonic * F0_VETO_HALF_WIDTH_HZ, 40)
 }
 
@@ -108,17 +119,17 @@ function voiceToleranceHz(harmonic) {
 const F0_FRAME_SIZE = 2048
 const F0_HOP = 512
 
-/** Voiced frames must clear the noise floor by this much to count. */
-const VOICING_GATE_DB = 8
+/** Frames must clear the noise floor by this much to count. */
+const ACTIVITY_GATE_DB = 8
 
 /**
  * Per-frame F0 over the analysis window, with an energy gate standing in for
- * Silero. Returns the speaker's median pitch and how tightly the estimates
- * cluster around it — see VOICE_PITCH_CONCENTRATION_MIN for why the second
- * number matters.
+ * Silero. Returns the median pitch of whatever sustained source is present and
+ * how tightly the estimates cluster around it — see PITCH_CONCENTRATION_MIN for
+ * why the second number matters.
  */
-function measureVoicePitch(samples, sampleRate) {
-  const none = { pitchHz: null, concentration: 0, voicedFrames: 0 }
+function measurePitchedSource(samples, sampleRate) {
+  const none = { pitchHz: null, concentration: 0, pitchedFrames: 0 }
   const nFrames = Math.floor((samples.length - F0_FRAME_SIZE) / F0_HOP) + 1
   if (nFrames < 1) return none
 
@@ -139,9 +150,9 @@ function measureVoicePitch(samples, sampleRate) {
   // `p10 + 8` is the speech gate reference_eq.py uses, and it is right for
   // material with real dynamic range. It collapses on steady content, though —
   // when every frame sits at the same level the 10th percentile IS that level,
-  // so nothing clears the gate and the pitch pass sees no voiced frames at all.
+  // so nothing clears the gate and the pitch pass sees no usable frames at all.
   // Falling back to just under the loud end keeps steady material analysable.
-  const gateDb = Math.min(p10 + VOICING_GATE_DB, p95 - 3)
+  const gateDb = Math.min(p10 + ACTIVITY_GATE_DB, p95 - 3)
 
   const tracker = new F0Tracker({ sampleRate, frameSize: F0_FRAME_SIZE })
   const frame = new Float64Array(F0_FRAME_SIZE)
@@ -149,8 +160,8 @@ function measureVoicePitch(samples, sampleRate) {
   for (let f = 0; f < nFrames; f++) {
     const off = f * F0_HOP
     for (let i = 0; i < F0_FRAME_SIZE; i++) frame[i] = samples[off + i]
-    const { f0, voiced } = tracker.estimate(frame, frameDb[f] > gateDb)
-    if (voiced) pitches.push(f0)
+    const { f0, pitched } = tracker.estimate(frame, frameDb[f] > gateDb)
+    if (pitched) pitches.push(f0)
   }
   if (pitches.length < F0_VETO_MIN_FRAMES) return none
 
@@ -168,17 +179,17 @@ function measureVoicePitch(samples, sampleRate) {
   return {
     pitchHz,
     concentration: near / pitches.length,
-    voicedFrames: pitches.length,
+    pitchedFrames: pitches.length,
   }
 }
 
 /**
- * Is this frequency the speaker's pitch, or a harmonic of it?
+ * Is this frequency the measured pitch, or a harmonic of it?
  * Returns the matching harmonic number, or 0 for no match.
  */
-function voiceHarmonicOf(frequency, pitchHz) {
-  for (let h = 1; h <= MAX_VOICE_HARMONIC; h++) {
-    if (Math.abs(frequency - h * pitchHz) <= voiceToleranceHz(h)) return h
+function pitchHarmonicOf(frequency, pitchHz) {
+  for (let h = 1; h <= MAX_TRACKED_HARMONIC; h++) {
+    if (Math.abs(frequency - h * pitchHz) <= pitchToleranceHz(h)) return h
   }
   return 0
 }
@@ -280,7 +291,7 @@ function getMedianFloor(magnitudeDb, centerHz, windowHz, excludeHz, sampleRate, 
  *   detectionDetail: Array<{
  *     frequency: number, multiplier: number, peakDb: number|null,
  *     floorDb: number|null, deltaDb: number|null, flagged: boolean,
- *     rejectionReason: string|null, looksLikeVoice: boolean,
+ *     rejectionReason: string|null, inPitchRange: boolean,
  *   }>,
  * }}
  */
@@ -316,9 +327,9 @@ export function detectHum(samples, sampleRate, options = {}) {
       deltaDb: null,
       flagged: false,
       rejectionReason: 'selection-too-short',
-      looksLikeVoice: false,
-      matchesVoicePitch: false,
-      voiceOverlapFraction: 0,
+      inPitchRange: false,
+      matchesPitchedSource: false,
+      pitchOverlapFraction: 0,
     })),
   }
   if (analyzedSeconds < MIN_ANALYSIS_SECONDS) return empty
@@ -328,19 +339,19 @@ export function detectHum(samples, sampleRate, options = {}) {
   const magnitudeDb = computeMagnitudeSpectrum(view, FFT_SIZE, fft)
 
   // Second line of defence, only worth the pitch pass if some candidate could
-  // plausibly be a voice fundamental.
-  const anyInVoiceRange = harmonics.some(m => {
+  // plausibly be the fundamental of a wanted pitched source.
+  const anyInPitchRange = harmonics.some(m => {
     const f = fundamental * m
-    return f >= VOICE_F0_RANGE_HZ[0] && f <= VOICE_F0_RANGE_HZ[1]
+    return f >= PITCHED_F0_RANGE_HZ[0] && f <= PITCHED_F0_RANGE_HZ[1]
   })
-  const voice =
-    opts.voicePitchCheck && anyInVoiceRange
-      ? measureVoicePitch(view, sampleRate)
-      : { pitchHz: null, concentration: 0, voicedFrames: 0 }
+  const source =
+    opts.pitchSourceCheck && anyInPitchRange
+      ? measurePitchedSource(view, sampleRate)
+      : { pitchHz: null, concentration: 0, pitchedFrames: 0 }
   // Only trust the pitch when the estimates actually cluster; a scattered
-  // contour means the tracker was chasing a tone, not following a speaker.
-  const voicePitchTrusted =
-    voice.pitchHz !== null && voice.concentration >= VOICE_PITCH_CONCENTRATION_MIN
+  // contour means the tracker was chasing the hum, not following a real source.
+  const pitchTrusted =
+    source.pitchHz !== null && source.concentration >= PITCH_CONCENTRATION_MIN
 
   // First pass: measure every harmonic, flag nothing yet.
   const measurements = harmonics.map(multiplier => {
@@ -386,10 +397,10 @@ export function detectHum(samples, sampleRate, options = {}) {
       else rejectionReason = 'anchor-coherence'
     }
 
-    const inVoiceRange =
-      frequency >= VOICE_F0_RANGE_HZ[0] && frequency <= VOICE_F0_RANGE_HZ[1]
-    const voiceHarmonic = voicePitchTrusted
-      ? voiceHarmonicOf(frequency, voice.pitchHz)
+    const inPitchRange =
+      frequency >= PITCHED_F0_RANGE_HZ[0] && frequency <= PITCHED_F0_RANGE_HZ[1]
+    const pitchHarmonic = pitchTrusted
+      ? pitchHarmonicOf(frequency, source.pitchHz)
       : 0
 
     detectionDetail.push({
@@ -400,10 +411,10 @@ export function detectHum(samples, sampleRate, options = {}) {
       deltaDb: round2(deltaDb),
       flagged,
       rejectionReason,
-      looksLikeVoice: inVoiceRange,
-      voiceHarmonic,
+      inPitchRange,
+      pitchHarmonic,
       // Filled in below, once the whole flagged set can be weighed.
-      matchesVoicePitch: false,
+      matchesPitchedSource: false,
     })
 
     if (flagged) flaggedHarmonics.push(frequency)
@@ -414,22 +425,22 @@ export function detectHum(samples, sampleRate, options = {}) {
   // A pitch match on its own is not enough. Hum whose fundamental has been
   // high-passed away — energy at 120, 180 and 240 — has a true period of 60 Hz,
   // below the tracker's floor, so it locks onto 120 Hz with a rock-steady
-  // contour and looks exactly like a 120 Hz speaker. What separates them is
+  // contour and looks exactly like a real 120 Hz source. What separates them is
   // 180 Hz: it sits on the mains grid but is nowhere in a 120 Hz harmonic
-  // series. So the voice hypothesis only wins when it accounts for EVERY
-  // flagged harmonic; a single one off the series means the mains grid is the
-  // better explanation and nothing is vetoed.
+  // series. So the pitched-source hypothesis only wins when it accounts for
+  // EVERY flagged harmonic; a single one off the series means the mains grid is
+  // the better explanation and nothing is vetoed.
   //
-  // When both are genuinely present — a 120 Hz speaker over real 60 Hz hum —
-  // the grid wins and the shared harmonics get notched. That is the right call
-  // by default: no notch can separate hum from a voice at the same frequency,
-  // and the row stays tickable either way.
+  // When both are genuinely present — a 120 Hz voice or bass over real 60 Hz
+  // hum — the grid wins and the shared harmonics get notched. That is the right
+  // call by default: no notch can separate hum from wanted content at the same
+  // frequency, and the row stays tickable either way.
   const flaggedDetails = detectionDetail.filter(d => d.flagged)
-  const voiceExplainsAll =
-    flaggedDetails.length > 0 && flaggedDetails.every(d => d.voiceHarmonic > 0)
-  if (voiceExplainsAll) {
+  const pitchExplainsAll =
+    flaggedDetails.length > 0 && flaggedDetails.every(d => d.pitchHarmonic > 0)
+  if (pitchExplainsAll) {
     for (const d of detectionDetail) {
-      d.matchesVoicePitch = d.voiceHarmonic > 0
+      d.matchesPitchedSource = d.pitchHarmonic > 0
     }
   }
 
@@ -437,7 +448,7 @@ export function detectHum(samples, sampleRate, options = {}) {
   // single remaining harmonic is more likely musical content or a room
   // resonance than mains hum, so it does not trigger on its own.
   const recommendedHarmonics = detectionDetail
-    .filter(d => d.flagged && !d.matchesVoicePitch)
+    .filter(d => d.flagged && !d.matchesPitchedSource)
     .map(d => d.frequency)
   const triggered = recommendedHarmonics.length >= minHarmonicsToTrigger
 
@@ -449,11 +460,15 @@ export function detectHum(samples, sampleRate, options = {}) {
     anchorDeltaDb: round2(anchorDelta),
     /** Everything the spectral test flagged, before the pitch check. */
     flaggedHarmonics,
-    /** What to actually notch — flagged, minus anything that is the speaker. */
+    /** What to actually notch — flagged, minus anything the pitch check claimed. */
     recommendedHarmonics,
-    /** Measured speaker pitch, or null when none was found or trusted. */
-    voicePitchHz: voicePitchTrusted ? round2(voice.pitchHz) : null,
-    voicePitchConcentration: round2(voice.concentration),
+    /**
+     * Median pitch of the sustained source found in the selection, or null
+     * when none was found or the contour was too scattered to trust. Usually a
+     * voice, but a bass, cello or held synth note reads the same way.
+     */
+    pitchedSourceHz: pitchTrusted ? round2(source.pitchHz) : null,
+    pitchConcentration: round2(source.concentration),
     detectionDetail,
   }
 }

--- a/src/audio/effects/resonance.js
+++ b/src/audio/effects/resonance.js
@@ -19,26 +19,12 @@
 
 import { ensureResonanceWorklet } from '../resonanceWorkletLoader.js'
 import { createLevelTap } from './levelTap.js'
+import { PITCH_RANGES, RESONANCE_FRAME_SIZE } from '../resonanceParams.js'
 
-/** Matches FFT_SIZE in resonanceProcessor.js. */
-export const RESONANCE_LATENCY_SAMPLES = 2048
+export { PITCH_RANGES, RESONANCE_FRAME_SIZE, effectivePitchRange } from '../resonanceParams.js'
 
-/**
- * Pitch search ranges for harmonic protection.
- *
- * The server's stage only ever ran on speech, so its range was a constant. This
- * effect is a general tool, and an out-of-range source does not degrade
- * gracefully: the tracker returns the best lag *within* the range, which for an
- * out-of-range pitch is an octave artefact reported with full confidence, and
- * the protection mask then lands on bins that are not harmonics.
- *
- * `wide` bottoms out at 40 Hz because a 2048-sample frame cannot autocorrelate
- * reliably at longer lags; the kernel clamps to what it can actually resolve.
- */
-export const PITCH_RANGES = {
-  voice: { minHz: 70, maxHz: 400, label: 'VOICE', title: 'Speech and vocals (70–400 Hz)' },
-  wide: { minHz: 40, maxHz: 1200, label: 'WIDE', title: 'Instruments and full-range material (40–1200 Hz)' },
-}
+/** This STFT holds back exactly one frame before a sample is reconstructed. */
+export const RESONANCE_LATENCY_SAMPLES = RESONANCE_FRAME_SIZE
 
 // Defaults are the acx_audiobook preset's resonanceSuppressor block
 // (src/audio/presets.js), which is the tuning these were chosen against.

--- a/src/audio/effects/resonance.js
+++ b/src/audio/effects/resonance.js
@@ -23,6 +23,23 @@ import { createLevelTap } from './levelTap.js'
 /** Matches FFT_SIZE in resonanceProcessor.js. */
 export const RESONANCE_LATENCY_SAMPLES = 2048
 
+/**
+ * Pitch search ranges for harmonic protection.
+ *
+ * The server's stage only ever ran on speech, so its range was a constant. This
+ * effect is a general tool, and an out-of-range source does not degrade
+ * gracefully: the tracker returns the best lag *within* the range, which for an
+ * out-of-range pitch is an octave artefact reported with full confidence, and
+ * the protection mask then lands on bins that are not harmonics.
+ *
+ * `wide` bottoms out at 40 Hz because a 2048-sample frame cannot autocorrelate
+ * reliably at longer lags; the kernel clamps to what it can actually resolve.
+ */
+export const PITCH_RANGES = {
+  voice: { minHz: 70, maxHz: 400, label: 'VOICE', title: 'Speech and vocals (70–400 Hz)' },
+  wide: { minHz: 40, maxHz: 1200, label: 'WIDE', title: 'Instruments and full-range material (40–1200 Hz)' },
+}
+
 // Defaults are the acx_audiobook preset's resonanceSuppressor block
 // (src/audio/presets.js), which is the tuning these were chosen against.
 export const RESONANCE_DEFAULTS = {
@@ -36,10 +53,12 @@ export const RESONANCE_DEFAULTS = {
   freqCeil: 20000, // Hz
   mode: 'soft', // 'soft' | 'hard'
   preserveHarmonics: true,
+  pitchRange: 'voice', // key of PITCH_RANGES
 }
 
 /** Map UI param names to kernel param names. */
 export function toKernelParams(params) {
+  const range = PITCH_RANGES[params.pitchRange] ?? PITCH_RANGES.voice
   return {
     depth: params.depth,
     sharpness: params.sharpness,
@@ -51,6 +70,8 @@ export function toKernelParams(params) {
     freqCeilHz: params.freqCeil,
     mode: params.mode,
     preserveHarmonics: params.preserveHarmonics,
+    pitchMinHz: range.minHz,
+    pitchMaxHz: range.maxHz,
   }
 }
 

--- a/src/audio/resonanceParams.js
+++ b/src/audio/resonanceParams.js
@@ -1,0 +1,49 @@
+/**
+ * Resonance Suppressor parameters shared between the UI and the kernel.
+ *
+ * Separate from effects/resonance.js because that module imports the worklet
+ * loader, whose `?worker&url` specifier only resolves under Vite — so anything
+ * it touches is unreachable from `node --test`. The pitch-range clamp mirrored
+ * here has to be testable against the kernel's own clamp, which is the whole
+ * reason it exists.
+ */
+
+import { pitchFloorHz } from './dsp/f0.js'
+
+/**
+ * Matches FFT_SIZE in resonanceProcessor.js. Duplicated rather than imported so
+ * the app bundle does not pull in the whole kernel — it is loaded as a worklet,
+ * not as a module.
+ */
+export const RESONANCE_FRAME_SIZE = 2048
+
+/**
+ * Pitch search ranges for harmonic protection.
+ *
+ * The server's stage only ever ran on speech, so its range was a constant. This
+ * effect is a general tool, and an out-of-range source does not degrade
+ * gracefully: the tracker returns the best lag *within* the range, which for an
+ * out-of-range pitch is an octave artefact reported with full confidence, and
+ * the protection mask then lands on bins that are not harmonics.
+ *
+ * `wide` asks for 40 Hz, below what a 2048-sample frame can autocorrelate; the
+ * kernel clamps it, and `effectivePitchRange` is how the UI finds out to what.
+ */
+export const PITCH_RANGES = {
+  voice: { minHz: 70, maxHz: 400, label: 'VOICE', title: 'Speech and vocals (70–400 Hz)' },
+  wide: { minHz: 40, maxHz: 1200, label: 'WIDE', title: 'Instruments and full-range material (40–1200 Hz)' },
+}
+
+/**
+ * The pitch range actually used, after the kernel's clamp.
+ *
+ * The kernel clamps the requested range to what its frame can autocorrelate and
+ * records the result on `kernel.pitchRange` — but that lives inside a worklet
+ * and there is no channel back out for a value needed to render a label. So the
+ * clamp is mirrored here, and a test pins the two together.
+ */
+export function effectivePitchRange(sampleRate, rangeKey) {
+  const range = PITCH_RANGES[rangeKey] ?? PITCH_RANGES.voice
+  const floor = pitchFloorHz(sampleRate, RESONANCE_FRAME_SIZE)
+  return { minHz: Math.max(floor, range.minHz), maxHz: range.maxHz }
+}

--- a/src/audio/resonanceProcessor.js
+++ b/src/audio/resonanceProcessor.js
@@ -277,8 +277,10 @@ export class ResonanceKernel {
       : 0
 
     // Pitch search range. The tracker clamps to what the frame can resolve and
-    // reports back what it settled on, so the UI can show the real range rather
-    // than the requested one.
+    // returns the range it settled on; kept here so tests and any future
+    // in-worklet reporting can read it. The UI mirrors the same clamp on the
+    // main thread via effectivePitchRange() — there is no channel out of a
+    // worklet for a value that is needed to render a label.
     this.pitchRange = this.f0.setRange(
       p.pitchMinHz ?? DEFAULT_PITCH_MIN_HZ,
       p.pitchMaxHz ?? DEFAULT_PITCH_MAX_HZ,

--- a/src/audio/resonanceProcessor.js
+++ b/src/audio/resonanceProcessor.js
@@ -27,20 +27,31 @@
  * transition detector (a ±5-frame lookahead that would cost another 58 ms of
  * latency and is outside the core parameter set).
  *
- * HARMONIC PROTECTION IS NOT OPTIONAL. Cepstral liftering puts the reference at
- * the inter-harmonic floor, so vocal harmonics protrude above it and read as
- * resonances. Without the mask the suppressor eats the voice — the server
- * refuses to run the stage at all when `preserve_harmonics` is on and no F0 is
- * available. Here F0Tracker supplies a per-frame pitch, which is what makes the
- * mask possible live.
+ * HARMONIC PROTECTION MATTERS WHEREVER THERE ARE HARMONICS. Cepstral liftering
+ * puts the reference at the inter-harmonic floor, so the harmonics of a pitched
+ * source protrude above it and read as resonances. Without the mask the
+ * suppressor eats them — the server refuses to run the stage at all when
+ * `preserve_harmonics` is on and no F0 is available. Here F0Tracker supplies a
+ * per-frame pitch, which is what makes the mask possible live.
+ *
+ * THIS EFFECT IS NOT VOICE-ONLY. The server stage ran inside a voice mastering
+ * chain and could assume speech; a realtime effect gets pointed at drums,
+ * synths, guitars and room tone. Two consequences run through this file:
+ *
+ *   - Suppression is gated on signal presence, never on pitch. Unpitched
+ *     material is exactly as valid an input as a narrator.
+ *   - The pitch search range is a parameter (`pitchMinHz` / `pitchMaxHz`), not
+ *     the server's hard-coded speech band. An out-of-range source does not fail
+ *     quietly — the tracker returns an octave artefact with full confidence and
+ *     the mask lands on bins that are not harmonics, which is worse than having
+ *     no mask at all.
  *
  * THREE APPROXIMATIONS vs. the server, all consequences of streaming:
  *
  *   - Lifter cutoff comes from a rolling median pitch rather than the whole
  *     file's median.
- *   - Voicing comes from the pitch tracker's correlation gate plus an absolute
- *     energy floor, in place of Silero labels. Non-voiced frames get a zero
- *     target so the IIR decays through them.
+ *   - Frame activity comes from an absolute energy floor in place of Silero
+ *     labels. Silent frames get a zero target so the IIR decays through them.
  *   - The cepstral reference is computed over the full spectrum rather than the
  *     server's band-restricted variant. Band restriction exists for passes with
  *     a very small lifter cutoff (L≈3, the sibilant-only passes), where the
@@ -61,28 +72,73 @@ const HOP_SIZE = 512
 /** Matches `eps` in resonance_suppressor.py's process(). */
 const MAG_EPS = 1e-10
 
-/** Lifter cutoff before any pitch has been measured. */
-const DEFAULT_F0_HZ = 60
+/**
+ * Cepstral lifter cutoff used when no pitch has been measured, in quefrency
+ * bins — the `else` branch of resonance_suppressor.py:346.
+ *
+ * This is a cutoff, NOT a pitch. An earlier version of this file seeded the
+ * tracker with a 60 Hz *pitch* and ran it through `0.40 * sr / f0`, which
+ * yields L = 294 rather than 60 — an envelope roughly five times finer than
+ * intended. A fine envelope traces a resonance instead of passing under it, so
+ * nothing protrudes and nothing is suppressed. On speech that only affected
+ * warmup, because a real pitch arrives within a frame or two. On unpitched
+ * material there is never a pitch, so the wrong cutoff was permanent and the
+ * effect did essentially nothing (measured: 0.3 dB removed from a 13 dB
+ * resonance in noise).
+ */
+const DEFAULT_LIFTER_CUTOFF = 60
 
 // Harmonic protection geometry — DEFAULT_PARAMS in resonance_suppressor.py.
 const HARMONIC_WIDTH_BINS = 2
 const HARMONIC_WIDTH_PCT = 0.01
-const MAX_HARMONIC = 100
+
+/**
+ * Safety bound on the harmonic walk.
+ *
+ * The server caps at a fixed 100 harmonics, which makes the protected band slide
+ * with pitch — at 40 Hz it stops at 4 kHz and leaves everything above exposed,
+ * at 220 Hz it runs past Nyquist. The walk now ends at `freqCeilHz` instead, so
+ * the protected band is the band the user asked to process. This is only a guard
+ * against a pathological pitch making the loop long.
+ */
+const MAX_HARMONIC = 4096
+
+/**
+ * Minimum open bins between neighbouring harmonic masks, and the harmonic
+ * spacing below which the comb stops being representable at all.
+ *
+ * A protection mask is only useful if the inter-harmonic floor stays exposed
+ * for the suppressor to work on. Once neighbouring masks touch, "protect the
+ * harmonics" becomes "protect everything" and the effect goes inert. At
+ * 2048/44.1 kHz the spacing limit puts the pitch floor for protection at
+ * ~64.6 Hz — which is, not coincidentally, right where the server's 70 Hz
+ * speech floor sits.
+ */
+const MIN_HARMONIC_GAP_BINS = 1
+const MIN_HARMONIC_SPACING_BINS = 3
 
 /** Bound the per-pitch mask cache so a long session cannot grow it forever. */
 const MASK_CACHE_LIMIT = 256
 
 /**
- * Absolute energy floor for the voicing decision, in dB of frame mean-square.
+ * Absolute energy floor below which a frame is treated as silence, in dB of
+ * frame mean-square.
  *
- * Voicing is decided by F0Tracker's correlation-ratio gate, which already
- * rejects noise and silence; this only stops the tracker chasing a pitch in
- * near-silence. It is deliberately absolute rather than relative to a measured
- * noise floor: a floor tracker rises toward the signal, so on continuous speech
- * with no silence in it the floor converges on the speech level and the gate
- * never opens at all.
+ * Deliberately absolute rather than relative to a measured noise floor: a floor
+ * tracker rises toward the signal, so on continuous material with no silence in
+ * it the floor converges on the signal level and the gate never opens at all.
  */
-const VOICING_FLOOR_DB = -60
+const SILENCE_FLOOR_DB = -60
+
+/**
+ * Default pitch search range for harmonic protection.
+ *
+ * The server hard-coded the speech range because the stage only ever ran inside
+ * a voice mastering chain. A realtime effect gets pointed at drums, synths and
+ * instruments, so the range is a parameter — see `pitchMinHz` / `pitchMaxHz`.
+ */
+const DEFAULT_PITCH_MIN_HZ = 70
+const DEFAULT_PITCH_MAX_HZ = 400
 
 export const RESONANCE_KERNEL_DEFAULTS = {
   depth: 0.67,
@@ -93,6 +149,8 @@ export const RESONANCE_KERNEL_DEFAULTS = {
   maxReductionDb: 36,
   freqFloorHz: 40,
   freqCeilHz: 20000,
+  pitchMinHz: DEFAULT_PITCH_MIN_HZ,
+  pitchMaxHz: DEFAULT_PITCH_MAX_HZ,
   mode: 'soft', // 'soft' | 'hard'
   preserveHarmonics: true,
 }
@@ -112,7 +170,9 @@ export class ResonanceKernel {
     this.f0 = new F0Tracker({
       sampleRate,
       frameSize: FFT_SIZE,
-      defaultF0: DEFAULT_F0_HZ,
+      defaultF0: null,
+      minHz: DEFAULT_PITCH_MIN_HZ,
+      maxHz: DEFAULT_PITCH_MAX_HZ,
     })
 
     // One STFT per channel. Detection runs on channel 0 and the resulting gain
@@ -167,6 +227,7 @@ export class ResonanceKernel {
 
   /** Merge a partial param update and recompute derived state. */
   setParams(partial) {
+    const prevCeilHz = this.freqCeilHz
     const p = { ...this.params, ...partial }
     this.params = p
 
@@ -215,8 +276,19 @@ export class ResonanceKernel {
       ? Math.exp(-this.frameRateMs / p.releaseMs)
       : 0
 
-    // Harmonic geometry changed (band limits), so cached masks no longer apply.
-    if ('freqFloorHz' in partial || 'freqCeilHz' in partial) this.maskCache.clear()
+    // Pitch search range. The tracker clamps to what the frame can resolve and
+    // reports back what it settled on, so the UI can show the real range rather
+    // than the requested one.
+    this.pitchRange = this.f0.setRange(
+      p.pitchMinHz ?? DEFAULT_PITCH_MIN_HZ,
+      p.pitchMaxHz ?? DEFAULT_PITCH_MAX_HZ,
+    )
+
+    // The harmonic walk now ends at freqCeilHz, so that is the only param the
+    // cached masks depend on. Compare values rather than key presence: the
+    // effect wrapper posts the full param object on every knob move, so an
+    // `in partial` test is true on every twist and never lets the cache survive.
+    if (this.freqCeilHz !== prevCeilHz) this.maskCache.clear()
   }
 
   reset() {
@@ -230,9 +302,14 @@ export class ResonanceKernel {
   /**
    * Boolean protection mask for one pitch: bins belonging to a harmonic of f0.
    * Cached per rounded pitch, as the Python does.
+   *
+   * Returns null when the comb cannot be represented at this bin width — see
+   * MIN_HARMONIC_SPACING_BINS. A null mask means "no protection available",
+   * which the caller must not confuse with "no protection needed".
    */
   _harmonicMask(f0) {
     if (!f0 || f0 <= 0) return null
+    if (f0 / this.binWidth < MIN_HARMONIC_SPACING_BINS) return null
     const key = Math.round(f0)
     const cached = this.maskCache.get(key)
     if (cached) return cached
@@ -241,12 +318,25 @@ export class ResonanceKernel {
 
     const mask = new Uint8Array(this.binCount)
     const nyquist = this.sampleRate / 2
+
+    // Widest half-width that still leaves a gap between neighbouring harmonics.
+    // Without this the comb merges into a solid block and the suppressor has
+    // nothing left to work on — measured at 100% coverage for f0 <= 82 Hz, and
+    // above ~5 kHz even at 150 Hz, because the 1% term outgrows the spacing.
+    // The server gets away with it only because its fixed 100-harmonic cap
+    // truncates the comb before the damage is visible.
+    const spacingBins = f0 / this.binWidth
+    const maxHalf = Math.max(
+      0,
+      Math.floor((spacingBins - 1 - MIN_HARMONIC_GAP_BINS) / 2),
+    )
+
     for (let h = 1; h <= MAX_HARMONIC; h++) {
       const freq = h * f0
       if (freq > this.freqCeilHz || freq >= nyquist) break
       const center = Math.round(freq / this.binWidth)
       const pctHalf = Math.round((freq * HARMONIC_WIDTH_PCT) / this.binWidth)
-      const half = Math.max(HARMONIC_WIDTH_BINS, pctHalf)
+      const half = Math.min(Math.max(HARMONIC_WIDTH_BINS, pctHalf), maxHalf)
       const lo = Math.max(0, center - half)
       const hi = Math.min(this.binCount - 1, center + half)
       for (let k = lo; k <= hi; k++) mask[k] = 1
@@ -295,17 +385,30 @@ export class ResonanceKernel {
     for (let i = 0; i < FFT_SIZE; i++) sumSq += raw[i] * raw[i]
     const frameDb = 10 * Math.log10(sumSq / FFT_SIZE + 1e-20)
 
-    const { f0, voiced } = this.f0.estimate(raw, frameDb > VOICING_FLOOR_DB)
-    const medianF0 = this.f0.median ?? DEFAULT_F0_HZ
-
-    // lifter_cutoff = max(20, int(0.40 * sr / f0))
+    // TWO SEPARATE QUESTIONS, and conflating them is what made this effect
+    // switch itself off on anything unpitched:
+    //
+    //   active  — is there enough signal here to act on at all? Drives whether
+    //             suppression runs.
+    //   pitched — did we find a periodic component? Drives ONLY whether the
+    //             harmonic protection mask is available.
+    //
+    // A frame can be loud and unpitched — a fricative, a snare, a cymbal, a
+    // noise sweep — and those frames still need suppressing. They just have no
+    // harmonics to protect.
+    const active = frameDb > SILENCE_FLOOR_DB
+    const { f0, pitched } = this.f0.estimate(raw, active)
+    // lifter_cutoff = max(20, int(0.40 * sr / f0)), or the flat default when
+    // no pitch has been measured yet — the two branches of
+    // resonance_suppressor.py:343-346.
+    const medianF0 = this.f0.median
     const lifterCutoff = medianF0 > 0
       ? Math.max(20, Math.trunc((0.4 * this.sampleRate) / medianF0))
-      : 60
+      : DEFAULT_LIFTER_CUTOFF
 
     this._cepstralEnvelope(lifterCutoff)
 
-    const mask = this.preserveHarmonics && voiced ? this._harmonicMask(f0) : null
+    const mask = this.preserveHarmonics && pitched ? this._harmonicMask(f0) : null
 
     // Spike detection → soft knee → depth → clip.
     for (let k = 0; k < binCount; k++) {
@@ -351,9 +454,10 @@ export class ResonanceKernel {
       }
     }
 
-    // Non-voiced frames target zero, so the IIR decays through silence rather
-    // than holding a cut across it.
-    if (!voiced) reduction.fill(0)
+    // Silent frames target zero, so the IIR decays through silence rather than
+    // holding a cut across it. Note this keys off `active`, not `pitched` —
+    // an unpitched frame is still processed.
+    if (!active) reduction.fill(0)
 
     // Per-bin attack/release at the frame rate.
     const { attackCoeff, releaseCoeff } = this

--- a/src/components/panels/HumRemoverModal.vue
+++ b/src/components/panels/HumRemoverModal.vue
@@ -40,15 +40,17 @@ const statusLine = computed(() => {
   }
   if (isStale.value) return 'Audio changed since analysis — analyse again.'
   const a = humAnalysis.value
-  const vetoed = a.detectionDetail.filter(d => d.flagged && d.matchesVoicePitch)
+  const vetoed = a.detectionDetail.filter(d => d.flagged && d.matchesPitchedSource)
   if (!a.triggered && enabledCount.value === 0) {
     if (vetoed.length > 0) {
       const list = vetoed.map(d => `${d.frequency} Hz`).join(', ')
-      return `Energy at ${list} tracks the voice (${a.voicePitchHz} Hz), not mains hum.`
+      return `Energy at ${list} follows a ${a.pitchedSourceHz} Hz source in the recording, not mains hum.`
     }
     return `No hum found. Anchor ${a.anchorFrequency} Hz was ${a.anchorDeltaDb} dB above the floor.`
   }
-  const suffix = vetoed.length > 0 ? ` ${vetoed.length} left out as voice.` : ''
+  const suffix = vetoed.length > 0
+    ? ` ${vetoed.length} left out as part of the recording.`
+    : ''
   return `${enabledCount.value} notch${enabledCount.value === 1 ? '' : 'es'} active.${suffix}`
 })
 
@@ -75,24 +77,31 @@ function deltaWidth(deltaDb) {
 /**
  * Accessible name for a harmonic's toggle. The visible row is a bar and a
  * number, so the label has to carry the frequency, how prominent it is, and
- * whether the pitch check thinks it is the voice — everything a sighted user
- * reads off the row before deciding.
+ * whether the pitch check attributed it to the recording — everything a
+ * sighted user reads off the row before deciding.
  */
 function harmonicToggleLabel(h) {
   if (h.deltaDb === null) return `${h.frequency} Hz — not analysed`
   const prominence = `${h.deltaDb.toFixed(1)} dB above the surrounding floor`
-  if (h.matchesVoicePitch) return `${h.frequency} Hz, ${prominence}, matches the speaker's pitch`
+  if (h.matchesPitchedSource) {
+    return `${h.frequency} Hz, ${prominence}, matches a pitched source in the recording`
+  }
   return `${h.frequency} Hz, ${prominence}`
 }
 
-/** Why a harmonic was marked as the speaker rather than hum. */
-function voiceTooltip(h) {
-  const pitch = humAnalysis.value?.voicePitchHz
-  if (!pitch) return 'This looks like the voice rather than hum.'
-  const which = h.voiceHarmonic === 1
-    ? `the speaker's pitch (${pitch} Hz)`
-    : `harmonic ${h.voiceHarmonic} of the speaker's pitch (${pitch} Hz)`
-  return `${h.frequency} Hz is ${which}, so this energy is probably the voice, not hum. Notching it will thin the recording. Tick it anyway if you can hear hum here.`
+/**
+ * Why a harmonic was attributed to the recording rather than to the mains.
+ *
+ * Deliberately says "source" rather than "voice": the check is an F0 contour,
+ * and a bass, a cello or a held synth note trips it exactly as a narrator does.
+ */
+function pitchedTooltip(h) {
+  const pitch = humAnalysis.value?.pitchedSourceHz
+  if (!pitch) return 'This looks like part of the recording rather than hum.'
+  const which = h.pitchHarmonic === 1
+    ? `the pitch of a sustained source in this selection (${pitch} Hz)`
+    : `harmonic ${h.pitchHarmonic} of a sustained source in this selection (${pitch} Hz)`
+  return `${h.frequency} Hz is ${which}, so this energy is probably content, not hum. Notching it will thin the recording. Tick it anyway if you can hear hum here.`
 }
 
 function rejectionLabel(h) {
@@ -224,10 +233,10 @@ async function applyAndClose() {
                   />
                 </div>
                 <span
-                  v-if="h.matchesVoicePitch"
-                  :title="voiceTooltip(h)"
+                  v-if="h.matchesPitchedSource"
+                  :title="pitchedTooltip(h)"
                   style="font:700 7.5px 'JetBrains Mono',monospace;letter-spacing:.08em;color:#ffb27a;white-space:nowrap"
-                >IS VOICE</span>
+                >IN SOURCE</span>
                 <span
                   v-else-if="rejectionLabel(h)"
                   style="font:500 8.5px 'Inter';color:rgba(255,255,255,.26);white-space:nowrap"
@@ -258,7 +267,7 @@ async function applyAndClose() {
            style="border-top:1px solid rgba(255,255,255,.06)">
         <p style="font:500 10px/1.5 'Inter';color:rgba(255,255,255,.3);max-width:320px">
           Narrow cuts at the mains frequency and its harmonics. Deeper and wider
-          removes more hum but takes more of the voice with it.
+          removes more hum but takes more of the recording with it.
         </p>
         <div class="flex gap-[26px]">
           <div class="w-[80px]">

--- a/src/components/panels/ResonanceModal.vue
+++ b/src/components/panels/ResonanceModal.vue
@@ -1,7 +1,7 @@
 <script setup>
 import { computed, onMounted } from 'vue'
 import { useResonance } from '../../composables/useResonance.js'
-import { PITCH_RANGES } from '../../audio/effects/resonance.js'
+import { PITCH_RANGES, effectivePitchRange } from '../../audio/resonanceParams.js'
 import { useEditorState } from '../../composables/useEditorState.js'
 import Knob from '../knobs/Knob.vue'
 import SegmentedSwitch from '../knobs/SegmentedSwitch.vue'
@@ -53,8 +53,11 @@ const modeCaption = computed(() =>
   resMode.value === 'soft' ? 'gradual knee' : 'linear above threshold',
 )
 
+// The kernel clamps the low end to what its analysis frame can resolve, so show
+// what it will actually search rather than what the preset asked for.
 const pitchRangeCaption = computed(() => {
-  const r = PITCH_RANGES[resPitchRange.value] ?? PITCH_RANGES.voice
+  const sr = state.currentFile?.sampleRate ?? 44100
+  const r = effectivePitchRange(sr, resPitchRange.value)
   return `${Math.round(r.minHz)}–${Math.round(r.maxHz)} Hz`
 })
 

--- a/src/components/panels/ResonanceModal.vue
+++ b/src/components/panels/ResonanceModal.vue
@@ -1,6 +1,7 @@
 <script setup>
 import { computed, onMounted } from 'vue'
 import { useResonance } from '../../composables/useResonance.js'
+import { PITCH_RANGES } from '../../audio/effects/resonance.js'
 import { useEditorState } from '../../composables/useEditorState.js'
 import Knob from '../knobs/Knob.vue'
 import SegmentedSwitch from '../knobs/SegmentedSwitch.vue'
@@ -15,10 +16,10 @@ defineProps({ z: { type: Number, default: 500 } })
 const {
   resDepth, resSharpness, resSelectivity, resAttack, resRelease,
   resMaxReduction, resFreqFloor, resFreqCeil, resMode, resPreserveHarmonics,
-  resPreview, resReduction, resInputDb, resOutputDb, hasSelection,
+  resPitchRange, resPreview, resReduction, resInputDb, resOutputDb, hasSelection,
   togglePreview, syncDepth, syncSharpness, syncSelectivity, syncAttack,
   syncRelease, syncMaxReduction, syncFreqFloor, syncFreqCeil, syncMode,
-  togglePreserveHarmonics, apply, teardown, closeModal,
+  syncPitchRange, togglePreserveHarmonics, apply, teardown, closeModal,
 } = useResonance()
 
 const { state } = useEditorState()
@@ -34,6 +35,14 @@ const MODE_OPTIONS = [
   { value: 'hard', label: 'HARD', title: 'Linear above the threshold' },
 ]
 
+// Which pitches harmonic protection looks for. Nothing else about the effect
+// assumes speech, and this should not either — see PITCH_RANGES.
+const PITCH_RANGE_OPTIONS = Object.entries(PITCH_RANGES).map(([value, r]) => ({
+  value,
+  label: r.label,
+  title: r.title,
+}))
+
 const percent = v => `${Math.round(v * 100)}`
 const oneDp = v => v.toFixed(1)
 const ms = v => `${Math.round(v)}`
@@ -43,6 +52,11 @@ const db = v => `${Math.round(v)}`
 const modeCaption = computed(() =>
   resMode.value === 'soft' ? 'gradual knee' : 'linear above threshold',
 )
+
+const pitchRangeCaption = computed(() => {
+  const r = PITCH_RANGES[resPitchRange.value] ?? PITCH_RANGES.voice
+  return `${Math.round(r.minHz)}–${Math.round(r.maxHz)} Hz`
+})
 
 function togglePlayback() {
   window.dispatchEvent(new CustomEvent('wavely:toggle-play'))
@@ -167,34 +181,48 @@ async function applyAndClose() {
 
           <!-- Harmonic protection is the safety mechanism, not a flavour
                control: without it the cepstral reference sits at the
-               inter-harmonic floor and the suppressor eats vocal harmonics. -->
-          <button
-            class="shrink-0 px-3 py-[9px] rounded-lg cursor-pointer transition-all text-left disabled:cursor-default"
-            :style="{
-              width: '186px',
-              background: resPreserveHarmonics ? 'rgba(141,224,168,.14)' : 'rgba(255,178,122,.12)',
-              border: `1px solid ${resPreserveHarmonics ? 'rgba(141,224,168,.4)' : 'rgba(255,178,122,.45)'}`,
-              opacity: resPreview ? 1 : 0.4,
-            }"
-            :disabled="!resPreview"
-            title="Protects the speaker's harmonics from being treated as resonances. Turning it off is a diagnostic aid — it will thin the voice."
-            @click="togglePreserveHarmonics"
-          >
-            <span
-              class="block"
+               inter-harmonic floor and the suppressor eats the harmonics of
+               whatever is playing. The range picker sits with it because it
+               feeds it — protection is only as good as the pitch it is handed,
+               and a source outside the range reports an octave artefact rather
+               than nothing, which puts the mask on the wrong bins. -->
+          <div class="shrink-0 flex flex-col gap-[10px]" style="width:186px">
+            <button
+              class="w-full px-3 py-[9px] rounded-lg cursor-pointer transition-all text-left disabled:cursor-default"
               :style="{
-                font: `700 8.5px 'JetBrains Mono',monospace`,
-                letterSpacing: '.12em',
-                color: resPreserveHarmonics ? '#8de0a8' : '#ffb27a',
+                background: resPreserveHarmonics ? 'rgba(141,224,168,.14)' : 'rgba(255,178,122,.12)',
+                border: `1px solid ${resPreserveHarmonics ? 'rgba(141,224,168,.4)' : 'rgba(255,178,122,.45)'}`,
+                opacity: resPreview ? 1 : 0.4,
               }"
-            >{{ resPreserveHarmonics ? 'PRESERVE HARMONICS' : 'PROTECTION OFF' }}</span>
-            <span
-              class="block mt-[3px]"
-              style="font:500 9px/1.4 'Inter';color:rgba(255,255,255,.35)"
-            >{{ resPreserveHarmonics
-              ? 'Preserves harmonic frequencies.'
-              : 'Full supression — risks thinning harmonic frequencies.' }}</span>
-          </button>
+              :disabled="!resPreview"
+              title="Protects the harmonics of the pitched source in the recording from being treated as resonances. Turning it off is a diagnostic aid — it will thin the material."
+              @click="togglePreserveHarmonics"
+            >
+              <span
+                class="block"
+                :style="{
+                  font: `700 8.5px 'JetBrains Mono',monospace`,
+                  letterSpacing: '.12em',
+                  color: resPreserveHarmonics ? '#8de0a8' : '#ffb27a',
+                }"
+              >{{ resPreserveHarmonics ? 'PRESERVE HARMONICS' : 'PROTECTION OFF' }}</span>
+              <span
+                class="block mt-[3px]"
+                style="font:500 9px/1.4 'Inter';color:rgba(255,255,255,.35)"
+              >{{ resPreserveHarmonics
+                ? 'Preserves harmonic frequencies.'
+                : 'Full suppression — risks thinning harmonic frequencies.' }}</span>
+            </button>
+
+            <SegmentedSwitch
+              :model-value="resPitchRange"
+              @update:model-value="syncPitchRange"
+              :options="PITCH_RANGE_OPTIONS"
+              :accent="ACCENT"
+              :disabled="!resPreview || !resPreserveHarmonics"
+              :caption="`Protect pitches ${pitchRangeCaption}`"
+            />
+          </div>
         </div>
       </div>
 

--- a/src/composables/useHumRemover.js
+++ b/src/composables/useHumRemover.js
@@ -185,21 +185,22 @@ export function useHumRemover() {
       humAnalysis.value = result
       analyzedKey.value = selectionKey()
       // Pre-tick what the detector recommends — flagged, minus anything the
-      // pitch check identified as the speaker's own voice. Every harmonic is
-      // still listed with its measurement so the user can override either way.
+      // pitch check attributed to a sustained source in the recording. Every
+      // harmonic is still listed with its measurement so the user can override
+      // either way.
       humHarmonics.value = result.detectionDetail.map(d => ({
         ...d,
-        enabled: d.flagged && !d.matchesVoicePitch,
+        enabled: d.flagged && !d.matchesPitchedSource,
       }))
       pushFrequencies()
 
       if (result.tooShort) {
         showToast('Selection too short to detect hum reliably')
       } else if (!result.triggered) {
-        const vetoed = result.detectionDetail.filter(d => d.flagged && d.matchesVoicePitch)
+        const vetoed = result.detectionDetail.filter(d => d.flagged && d.matchesPitchedSource)
         showToast(
           vetoed.length > 0
-            ? 'No hum found — the energy there is the voice itself'
+            ? 'No hum found — that energy belongs to the recording itself'
             : 'No mains hum detected',
         )
       } else {

--- a/src/composables/useResonance.js
+++ b/src/composables/useResonance.js
@@ -19,6 +19,7 @@ const resFreqFloor = ref(RESONANCE_DEFAULTS.freqFloor)
 const resFreqCeil = ref(RESONANCE_DEFAULTS.freqCeil)
 const resMode = ref(RESONANCE_DEFAULTS.mode)
 const resPreserveHarmonics = ref(RESONANCE_DEFAULTS.preserveHarmonics)
+const resPitchRange = ref(RESONANCE_DEFAULTS.pitchRange)
 
 const resPreview = ref(false)
 const resReduction = ref(0)
@@ -38,6 +39,7 @@ function currentParams() {
     freqCeil: resFreqCeil.value,
     mode: resMode.value,
     preserveHarmonics: resPreserveHarmonics.value,
+    pitchRange: resPitchRange.value,
   }
 }
 
@@ -120,6 +122,7 @@ export function useResonance() {
   const syncFreqFloor = v => syncParam('freqFloor', resFreqFloor, v)
   const syncFreqCeil = v => syncParam('freqCeil', resFreqCeil, v)
   const syncMode = v => syncParam('mode', resMode, v)
+  const syncPitchRange = v => syncParam('pitchRange', resPitchRange, v)
 
   function togglePreserveHarmonics() {
     syncParam('preserveHarmonics', resPreserveHarmonics, !resPreserveHarmonics.value)
@@ -179,6 +182,7 @@ export function useResonance() {
     resFreqCeil,
     resMode,
     resPreserveHarmonics,
+    resPitchRange,
     resPreview,
     resReduction,
     resInputDb,
@@ -194,6 +198,7 @@ export function useResonance() {
     syncFreqFloor,
     syncFreqCeil,
     syncMode,
+    syncPitchRange,
     togglePreserveHarmonics,
     apply,
     teardown,

--- a/test/dsp/f0.test.js
+++ b/test/dsp/f0.test.js
@@ -25,8 +25,8 @@ function makeTracker(opts = {}) {
 test('estimates the pitch of a sawtooth across the vocal range', () => {
   for (const f of [80, 100, 120, 150, 200, 250, 300, 380]) {
     const t = makeTracker()
-    const { f0, voiced } = t.estimate(sawFrame(f))
-    assert.ok(voiced, `${f} Hz should read voiced`)
+    const { f0, pitched } = t.estimate(sawFrame(f))
+    assert.ok(pitched, `${f} Hz should read pitched`)
     const errCents = 1200 * Math.log2(f0 / f)
     assert.ok(
       Math.abs(errCents) < 25,
@@ -104,7 +104,7 @@ test('matches the reference on harmonic stacks and mixtures', () => {
   assert.ok(Math.abs(makeTracker().estimate(mix).f0 - 119.863462) < 1e-6)
 })
 
-test('white noise is not reported as voiced', () => {
+test('white noise is not reported as pitched', () => {
   const t = makeTracker()
   let s = 12345
   const frame = new Float64Array(FRAME)
@@ -112,21 +112,21 @@ test('white noise is not reported as voiced', () => {
     s = (s * 1103515245 + 12345) & 0x7fffffff
     frame[i] = s / 0x3fffffff - 1
   }
-  const { voiced } = t.estimate(frame)
-  assert.equal(voiced, false, 'noise should fail the correlation-ratio gate')
+  const { pitched } = t.estimate(frame)
+  assert.equal(pitched, false, 'noise should fail the correlation-ratio gate')
 })
 
-test('silence is not reported as voiced', () => {
+test('silence is not reported as pitched', () => {
   const t = makeTracker()
-  const { voiced, f0 } = t.estimate(new Float64Array(FRAME))
-  assert.equal(voiced, false)
+  const { pitched, f0 } = t.estimate(new Float64Array(FRAME))
+  assert.equal(pitched, false)
   assert.equal(f0, null)
 })
 
 test('the caller energy gate can veto an otherwise periodic frame', () => {
   const t = makeTracker()
-  const { voiced } = t.estimate(sawFrame(150), false)
-  assert.equal(voiced, false, 'energy gate should override the correlation gate')
+  const { pitched } = t.estimate(sawFrame(150), false)
+  assert.equal(pitched, false, 'energy gate should override the correlation gate')
 })
 
 test('is insensitive to DC offset', () => {
@@ -137,7 +137,7 @@ test('is insensitive to DC offset', () => {
   assert.ok(Math.abs(a - b) < 1e-9, `DC changed the estimate: ${a} vs ${b}`)
 })
 
-test('rolling median tracks the speaker and ignores unvoiced frames', () => {
+test('rolling median tracks the source and ignores unpitched frames', () => {
   const t = makeTracker({ medianWindow: 5, defaultF0: 60 })
   assert.equal(t.median, 60, 'seeded default before any voiced frame')
 
@@ -163,8 +163,8 @@ test('lag range brackets the configured F0 limits', () => {
   assert.equal(t.lagMin, Math.floor(SR / F0_MAX_HZ))
   assert.equal(t.lagMax, Math.floor(SR / F0_MIN_HZ))
   // A tone below F0_MIN cannot be reported inside the range.
-  const { f0, voiced } = makeTracker().estimate(sawFrame(45))
-  if (voiced) {
+  const { f0, pitched } = makeTracker().estimate(sawFrame(45))
+  if (pitched) {
     assert.ok(f0 >= F0_MIN_HZ - 5, `reported ${f0} below the search floor`)
   }
 })

--- a/test/dsp/humDetect.test.js
+++ b/test/dsp/humDetect.test.js
@@ -108,11 +108,11 @@ test('a voice sitting on the mains grid is not mistaken for hum', () => {
     r.flaggedHarmonics.includes(120),
     'the spectral test is expected to flag it — that is the blind spot',
   )
-  assert.ok(r.pitchedSourceHz !== null, 'a speaker pitch should have been measured')
+  assert.ok(r.pitchedSourceHz !== null, 'a source pitch should have been measured')
   assert.ok(Math.abs(r.pitchedSourceHz - 120) < 6, `measured pitch ${r.pitchedSourceHz}`)
 
   const at120 = r.detectionDetail.find(d => d.frequency === 120)
-  assert.equal(at120.matchesPitchedSource, true, 'pitch check should identify it as voice')
+  assert.equal(at120.matchesPitchedSource, true, 'pitch check should claim it')
   assert.equal(at120.pitchHarmonic, 1)
 
   // 240 Hz is the speaker's second harmonic — real vocal energy, and notching
@@ -130,7 +130,7 @@ test('a scattered pitch contour is not trusted', () => {
   // it and reports a "pitch" that is really nothing of the kind. The
   // concentration test is what stops that vetoing genuine hum harmonics.
   const r = detectHum(makeSignal({ humFundamental: 60 }), SR)
-  assert.equal(r.pitchedSourceHz, null, 'no speaker should be reported on pure hum')
+  assert.equal(r.pitchedSourceHz, null, 'no pitched source should be reported on pure hum')
   assert.ok(
     r.pitchConcentration < 0.5,
     `contour was unexpectedly tight: ${r.pitchConcentration}`,
@@ -154,7 +154,7 @@ test('real hum under a voice at a different pitch still gets found', () => {
   assert.equal(r.triggered, true, 'hum should survive the pitch check')
   assert.ok(r.recommendedHarmonics.includes(120), `got ${r.recommendedHarmonics}`)
   const at120 = r.detectionDetail.find(d => d.frequency === 120)
-  assert.equal(at120.matchesPitchedSource, false, '120 Hz is not this speaker’s pitch')
+  assert.equal(at120.matchesPitchedSource, false, '120 Hz is not this source’s pitch')
 })
 
 test('a 180 Hz male fundamental alone does not trigger', () => {
@@ -168,20 +168,20 @@ test('a 180 Hz male fundamental alone does not trigger', () => {
   assert.equal(at180.flagged, false)
 })
 
-test('reports which candidates could plausibly be a voice', () => {
+test('reports which candidates could plausibly be a pitched source', () => {
   const r = detectHum(makeSignal({ humFundamental: 60 }), SR)
   const byFreq = Object.fromEntries(r.detectionDetail.map(d => [d.frequency, d]))
-  assert.equal(byFreq[60].inPitchRange, false, '60 Hz is below any voice F0')
+  assert.equal(byFreq[60].inPitchRange, false, '60 Hz is below the pitched-source range')
   assert.equal(byFreq[120].inPitchRange, true)
   assert.equal(byFreq[180].inPitchRange, true)
   assert.equal(byFreq[300].inPitchRange, true)
   // Pure hum with no voice present: in range, but no trusted pitch to match.
   for (const d of r.detectionDetail) {
-    assert.equal(d.matchesPitchedSource, false, `${d.frequency} Hz falsely read as voice`)
+    assert.equal(d.matchesPitchedSource, false, `${d.frequency} Hz falsely attributed to a pitched source`)
   }
 })
 
-test('a genuine hum harmonic near the speaker is not vetoed', () => {
+test('a genuine hum harmonic near the source pitch is not vetoed', () => {
   // 200 Hz speaker over 60 Hz hum. A naive per-frame overlap test reads ~14%
   // of frames within 15 Hz of 180 (the low tail of the pitch wobble) and would
   // veto a real hum harmonic. Anchoring on the median pitch instead does not.
@@ -189,11 +189,11 @@ test('a genuine hum harmonic near the speaker is not vetoed', () => {
   const r = detectHum(sig, SR)
   assert.ok(Math.abs(r.pitchedSourceHz - 200) < 8, `measured pitch ${r.pitchedSourceHz}`)
   const at180 = r.detectionDetail.find(d => d.frequency === 180)
-  assert.equal(at180.matchesPitchedSource, false, '180 Hz is hum, not the speaker')
+  assert.equal(at180.matchesPitchedSource, false, '180 Hz is hum, not the source')
   assert.ok(r.recommendedHarmonics.includes(180), `got ${r.recommendedHarmonics}`)
 })
 
-test('recommendedHarmonics is flaggedHarmonics minus the voice matches', () => {
+test('recommendedHarmonics is flaggedHarmonics minus the pitch matches', () => {
   const r = detectHum(makeSignal({ voiceF0: 120 }), SR)
   const vetoed = r.detectionDetail.filter(d => d.flagged && d.matchesPitchedSource)
   assert.ok(vetoed.length > 0, 'this fixture is meant to exercise the veto')
@@ -239,7 +239,7 @@ test('finds hum whose fundamental has been high-passed away', () => {
   assert.ok(!r.flaggedHarmonics.includes(60), '60 Hz is absent, should not flag')
 })
 
-test('the mains grid wins when the voice cannot explain every flagged harmonic', () => {
+test('the mains grid wins when the pitch cannot explain every flagged harmonic', () => {
   // High-passed hum (120/180/240) has a true period of 60 Hz, below the
   // tracker's floor, so it locks onto 120 Hz with a perfectly steady contour —
   // indistinguishable from a 120 Hz speaker by pitch alone. 180 Hz is what

--- a/test/dsp/humDetect.test.js
+++ b/test/dsp/humDetect.test.js
@@ -108,18 +108,18 @@ test('a voice sitting on the mains grid is not mistaken for hum', () => {
     r.flaggedHarmonics.includes(120),
     'the spectral test is expected to flag it — that is the blind spot',
   )
-  assert.ok(r.voicePitchHz !== null, 'a speaker pitch should have been measured')
-  assert.ok(Math.abs(r.voicePitchHz - 120) < 6, `measured pitch ${r.voicePitchHz}`)
+  assert.ok(r.pitchedSourceHz !== null, 'a speaker pitch should have been measured')
+  assert.ok(Math.abs(r.pitchedSourceHz - 120) < 6, `measured pitch ${r.pitchedSourceHz}`)
 
   const at120 = r.detectionDetail.find(d => d.frequency === 120)
-  assert.equal(at120.matchesVoicePitch, true, 'pitch check should identify it as voice')
-  assert.equal(at120.voiceHarmonic, 1)
+  assert.equal(at120.matchesPitchedSource, true, 'pitch check should identify it as voice')
+  assert.equal(at120.pitchHarmonic, 1)
 
   // 240 Hz is the speaker's second harmonic — real vocal energy, and notching
   // it thins the voice just as badly as notching the fundamental.
   const at240 = r.detectionDetail.find(d => d.frequency === 240)
-  assert.equal(at240.matchesVoicePitch, true, 'harmonics of the pitch count too')
-  assert.equal(at240.voiceHarmonic, 2)
+  assert.equal(at240.matchesPitchedSource, true, 'harmonics of the pitch count too')
+  assert.equal(at240.pitchHarmonic, 2)
 
   assert.equal(r.triggered, false, `false positive: ${JSON.stringify(r.recommendedHarmonics)}`)
   assert.deepEqual(r.recommendedHarmonics, [], 'nothing should be recommended')
@@ -130,20 +130,20 @@ test('a scattered pitch contour is not trusted', () => {
   // it and reports a "pitch" that is really nothing of the kind. The
   // concentration test is what stops that vetoing genuine hum harmonics.
   const r = detectHum(makeSignal({ humFundamental: 60 }), SR)
-  assert.equal(r.voicePitchHz, null, 'no speaker should be reported on pure hum')
+  assert.equal(r.pitchedSourceHz, null, 'no speaker should be reported on pure hum')
   assert.ok(
-    r.voicePitchConcentration < 0.5,
-    `contour was unexpectedly tight: ${r.voicePitchConcentration}`,
+    r.pitchConcentration < 0.5,
+    `contour was unexpectedly tight: ${r.pitchConcentration}`,
   )
 })
 
 test('the pitch check can be turned off', () => {
   // Confirms the veto is what suppresses the previous case, not something else.
   const sig = makeSignal({ voiceF0: 120 })
-  const r = detectHum(sig, SR, { voicePitchCheck: false })
+  const r = detectHum(sig, SR, { pitchSourceCheck: false })
   assert.equal(r.triggered, true, 'without the pitch check this is a false positive')
   for (const d of r.detectionDetail) {
-    assert.equal(d.matchesVoicePitch, false)
+    assert.equal(d.matchesPitchedSource, false)
   }
 })
 
@@ -154,7 +154,7 @@ test('real hum under a voice at a different pitch still gets found', () => {
   assert.equal(r.triggered, true, 'hum should survive the pitch check')
   assert.ok(r.recommendedHarmonics.includes(120), `got ${r.recommendedHarmonics}`)
   const at120 = r.detectionDetail.find(d => d.frequency === 120)
-  assert.equal(at120.matchesVoicePitch, false, '120 Hz is not this speaker’s pitch')
+  assert.equal(at120.matchesPitchedSource, false, '120 Hz is not this speaker’s pitch')
 })
 
 test('a 180 Hz male fundamental alone does not trigger', () => {
@@ -171,13 +171,13 @@ test('a 180 Hz male fundamental alone does not trigger', () => {
 test('reports which candidates could plausibly be a voice', () => {
   const r = detectHum(makeSignal({ humFundamental: 60 }), SR)
   const byFreq = Object.fromEntries(r.detectionDetail.map(d => [d.frequency, d]))
-  assert.equal(byFreq[60].looksLikeVoice, false, '60 Hz is below any voice F0')
-  assert.equal(byFreq[120].looksLikeVoice, true)
-  assert.equal(byFreq[180].looksLikeVoice, true)
-  assert.equal(byFreq[300].looksLikeVoice, true)
+  assert.equal(byFreq[60].inPitchRange, false, '60 Hz is below any voice F0')
+  assert.equal(byFreq[120].inPitchRange, true)
+  assert.equal(byFreq[180].inPitchRange, true)
+  assert.equal(byFreq[300].inPitchRange, true)
   // Pure hum with no voice present: in range, but no trusted pitch to match.
   for (const d of r.detectionDetail) {
-    assert.equal(d.matchesVoicePitch, false, `${d.frequency} Hz falsely read as voice`)
+    assert.equal(d.matchesPitchedSource, false, `${d.frequency} Hz falsely read as voice`)
   }
 })
 
@@ -187,15 +187,15 @@ test('a genuine hum harmonic near the speaker is not vetoed', () => {
   // veto a real hum harmonic. Anchoring on the median pitch instead does not.
   const sig = makeSignal({ humFundamental: 60, humDb: -40, voiceF0: 200, voiceDb: -26, voiceJitterHz: 6 })
   const r = detectHum(sig, SR)
-  assert.ok(Math.abs(r.voicePitchHz - 200) < 8, `measured pitch ${r.voicePitchHz}`)
+  assert.ok(Math.abs(r.pitchedSourceHz - 200) < 8, `measured pitch ${r.pitchedSourceHz}`)
   const at180 = r.detectionDetail.find(d => d.frequency === 180)
-  assert.equal(at180.matchesVoicePitch, false, '180 Hz is hum, not the speaker')
+  assert.equal(at180.matchesPitchedSource, false, '180 Hz is hum, not the speaker')
   assert.ok(r.recommendedHarmonics.includes(180), `got ${r.recommendedHarmonics}`)
 })
 
 test('recommendedHarmonics is flaggedHarmonics minus the voice matches', () => {
   const r = detectHum(makeSignal({ voiceF0: 120 }), SR)
-  const vetoed = r.detectionDetail.filter(d => d.flagged && d.matchesVoicePitch)
+  const vetoed = r.detectionDetail.filter(d => d.flagged && d.matchesPitchedSource)
   assert.ok(vetoed.length > 0, 'this fixture is meant to exercise the veto')
   assert.deepEqual(
     r.recommendedHarmonics,
@@ -246,13 +246,13 @@ test('the mains grid wins when the voice cannot explain every flagged harmonic',
   // separates them: on the mains grid, absent from a 120 Hz harmonic series.
   const r = detectHum(makeSignal({ humFundamental: 60, humHarmonics: [2, 3, 4] }), SR)
 
-  assert.ok(r.voicePitchHz !== null, 'the tracker is expected to report a pitch here')
-  assert.ok(Math.abs(r.voicePitchHz - 120) < 6, `locked onto ${r.voicePitchHz}`)
-  assert.equal(r.voicePitchConcentration, 1, 'and to be entirely confident about it')
+  assert.ok(r.pitchedSourceHz !== null, 'the tracker is expected to report a pitch here')
+  assert.ok(Math.abs(r.pitchedSourceHz - 120) < 6, `locked onto ${r.pitchedSourceHz}`)
+  assert.equal(r.pitchConcentration, 1, 'and to be entirely confident about it')
 
   // ...and yet nothing is vetoed, because 180 Hz does not fit that series.
   for (const d of r.detectionDetail) {
-    assert.equal(d.matchesVoicePitch, false, `${d.frequency} Hz should not be vetoed`)
+    assert.equal(d.matchesPitchedSource, false, `${d.frequency} Hz should not be vetoed`)
   }
   assert.equal(r.triggered, true)
   assert.deepEqual(r.recommendedHarmonics, [120, 180, 240])

--- a/test/dsp/resonance.test.js
+++ b/test/dsp/resonance.test.js
@@ -15,9 +15,11 @@ const SR = 44100
 const LATENCY = 2048
 
 /**
- * Voiced signal: a harmonic stack with slow pitch wobble over a broadband
- * floor. The stack matters — non-voiced frames target zero reduction by
- * design, so the suppressor does nothing at all to pure noise.
+ * Pitched signal: a harmonic stack with slow pitch wobble over a broadband
+ * floor. Used wherever a test needs harmonics to protect. It is NOT required
+ * for the suppressor to do anything — see the unpitched test below, which is
+ * the regression guard for the gate that used to switch the effect off on
+ * anything the pitch tracker could not read.
  */
 function voice({
   seconds = 3, f0 = 150, jitterHz = 3, amp = 0.2, noiseDb = -45,
@@ -48,6 +50,19 @@ function resonate(sig, freqHz, q, gainDb) {
   cascade.setSections([peaking(SR, freqHz, q, gainDb)])
   const out = new Float32Array(sig.length)
   cascade.process(sig, out, sig.length, 0)
+  return out
+}
+
+/** Unpitched broadband signal — the tracker reads 0 of 255 frames as pitched. */
+function noise({ seconds = 3, db = -20 } = {}) {
+  const n = Math.round(seconds * SR)
+  const out = new Float32Array(n)
+  const amp = Math.pow(10, db / 20)
+  let s = 4242
+  for (let i = 0; i < n; i++) {
+    s = (s * 1103515245 + 12345) & 0x7fffffff
+    out[i] = amp * (s / 0x3fffffff - 1)
+  }
   return out
 }
 
@@ -138,13 +153,21 @@ test('the delay is measurable, not merely advertised', () => {
   assert.equal(argmax(out) - argmax(sig), LATENCY)
 })
 
-test('harmonic mask matches the Python bin for bin', () => {
-  // Golden bin counts from _compute_harmonic_mask_for_f0 in
-  // resonance_suppressor.py, reproduced with its exact geometry
-  // (harmonic_width_bins 2, harmonic_width_pct 0.01, max_harmonic 100,
-  // freq_ceil 20 kHz). Verified equal as full index lists, not just counts.
+test('harmonic mask geometry is pinned', () => {
+  // These counts DIVERGE from resonance_suppressor.py, deliberately. Two
+  // changes, both forced by this being a general-purpose effect rather than a
+  // stage inside a speech chain:
+  //
+  //   - the walk ends at freqCeilHz instead of a fixed 100 harmonics, so the
+  //     protected band no longer slides with pitch (at 40 Hz the Python stops
+  //     at 4 kHz and leaves everything above exposed);
+  //   - the half-width is clamped so neighbouring masks keep a gap.
+  //
+  // The second is what makes the first safe. With the cap lifted and no clamp,
+  // coverage measured 100% for every f0 at or below 82 Hz — "protect the
+  // harmonics" collapses into "protect everything" and the effect goes inert.
   const kernel = new ResonanceKernel(SR)
-  const golden = { 100: 467, 120.5: 538, 150: 632, 154.7: 645, 220: 755, 300: 654 }
+  const golden = { 100: 600, 120.5: 495, 150: 665, 154.7: 645, 220: 694, 300: 578 }
   for (const [f0, expected] of Object.entries(golden)) {
     const mask = kernel._harmonicMask(parseFloat(f0))
     let count = 0
@@ -153,14 +176,20 @@ test('harmonic mask matches the Python bin for bin', () => {
   }
 })
 
-test('harmonic protection covers most of the spectrum, and all of it up high', () => {
-  // Surprising enough to pin. Protection half-width is
-  // max(2 bins, 1% of the harmonic frequency), so once 2% of a harmonic's
-  // frequency exceeds the pitch — above roughly 50x F0 — adjacent protection
-  // zones touch and nothing is reachable. For a 150 Hz speaker that is about
-  // 7.5 kHz. This is the server's own geometry, not a divergence, and it is
-  // why the effect works mainly on narrow resonances at low and mid
-  // frequencies.
+test('no mask at all below the resolvable harmonic spacing', () => {
+  // Under ~64.6 Hz at this bin width, consecutive harmonics land closer than
+  // three bins and no comb with gaps can be drawn. Returning null says "no
+  // protection available" rather than silently protecting the whole spectrum.
+  const kernel = new ResonanceKernel(SR)
+  assert.equal(kernel._harmonicMask(64), null)
+  assert.ok(kernel._harmonicMask(70) instanceof Uint8Array)
+})
+
+test('harmonic protection leaves gaps at every frequency', () => {
+  // The property that matters: the inter-harmonic floor stays reachable across
+  // the whole band. This previously failed above roughly 50x F0 — for a 150 Hz
+  // speaker, everything above ~7.5 kHz was fully masked and unreachable,
+  // because the 1%-of-frequency half-width outgrew the harmonic spacing.
   const kernel = new ResonanceKernel(SR)
   const binHz = SR / 2048
   const coverage = (f0, loHz, hiHz) => {
@@ -176,10 +205,15 @@ test('harmonic protection covers most of the spectrum, and all of it up high', (
     }
     return covered / total
   }
-  assert.ok(coverage(150, 500, 1500) < 0.9, 'mid band should still have gaps')
-  assert.ok(coverage(150, 8000, 12000) > 0.99, 'high band should be fully protected')
-  assert.ok(coverage(220, 500, 1500) < coverage(150, 500, 1500) + 0.01,
-    'a higher pitch leaves at least as much room')
+  for (const f0 of [100, 150, 220, 300]) {
+    for (const [lo, hi] of [[500, 1500], [8000, 12000], [16000, 20000]]) {
+      const c = coverage(f0, lo, hi)
+      assert.ok(
+        c < 0.95,
+        `f0 ${f0}, ${lo}-${hi} Hz: ${(c * 100).toFixed(1)}% masked, nothing left to work on`,
+      )
+    }
+  }
 })
 
 test('suppresses a narrow resonance', () => {
@@ -238,6 +272,59 @@ test('harmonic protection holds the suppressor off the voice', () => {
     unguarded > guarded * 3,
     `mask made little difference: ${guarded.toExponential(2)} vs ${unguarded.toExponential(2)}`,
   )
+})
+
+test('suppresses a resonance in unpitched material', () => {
+  // REGRESSION GUARD. Suppression used to be gated on the pitch tracker
+  // reporting a pitch, which conflated "is there signal here" with "did we
+  // find a periodic component". On this input the tracker reads 1 frame in 258
+  // as pitched, so the old gate zeroed the reduction on 257 of them and the
+  // effect did nothing at all. Drums, cymbals, synths, room tone and every
+  // fricative in a narration land in the same hole.
+  const sig = resonate(noise(), 3000, 40, 14)
+  const out = processResonanceBuffer([sig], SR, RESONANCE_KERNEL_DEFAULTS).channelData[0]
+
+  const change = f => bandDb(out, f, SR + LATENCY) - bandDb(sig, f, SR)
+  const onResonance = change(3000)
+  assert.ok(onResonance < -1.5, `resonant band only moved ${onResonance.toFixed(2)} dB`)
+  for (const control of [1500, 6000]) {
+    assert.ok(
+      change(control) > onResonance + 1,
+      `${control} Hz moved as much as the resonance — the cut is not selective`,
+    )
+  }
+})
+
+test('the pitch search range is settable and clamped to what the frame resolves', () => {
+  // The server hard-coded 70-400 Hz because it only ever saw speech. An
+  // out-of-range source does not fail quietly here: the peak picker returns the
+  // best lag WITHIN the range, so a 45 Hz source is reported as an octave
+  // artefact with full confidence and the mask lands on non-harmonics.
+  const kernel = new ResonanceKernel(SR)
+
+  kernel.setParams({ pitchMinHz: 40, pitchMaxHz: 1200 })
+  assert.ok(kernel.pitchRange.minHz >= 43, 'a 2048-sample frame cannot reach below ~43 Hz')
+  assert.ok(kernel.pitchRange.minHz < 45, `clamped too hard: ${kernel.pitchRange.minHz}`)
+  assert.equal(kernel.pitchRange.maxHz, 1200)
+  assert.equal(kernel.f0.lagMin, Math.floor(SR / 1200))
+
+  kernel.setParams({ pitchMinHz: 70, pitchMaxHz: 400 })
+  assert.equal(kernel.pitchRange.minHz, 70)
+  assert.equal(kernel.f0.lagMax, Math.floor(SR / 70))
+})
+
+test('the mask cache survives a knob move that does not change its geometry', () => {
+  // The effect wrapper posts the whole param object on every knob move, so an
+  // `in partial` test on the key would clear the cache on every twist.
+  const kernel = new ResonanceKernel(SR)
+  kernel._harmonicMask(150)
+  assert.equal(kernel.maskCache.size, 1)
+
+  kernel.setParams({ ...RESONANCE_KERNEL_DEFAULTS, depth: 0.4 })
+  assert.equal(kernel.maskCache.size, 1, 'depth does not move a single harmonic')
+
+  kernel.setParams({ ...RESONANCE_KERNEL_DEFAULTS, freqCeilHz: 12000 })
+  assert.equal(kernel.maskCache.size, 0, 'the ceiling ends the harmonic walk')
 })
 
 test('output is independent of the block size it was fed in', () => {

--- a/test/dsp/resonance.test.js
+++ b/test/dsp/resonance.test.js
@@ -8,6 +8,7 @@ import {
   RESONANCE_KERNEL_DEFAULTS,
   processResonanceBuffer,
 } from '../../src/audio/resonanceProcessor.js'
+import { effectivePitchRange, PITCH_RANGES } from '../../src/audio/resonanceParams.js'
 import { peaking, BiquadCascade } from '../../src/audio/dsp/biquad.js'
 import { getFFT, rfftBinCount } from '../../src/audio/dsp/fft.js'
 
@@ -311,6 +312,26 @@ test('the pitch search range is settable and clamped to what the frame resolves'
   kernel.setParams({ pitchMinHz: 70, pitchMaxHz: 400 })
   assert.equal(kernel.pitchRange.minHz, 70)
   assert.equal(kernel.f0.lagMax, Math.floor(SR / 70))
+})
+
+test('the range the UI shows is the range the kernel uses', () => {
+  // effectivePitchRange mirrors the kernel's clamp on the main thread, because
+  // a worklet has no way to hand a value back for rendering a label. Mirrored
+  // logic drifts, so pin the two together.
+  for (const sampleRate of [44100, 48000, 96000]) {
+    const kernel = new ResonanceKernel(sampleRate)
+    for (const [key, range] of Object.entries(PITCH_RANGES)) {
+      kernel.setParams({ pitchMinHz: range.minHz, pitchMaxHz: range.maxHz })
+      const shown = effectivePitchRange(sampleRate, key)
+      assert.ok(
+        Math.abs(shown.minHz - kernel.pitchRange.minHz) < 1e-9,
+        `${key} @ ${sampleRate}: UI says ${shown.minHz}, kernel uses ${kernel.pitchRange.minHz}`,
+      )
+      assert.equal(shown.maxHz, kernel.pitchRange.maxHz)
+    }
+  }
+  // The case that motivated it: 'wide' asks for 40 Hz and does not get it.
+  assert.ok(effectivePitchRange(44100, 'wide').minHz > PITCH_RANGES.wide.minHz)
 })
 
 test('the mask cache survives a knob move that does not change its geometry', () => {


### PR DESCRIPTION
## Summary

Refactored pitch tracking and harmonic protection throughout the codebase to support arbitrary pitched sources (instruments, synths, etc.) rather than assuming speech-only input. This enables the resonance suppressor and hum detector to work correctly on any audio material, not just voice.

## Key Changes

**Terminology updates across all affected modules:**
- Renamed `voicePitchCheck` → `pitchSourceCheck`, `voicePitchHz` → `pitchedSourceHz`, `voiced` → `pitched`, `voiceHarmonic` → `pitchHarmonic`, etc.
- Updated all comments and documentation to refer to "pitched sources" or "sustained sources" instead of "speaker" or "voice"
- Changed `VOICE_F0_RANGE_HZ` → `PITCHED_F0_RANGE_HZ`, `VOICE_PITCH_CONCENTRATION_MIN` → `PITCH_CONCENTRATION_MIN`, `MAX_VOICE_HARMONIC` → `MAX_TRACKED_HARMONIC`

**Hum detector (`humDetect.js`):**
- Clarified that the F0 veto protects "wanted content" not just voice
- Updated documentation to explain the check works on any sustained pitched source
- Renamed internal functions: `measureVoicePitch()` → `measurePitchedSource()`, `voiceHarmonicOf()` → `pitchHarmonicOf()`, `voiceToleranceHz()` → `pitchToleranceHz()`
- Changed `VOICING_GATE_DB` → `ACTIVITY_GATE_DB` to reflect that it gates on signal presence, not voicing

**Resonance suppressor (`resonanceProcessor.js`):**
- Added pitch search range parameters (`pitchMinHz`, `pitchMaxHz`) to support non-speech sources
- Introduced `DEFAULT_LIFTER_CUTOFF` constant with detailed explanation of why it's a cutoff (60 bins), not a pitch (60 Hz)
- Increased `MAX_HARMONIC` from 100 to 4096 with safety bounds, since the protected band now ends at `freqCeilHz` instead of sliding with pitch
- Added `MIN_HARMONIC_GAP_BINS` and `MIN_HARMONIC_SPACING_BINS` constants to prevent harmonic masks from merging into solid blocks
- Implemented dynamic harmonic mask width clamping to maintain gaps between neighboring harmonics across all frequencies
- Changed suppression gating from pitch-dependent to signal-presence-dependent (activity floor only)
- Updated `_harmonicMask()` to return `null` when harmonics cannot be represented at the current bin width
- Clarified that harmonic protection matters "wherever there are harmonics," not just for voice

**F0 Tracker (`f0.js`):**
- Added `setRange()` method to allow runtime pitch search range configuration
- Introduced `pitchFloorHz()` function to calculate the lowest resolvable pitch for a given frame size
- Added detailed documentation explaining that this is not a voice activity detector
- Changed `defaultF0` from 60 Hz to `null` to avoid seeding with an incorrect pitch
- Updated return value naming: `voiced` → `pitched` with clarification that it means "periodic component found in range"

**UI updates:**
- Added pitch range selector to resonance modal with "VOICE" (70–400 Hz) and "WIDE" (40–1200 Hz) presets
- Updated hum remover UI text to refer to "pitched source" and "recording" instead of "speaker" and "voice"
- Updated tooltips and status messages to be source-agnostic

**Tests:**
- Updated test descriptions and assertions to use "pitched" terminology
- Added regression test for suppression on unpitched material (drums, noise, etc.)
- Added test for pitch range parameter clamping
- Added test for mask cache survival across parameter updates
- Updated harmonic mask geometry tests to reflect new clamping behavior

## Notable Implementation Details

- The harmonic mask now dynamically clamps its half-width to maintain minimum gaps between neighboring harmonics, preventing the mask from becoming a solid block that would disable suppression entirely
- Pitch search range is clamped to what the frame size

https://claude.ai/code/session_019b1Nt95cB9aGTecubKbo9L