### PR TITLE
Level meters: fixed colour zones, peak hold, over lamp, readout and s…

### DIFF
--- a/src/audio/effects/airBand.js
+++ b/src/audio/effects/airBand.js
@@ -83,12 +83,12 @@ export function createAirBand(audioContext) {
       return params[name]
     },
 
-    getInputLevels() {
-      return inputTap.getLevels()
+    getInputLevels(channelCount) {
+      return inputTap.getLevels(channelCount)
     },
 
-    getOutputLevels() {
-      return outputTap.getLevels()
+    getOutputLevels(channelCount) {
+      return outputTap.getLevels(channelCount)
     },
 
     destroy() {

--- a/src/audio/effects/airBand.js
+++ b/src/audio/effects/airBand.js
@@ -83,12 +83,12 @@ export function createAirBand(audioContext) {
       return params[name]
     },
 
-    getInputLevelDb() {
-      return inputTap.getLevelDb()
+    getInputLevels() {
+      return inputTap.getLevels()
     },
 
-    getOutputLevelDb() {
-      return outputTap.getLevelDb()
+    getOutputLevels() {
+      return outputTap.getLevels()
     },
 
     destroy() {

--- a/src/audio/effects/clipGainDeEss.js
+++ b/src/audio/effects/clipGainDeEss.js
@@ -267,12 +267,12 @@ export function createClipGainDeEsser(audioContext) {
       return gain > 0 ? 20 * Math.log10(gain) : 0
     },
 
-    getInputLevelDb() {
-      return inputTap.getLevelDb()
+    getInputLevels() {
+      return inputTap.getLevels()
     },
 
-    getOutputLevelDb() {
-      return outputTap.getLevelDb()
+    getOutputLevels() {
+      return outputTap.getLevels()
     },
 
     destroy() {

--- a/src/audio/effects/clipGainDeEss.js
+++ b/src/audio/effects/clipGainDeEss.js
@@ -267,12 +267,12 @@ export function createClipGainDeEsser(audioContext) {
       return gain > 0 ? 20 * Math.log10(gain) : 0
     },
 
-    getInputLevels() {
-      return inputTap.getLevels()
+    getInputLevels(channelCount) {
+      return inputTap.getLevels(channelCount)
     },
 
-    getOutputLevels() {
-      return outputTap.getLevels()
+    getOutputLevels(channelCount) {
+      return outputTap.getLevels(channelCount)
     },
 
     destroy() {

--- a/src/audio/effects/fet1176Compressor.js
+++ b/src/audio/effects/fet1176Compressor.js
@@ -105,12 +105,12 @@ export function createFET1176Compressor(audioContext) {
       return -grDb
     },
 
-    getInputLevels() {
-      return inputTap.getLevels()
+    getInputLevels(channelCount) {
+      return inputTap.getLevels(channelCount)
     },
 
-    getOutputLevels() {
-      return outputTap.getLevels()
+    getOutputLevels(channelCount) {
+      return outputTap.getLevels(channelCount)
     },
 
     destroy() {

--- a/src/audio/effects/fet1176Compressor.js
+++ b/src/audio/effects/fet1176Compressor.js
@@ -105,12 +105,12 @@ export function createFET1176Compressor(audioContext) {
       return -grDb
     },
 
-    getInputLevelDb() {
-      return inputTap.getLevelDb()
+    getInputLevels() {
+      return inputTap.getLevels()
     },
 
-    getOutputLevelDb() {
-      return outputTap.getLevelDb()
+    getOutputLevels() {
+      return outputTap.getLevels()
     },
 
     destroy() {

--- a/src/audio/effects/humNotch.js
+++ b/src/audio/effects/humNotch.js
@@ -82,12 +82,12 @@ export function createHumNotch(audioContext) {
       return params[name]
     },
 
-    getInputLevelDb() {
-      return inputTap.getLevelDb()
+    getInputLevels() {
+      return inputTap.getLevels()
     },
 
-    getOutputLevelDb() {
-      return outputTap.getLevelDb()
+    getOutputLevels() {
+      return outputTap.getLevels()
     },
 
     destroy() {

--- a/src/audio/effects/humNotch.js
+++ b/src/audio/effects/humNotch.js
@@ -82,12 +82,12 @@ export function createHumNotch(audioContext) {
       return params[name]
     },
 
-    getInputLevels() {
-      return inputTap.getLevels()
+    getInputLevels(channelCount) {
+      return inputTap.getLevels(channelCount)
     },
 
-    getOutputLevels() {
-      return outputTap.getLevels()
+    getOutputLevels(channelCount) {
+      return outputTap.getLevels(channelCount)
     },
 
     destroy() {

--- a/src/audio/effects/la2aCompressor.js
+++ b/src/audio/effects/la2aCompressor.js
@@ -99,12 +99,12 @@ export function createLA2ACompressor(audioContext) {
       return -grDb
     },
 
-    getInputLevelDb() {
-      return inputTap.getLevelDb()
+    getInputLevels() {
+      return inputTap.getLevels()
     },
 
-    getOutputLevelDb() {
-      return outputTap.getLevelDb()
+    getOutputLevels() {
+      return outputTap.getLevels()
     },
 
     destroy() {

--- a/src/audio/effects/la2aCompressor.js
+++ b/src/audio/effects/la2aCompressor.js
@@ -99,12 +99,12 @@ export function createLA2ACompressor(audioContext) {
       return -grDb
     },
 
-    getInputLevels() {
-      return inputTap.getLevels()
+    getInputLevels(channelCount) {
+      return inputTap.getLevels(channelCount)
     },
 
-    getOutputLevels() {
-      return outputTap.getLevels()
+    getOutputLevels(channelCount) {
+      return outputTap.getLevels(channelCount)
     },
 
     destroy() {

--- a/src/audio/effects/levelTap.js
+++ b/src/audio/effects/levelTap.js
@@ -52,10 +52,16 @@ export function createSpectrumTap(audioContext, node) {
   }
 }
 
+/**
+ * Time-domain tap, for the level meters.
+ *
+ * No `smoothingTimeConstant` here: it only applies to the FFT that backs
+ * `getFloatFrequencyData`, so on a tap that is read purely in the time domain
+ * it does nothing. Meter ballistics belong to whoever renders the reading.
+ */
 export function createLevelTap(audioContext, node) {
   const analyser = audioContext.createAnalyser()
   analyser.fftSize = 1024
-  analyser.smoothingTimeConstant = 0.6
   node.connect(analyser)
 
   const silentSink = audioContext.createGain()
@@ -64,16 +70,38 @@ export function createLevelTap(audioContext, node) {
   silentSink.connect(audioContext.destination)
 
   const data = new Float32Array(analyser.fftSize)
+  const levels = { rmsDb: -Infinity, peakDb: -Infinity }
 
   return {
     analyser,
-    getLevelDb() {
+    /**
+     * RMS and sample peak of the most recent window, both in dBFS.
+     *
+     * The window is 1024 samples and a 60 Hz caller advances 735 of them
+     * between reads, so consecutive windows overlap and no sample goes
+     * unseen. That is what makes the peak reading trustworthy enough to
+     * drive an over indicator — the guarantee does not survive rAF
+     * throttling in a backgrounded tab, where samples can pass unread.
+     *
+     * Both figures are taken from the analyser's mono downmix, so a peak on
+     * one channel of a stereo file reads lower here than it truly is.
+     *
+     * Reuses one object — read the fields, do not retain it.
+     */
+    getLevels() {
       analyser.getFloatTimeDomainData(data)
       let sumSquares = 0
-      for (let i = 0; i < data.length; i++) sumSquares += data[i] * data[i]
+      let peak = 0
+      for (let i = 0; i < data.length; i++) {
+        const sample = data[i]
+        sumSquares += sample * sample
+        const magnitude = Math.abs(sample)
+        if (magnitude > peak) peak = magnitude
+      }
       const rms = Math.sqrt(sumSquares / data.length)
-      if (rms <= 0) return -Infinity
-      return 20 * Math.log10(rms)
+      levels.rmsDb = rms > 0 ? 20 * Math.log10(rms) : -Infinity
+      levels.peakDb = peak > 0 ? 20 * Math.log10(peak) : -Infinity
+      return levels
     },
     destroy() {
       analyser.disconnect()

--- a/src/audio/effects/levelTap.js
+++ b/src/audio/effects/levelTap.js
@@ -52,30 +52,72 @@ export function createSpectrumTap(audioContext, node) {
   }
 }
 
+/** Channels the tap is wired to measure. Voice work does not exceed stereo. */
+export const MAX_METER_CHANNELS = 2
+
 /**
- * Time-domain tap, for the level meters.
+ * Copy a reading out of the tap's reused object.
+ *
+ * `getLevels` hands back the same object every frame, which is right for a
+ * 60 Hz read and wrong for anything that stores it: assigning it to a ref
+ * would leave every past reading pointing at the present one.
+ */
+export function snapshotLevels(levels) {
+  const out = []
+  for (let ch = 0; ch < levels.count; ch++) {
+    out.push({ rmsDb: levels.channels[ch].rmsDb, peakDb: levels.channels[ch].peakDb })
+  }
+  return out
+}
+
+/**
+ * Time-domain tap, for the level meters. Measures each channel separately.
+ *
+ * A splitter feeds one analyser per channel, because an analyser placed
+ * straight on the signal reports its mono downmix — on which a peak in one
+ * channel of a stereo pair reads low, and a channel imbalance does not appear
+ * at all. Splitting is what makes a stereo meter mean anything.
+ *
+ * The splitter's `channelInterpretation` is "discrete", so a mono source
+ * lights channel 0 and leaves channel 1 digitally silent rather than
+ * duplicating into it. Callers must therefore ask for the number of channels
+ * the source actually has — request two for a mono file and the second bar
+ * reads a convincing, permanent -∞.
  *
  * No `smoothingTimeConstant` here: it only applies to the FFT that backs
  * `getFloatFrequencyData`, so on a tap that is read purely in the time domain
  * it does nothing. Meter ballistics belong to whoever renders the reading.
  */
 export function createLevelTap(audioContext, node) {
-  const analyser = audioContext.createAnalyser()
-  analyser.fftSize = 1024
-  node.connect(analyser)
+  const splitter = audioContext.createChannelSplitter(MAX_METER_CHANNELS)
+  node.connect(splitter)
 
   const silentSink = audioContext.createGain()
   silentSink.gain.value = 0
-  analyser.connect(silentSink)
   silentSink.connect(audioContext.destination)
 
-  const data = new Float32Array(analyser.fftSize)
-  const levels = { rmsDb: -Infinity, peakDb: -Infinity }
+  const analysers = []
+  const buffers = []
+  for (let ch = 0; ch < MAX_METER_CHANNELS; ch++) {
+    const analyser = audioContext.createAnalyser()
+    analyser.fftSize = 1024
+    splitter.connect(analyser, ch)
+    analyser.connect(silentSink)
+    analysers.push(analyser)
+    buffers.push(new Float32Array(analyser.fftSize))
+  }
+
+  // Reused across frames, one entry per channel.
+  const channels = analysers.map(() => ({ rmsDb: -Infinity, peakDb: -Infinity }))
+  const levels = { count: 0, channels }
 
   return {
-    analyser,
+    analysers,
     /**
-     * RMS and sample peak of the most recent window, both in dBFS.
+     * Per-channel RMS and sample peak of the most recent window, in dBFS.
+     *
+     * `count` is how many channels the source really carries; only that many
+     * entries are refreshed, and `levels.count` reports how many are valid.
      *
      * The window is 1024 samples and a 60 Hz caller advances 735 of them
      * between reads, so consecutive windows overlap and no sample goes
@@ -83,28 +125,31 @@ export function createLevelTap(audioContext, node) {
      * drive an over indicator — the guarantee does not survive rAF
      * throttling in a backgrounded tab, where samples can pass unread.
      *
-     * Both figures are taken from the analyser's mono downmix, so a peak on
-     * one channel of a stereo file reads lower here than it truly is.
-     *
      * Reuses one object — read the fields, do not retain it.
      */
-    getLevels() {
-      analyser.getFloatTimeDomainData(data)
-      let sumSquares = 0
-      let peak = 0
-      for (let i = 0; i < data.length; i++) {
-        const sample = data[i]
-        sumSquares += sample * sample
-        const magnitude = Math.abs(sample)
-        if (magnitude > peak) peak = magnitude
+    getLevels(count = MAX_METER_CHANNELS) {
+      const active = Math.max(1, Math.min(MAX_METER_CHANNELS, count))
+      levels.count = active
+      for (let ch = 0; ch < active; ch++) {
+        const data = buffers[ch]
+        analysers[ch].getFloatTimeDomainData(data)
+        let sumSquares = 0
+        let peak = 0
+        for (let i = 0; i < data.length; i++) {
+          const sample = data[i]
+          sumSquares += sample * sample
+          const magnitude = Math.abs(sample)
+          if (magnitude > peak) peak = magnitude
+        }
+        const rms = Math.sqrt(sumSquares / data.length)
+        channels[ch].rmsDb = rms > 0 ? 20 * Math.log10(rms) : -Infinity
+        channels[ch].peakDb = peak > 0 ? 20 * Math.log10(peak) : -Infinity
       }
-      const rms = Math.sqrt(sumSquares / data.length)
-      levels.rmsDb = rms > 0 ? 20 * Math.log10(rms) : -Infinity
-      levels.peakDb = peak > 0 ? 20 * Math.log10(peak) : -Infinity
       return levels
     },
     destroy() {
-      analyser.disconnect()
+      splitter.disconnect()
+      for (const analyser of analysers) analyser.disconnect()
       silentSink.disconnect()
     },
   }

--- a/src/audio/effects/manualEq.js
+++ b/src/audio/effects/manualEq.js
@@ -113,12 +113,12 @@ export function createManualEq(audioContext) {
       return params[name]
     },
 
-    getInputLevelDb() {
-      return inputTap.getLevelDb()
+    getInputLevels() {
+      return inputTap.getLevels()
     },
 
-    getOutputLevelDb() {
-      return outputTap.getLevelDb()
+    getOutputLevels() {
+      return outputTap.getLevels()
     },
 
     getSpectrumDb() {

--- a/src/audio/effects/manualEq.js
+++ b/src/audio/effects/manualEq.js
@@ -113,12 +113,12 @@ export function createManualEq(audioContext) {
       return params[name]
     },
 
-    getInputLevels() {
-      return inputTap.getLevels()
+    getInputLevels(channelCount) {
+      return inputTap.getLevels(channelCount)
     },
 
-    getOutputLevels() {
-      return outputTap.getLevels()
+    getOutputLevels(channelCount) {
+      return outputTap.getLevels(channelCount)
     },
 
     getSpectrumDb() {

--- a/src/audio/effects/resonance.js
+++ b/src/audio/effects/resonance.js
@@ -120,12 +120,12 @@ export function createResonance(audioContext) {
       return -grDb
     },
 
-    getInputLevelDb() {
-      return inputTap.getLevelDb()
+    getInputLevels() {
+      return inputTap.getLevels()
     },
 
-    getOutputLevelDb() {
-      return outputTap.getLevelDb()
+    getOutputLevels() {
+      return outputTap.getLevels()
     },
 
     destroy() {

--- a/src/audio/effects/resonance.js
+++ b/src/audio/effects/resonance.js
@@ -120,12 +120,12 @@ export function createResonance(audioContext) {
       return -grDb
     },
 
-    getInputLevels() {
-      return inputTap.getLevels()
+    getInputLevels(channelCount) {
+      return inputTap.getLevels(channelCount)
     },
 
-    getOutputLevels() {
-      return outputTap.getLevels()
+    getOutputLevels(channelCount) {
+      return outputTap.getLevels(channelCount)
     },
 
     destroy() {

--- a/src/audio/effects/vocalSat.js
+++ b/src/audio/effects/vocalSat.js
@@ -95,12 +95,12 @@ export function createVocalSat(audioContext) {
       return params[name]
     },
 
-    getInputLevelDb() {
-      return inputTap.getLevelDb()
+    getInputLevels() {
+      return inputTap.getLevels()
     },
 
-    getOutputLevelDb() {
-      return outputTap.getLevelDb()
+    getOutputLevels() {
+      return outputTap.getLevels()
     },
 
     destroy() {

--- a/src/audio/effects/vocalSat.js
+++ b/src/audio/effects/vocalSat.js
@@ -95,12 +95,12 @@ export function createVocalSat(audioContext) {
       return params[name]
     },
 
-    getInputLevels() {
-      return inputTap.getLevels()
+    getInputLevels(channelCount) {
+      return inputTap.getLevels(channelCount)
     },
 
-    getOutputLevels() {
-      return outputTap.getLevels()
+    getOutputLevels(channelCount) {
+      return outputTap.getLevels(channelCount)
     },
 
     destroy() {

--- a/src/components/meters/GainReductionBar.vue
+++ b/src/components/meters/GainReductionBar.vue
@@ -11,7 +11,13 @@ const props = defineProps({
   accent: { type: String, default: '#f5a623' },
   // Reduction (in dB) that fills the bar end to end.
   fullScaleDb: { type: Number, default: 40 },
-  scale: { type: Array, default: () => ['0', '-3', '-6', '-12', '-24'] },
+  /**
+   * Marks to engrave, in dB of reduction. Each is placed at its true position
+   * on the bar, so the numbers may be spaced however they like. The previous
+   * default read 0/-3/-6/-12/-24 laid out at even intervals, which put -24 at
+   * the far end of a 40 dB bar instead of three fifths along.
+   */
+  scale: { type: Array, default: () => [0, -10, -20, -30, -40] },
   title: { type: String, default: 'GAIN REDUCTION' },
   // CSS smoothing on the fill. Fine for a compressor, whose reduction is already
   // a continuous tens-of-ms envelope. Set to 0 when the caller applies its own
@@ -21,6 +27,21 @@ const props = defineProps({
 
 const amount = computed(() => Math.abs(props.reductionDb))
 const fillPct = computed(() => Math.min(100, (amount.value / props.fullScaleDb) * 100))
+
+/**
+ * Marks with their true positions. Accepts numbers or the numeric strings the
+ * callers used to pass. The end labels are pulled inside the bar rather than
+ * centred on their tick, so neither overhangs the track.
+ */
+const marks = computed(() => props.scale.map((mark) => {
+  const db = typeof mark === 'number' ? mark : parseFloat(mark)
+  const pct = Math.max(0, Math.min(100, (Math.abs(db) / props.fullScaleDb) * 100))
+  return {
+    label: String(mark),
+    pct,
+    shift: pct <= 0 ? 'none' : pct >= 100 ? 'translateX(-100%)' : 'translateX(-50%)',
+  }
+}))
 </script>
 
 <template>
@@ -42,9 +63,21 @@ const fillPct = computed(() => Math.min(100, (amount.value / props.fullScaleDb) 
              boxShadow: `0 0 16px color-mix(in srgb, ${accent} 70%, transparent)`,
            }"></div>
       <div class="absolute inset-0 rounded-[9px]" style="background:repeating-linear-gradient(90deg,#0000 0 9px,rgba(10,8,6,.85) 9px 11px)"></div>
+      <!-- Ticks on the track itself, so the engraving is visibly tied to the
+           positions the numerals claim. -->
+      <div
+        v-for="(mark, i) in marks" :key="`t${i}`"
+        v-show="mark.pct > 0 && mark.pct < 100"
+        class="absolute"
+        :style="{ left: mark.pct + '%', top: '0', bottom: '0', width: '1px', background: 'rgba(255,255,255,.16)' }"
+      ></div>
     </div>
-    <div class="flex justify-between mt-[5px]" style="font:600 8px 'JetBrains Mono',monospace;color:rgba(255,255,255,.3)">
-      <span v-for="(mark, i) in scale" :key="i">{{ mark }}</span>
+    <div class="relative mt-[5px] h-[10px]" style="font:600 8px 'JetBrains Mono',monospace;color:rgba(255,255,255,.3)">
+      <span
+        v-for="(mark, i) in marks" :key="i"
+        class="absolute top-0"
+        :style="{ left: mark.pct + '%', transform: mark.shift }"
+      >{{ mark.label }}</span>
     </div>
   </div>
 </template>

--- a/src/components/meters/LevelMeter.vue
+++ b/src/components/meters/LevelMeter.vue
@@ -11,19 +11,14 @@ import { computed, onMounted, onUnmounted, ref } from 'vue'
  * number and the hold line show how close the transients are to the ceiling.
  */
 const props = defineProps({
-  // RMS level in dBFS, the bar reading.
-  db: { type: Number, required: true },
-  // Sample peak in dBFS. Drives the hold line, the readout and the over lamp.
-  // Callers without a peak source can omit it and get a bar-only meter.
-  peakDb: { type: Number, default: -Infinity },
-  label: { type: String, default: '' },
   /**
-   * Bars to draw. One per independent reading the caller actually has — the
-   * level tap measures the analyser's mono downmix, so one is the honest
-   * answer for every current caller. Drawing two from a single number was
-   * a stereo meter that could not show a channel imbalance if there was one.
+   * One `{ rmsDb, peakDb }` per channel, in dBFS, refreshed every frame by
+   * the caller. Length sets how many bars are drawn, so it must be the
+   * source's real channel count — see `createLevelTap`. Empty means the
+   * graph is not running.
    */
-  channels: { type: Number, default: 1 },
+  levels: { type: Array, default: () => [] },
+  label: { type: String, default: '' },
   height: { type: Number, default: 150 },
   // Bottom of the scale. The top is always 0 dBFS.
   floorDb: { type: Number, default: -60 },
@@ -81,11 +76,12 @@ function dbToPct(db) {
   return Math.max(0, Math.min(100, pct))
 }
 
-const displayDb = ref(-Infinity)
-const heldPeakDb = ref(-Infinity)
+// One entry per channel: `{ displayDb, heldPeakDb }` after ballistics.
+const bars = ref([])
 const clipped = ref(false)
-let holdUntil = 0
+let holdUntil = []
 let lastTs = 0
+let rafId = null
 
 /**
  * Ballistics run on their own frame loop rather than off a watcher.
@@ -95,44 +91,54 @@ let lastTs = 0
  * steady tone — or any signal that momentarily plateaus — freezes the bar
  * part-way down. The loop keeps falling whatever the input does.
  */
-let rafId = null
-
 function advance() {
-  const rms = props.db
-  const peak = props.peakDb
+  const src = props.levels
+  const now = performance.now()
 
-  // A non-finite reading means the graph is not running — no real recording
-  // reaches digital silence. Clear rather than decay, so a torn-down meter
-  // cannot strand a bar or a hold line at whatever it last saw.
-  if (!Number.isFinite(rms) && !Number.isFinite(peak)) {
-    displayDb.value = -Infinity
-    heldPeakDb.value = -Infinity
+  // No channels means the graph is not running. Clear rather than decay, so
+  // a torn-down meter cannot strand a bar or a hold line at its last reading.
+  if (!src || src.length === 0) {
+    if (bars.value.length) bars.value = []
     clipped.value = false
+    holdUntil = []
     lastTs = 0
     rafId = requestAnimationFrame(advance)
     return
   }
 
-  const now = performance.now()
   const elapsedS = lastTs ? (now - lastTs) / 1000 : 0
   lastTs = now
 
-  if (!Number.isFinite(displayDb.value) || rms >= displayDb.value) {
-    displayDb.value = rms
-  } else {
-    displayDb.value = Math.max(rms, displayDb.value - BAR_RELEASE_DB_PER_S * elapsedS)
-  }
+  const prev = bars.value
+  const next = new Array(src.length)
+  if (holdUntil.length !== src.length) holdUntil = new Array(src.length).fill(0)
 
-  if (Number.isFinite(peak)) {
+  for (let ch = 0; ch < src.length; ch++) {
+    const rms = src[ch].rmsDb
+    const peak = src[ch].peakDb
+    const last = prev[ch] ?? { displayDb: -Infinity, heldPeakDb: -Infinity }
+
+    const displayDb = (!Number.isFinite(last.displayDb) || rms >= last.displayDb)
+      ? rms
+      : Math.max(rms, last.displayDb - BAR_RELEASE_DB_PER_S * elapsedS)
+
+    // An over on any channel lights the one lamp.
     if (peak >= props.clipDb) clipped.value = true
-    if (!Number.isFinite(heldPeakDb.value) || peak >= heldPeakDb.value) {
-      heldPeakDb.value = peak
-      holdUntil = now + PEAK_HOLD_MS
-    } else if (now >= holdUntil) {
-      heldPeakDb.value = Math.max(peak, heldPeakDb.value - PEAK_RELEASE_DB_PER_S * elapsedS)
+
+    let heldPeakDb = last.heldPeakDb
+    if (!Number.isFinite(heldPeakDb) || peak >= heldPeakDb) {
+      heldPeakDb = peak
+      holdUntil[ch] = now + PEAK_HOLD_MS
+    } else if (now >= holdUntil[ch]) {
+      // Math.max against a -Infinity peak still decays, so a hold line over a
+      // digitally silent passage falls away instead of hanging there.
+      heldPeakDb = Math.max(peak, heldPeakDb - PEAK_RELEASE_DB_PER_S * elapsedS)
     }
+
+    next[ch] = { displayDb, heldPeakDb }
   }
 
+  bars.value = next
   rafId = requestAnimationFrame(advance)
 }
 
@@ -142,9 +148,6 @@ onUnmounted(() => {
   rafId = null
 })
 
-const fillPct = computed(() =>
-  Number.isFinite(displayDb.value) ? dbToPct(displayDb.value) : 0)
-
 /**
  * The gradient is sized to the full track and pinned to its bottom edge, so
  * the zones stay at fixed dB positions. Left to resolve against the fill —
@@ -152,8 +155,7 @@ const fillPct = computed(() =>
  * they would scale with the reading, and every level would render with a red
  * tip. Stops come from dbToPct, so the zones follow the knee automatically.
  */
-const fillStyle = computed(() => ({
-  height: fillPct.value + '%',
+const fillBackground = computed(() => ({
   backgroundImage: `linear-gradient(to top,
     #2ec96b 0 ${dbToPct(AMBER_DB)}%,
     #e9c63b ${dbToPct(AMBER_DB)}% ${dbToPct(RED_DB)}%,
@@ -163,22 +165,45 @@ const fillStyle = computed(() => ({
   backgroundRepeat: 'no-repeat',
 }))
 
-const heldPeakPct = computed(() =>
-  Number.isFinite(heldPeakDb.value) ? dbToPct(heldPeakDb.value) : 0)
+function fillStyle(bar) {
+  return {
+    height: (Number.isFinite(bar.displayDb) ? dbToPct(bar.displayDb) : 0) + '%',
+    ...fillBackground.value,
+  }
+}
+
+const channelCount = computed(() => Math.max(1, props.levels.length))
+
+// Channel identity is carried in the label rather than drawn: at 9 px a bar
+// has no room for a caption, and a stereo pair reads as left-then-right.
+function channelName(index) {
+  if (channelCount.value < 2) return ''
+  return index === 0 ? 'left' : 'right'
+}
+
+/** Loudest peak across channels — one number over a pair means the hotter. */
+const readoutDb = computed(() => {
+  let max = -Infinity
+  for (const bar of bars.value) {
+    if (bar.heldPeakDb > max) max = bar.heldPeakDb
+  }
+  return max
+})
 
 const readout = computed(() =>
-  Number.isFinite(heldPeakDb.value) ? heldPeakDb.value.toFixed(1) : '-∞')
+  Number.isFinite(readoutDb.value) ? readoutDb.value.toFixed(1) : '-∞')
 
 // The lamp belongs to the bars, not to the whole component — the scale gutter
 // and the caption are both wider, and stretching to them left it floating
 // unaligned above the thing it reports on.
 const barBlockWidth = computed(() =>
-  props.channels * BAR_WIDTH + (props.channels - 1) * BAR_GAP)
+  channelCount.value * BAR_WIDTH + (channelCount.value - 1) * BAR_GAP)
 
 const visibleTicks = computed(() => TICKS.filter(t => t > props.floorDb))
 
-const ariaText = computed(() =>
-  Number.isFinite(props.db) ? `${props.db.toFixed(1)} dBFS` : 'silent')
+function ariaText(bar) {
+  return Number.isFinite(bar.displayDb) ? `${bar.displayDb.toFixed(1)} dBFS` : 'silent'
+}
 </script>
 
 <template>
@@ -208,32 +233,35 @@ const ariaText = computed(() =>
 
     <div class="flex items-end" :style="{ gap: showScale ? '5px' : '0' }">
       <div class="flex" :style="{ gap: BAR_GAP + 'px' }">
+        <!-- Before the first frame there are no bars yet; draw the empty
+             tracks so the panel does not reflow as metering starts. -->
         <div
-          v-for="ch in channels" :key="ch"
+          v-for="(bar, ch) in (bars.length ? bars : [{ displayDb: -Infinity, heldPeakDb: -Infinity }])"
+          :key="ch"
           class="relative rounded-[3px]"
           :style="{ width: BAR_WIDTH + 'px', height: height + 'px' }"
           style="background:#07090c;box-shadow:inset 0 0 0 1px rgba(255,255,255,.05)"
           role="meter"
           :aria-valuemin="floorDb"
           :aria-valuemax="0"
-          :aria-valuenow="Number.isFinite(db) ? Number(db.toFixed(1)) : floorDb"
-          :aria-valuetext="ariaText"
-          :aria-label="label ? `${label} level` : 'Level'"
+          :aria-valuenow="Number.isFinite(bar.displayDb) ? Number(bar.displayDb.toFixed(1)) : floorDb"
+          :aria-valuetext="ariaText(bar)"
+          :aria-label="[label, channelName(ch), 'level'].filter(Boolean).join(' ')"
         >
           <!-- No CSS transition: ballistics are applied above, and a
                transition restarting every frame never reaches its target. -->
-          <div class="absolute bottom-0 left-0 right-0 rounded-[3px]" :style="fillStyle"></div>
+          <div class="absolute bottom-0 left-0 right-0 rounded-[3px]" :style="fillStyle(bar)"></div>
 
           <!-- Segment ruling, purely cosmetic — the scale is the ticks. -->
           <div class="absolute inset-0" style="background:repeating-linear-gradient(to top,#0000 0 4px,#07090c 4px 6px)"></div>
 
           <div
-            v-if="Number.isFinite(heldPeakDb)"
+            v-if="Number.isFinite(bar.heldPeakDb)"
             class="absolute left-0 right-0"
             :style="{
-              bottom: `calc(${heldPeakPct}% - 1px)`,
+              bottom: `calc(${dbToPct(bar.heldPeakDb)}% - 1px)`,
               height: '2px',
-              background: heldPeakDb >= RED_DB ? '#ff8a7a' : 'rgba(255,255,255,.85)',
+              background: bar.heldPeakDb >= RED_DB ? '#ff8a7a' : 'rgba(255,255,255,.85)',
             }"
           ></div>
         </div>

--- a/src/components/meters/LevelMeter.vue
+++ b/src/components/meters/LevelMeter.vue
@@ -3,13 +3,12 @@ import { computed, onMounted, onUnmounted, ref } from 'vue'
 
 /**
  * Vertical level meter — a segmented LED ladder per channel, a peak-hold
- * segment, a clip lamp and a labelled scale. Shared by the plugin panels for
+ * line, a clip lamp and a labelled scale. Shared by the plugin panels for
  * their IN and OUT readouts.
  *
  * The ladder is RMS and the readout is peak, which is the split that makes a
  * meter this size useful: the ladder shows how loud the passage sits, the
- * number and the held segment show how close the transients are to the
- * ceiling.
+ * number and the hold line show how close the transients are to the ceiling.
  */
 const props = defineProps({
   /**
@@ -77,8 +76,8 @@ const KNEE_DB = -24
 const KNEE_PCT = 35
 
 // Meter ballistics. Instant attack so nothing is missed, timed release so the
-// eye can follow. The ladder falls faster than the hold segment, which is what
-// keeps the hold segment visible above it.
+// eye can follow. The ladder falls faster than the hold line, which is what
+// keeps the hold line visible above it.
 const BAR_RELEASE_DB_PER_S = 26
 const PEAK_RELEASE_DB_PER_S = 20
 const PEAK_HOLD_MS = 1200
@@ -161,7 +160,7 @@ function advance() {
       holdUntil[ch] = now + PEAK_HOLD_MS
     } else if (now >= holdUntil[ch]) {
       // Decays against the floor rather than against the peak, so a hold
-      // segment over a digitally silent passage falls away and settles
+      // line over a digitally silent passage falls away and settles
       // instead of either hanging there or running off the bottom.
       heldPeakDb = heldPeakDb - PEAK_RELEASE_DB_PER_S * elapsedS
     }
@@ -211,7 +210,6 @@ const segMeta = computed(() => {
  */
 const ladders = computed(() => {
   const meta = segMeta.value
-  const h = ladderHeight.value
   const floor = props.floorDb
   const source = bars.value.length
     ? bars.value
@@ -220,28 +218,29 @@ const ladders = computed(() => {
   return source.map((bar) => {
     const levelPct = dbToPct(bar.displayDb)
 
-    // The hold reads as one segment, so snap it to the nearest one rather
-    // than letting it fall between two and light neither. At the floor there
-    // is nothing to hold, so no segment is claimed.
-    const peakIndex = bar.heldPeakDb <= floor
-      ? -1
-      : Math.max(0, Math.min(meta.length - 1,
-        Math.round((dbToPct(bar.heldPeakDb) / 100 * h - SEG_H / 2) / PITCH)))
-
-    const segments = meta.map((seg, i) => {
+    const segments = meta.map((seg) => {
       const on = seg.centerPct <= levelPct
-      const held = i === peakIndex
       return {
         color: seg.color,
-        // Lit runs at full; a hold sitting above the run is dimmed so the two
-        // stay tellable apart, and everything else is the dark faceplate.
-        opacity: on ? 1 : held ? 0.85 : 0.1,
-        glow: on || held,
+        opacity: on ? 1 : 0.1,
+        glow: on,
       }
     })
     // Drawn top-down.
     segments.reverse()
-    return { bar, segments }
+
+    // The hold is a hairline riding over the ladder, not a lit segment. Drawn
+    // in the ladder's own vocabulary it reads as "the level is briefly up
+    // there too", which is the opposite of what it means — it is a mark left
+    // behind. A rule in a foreign colour, sitting in the gaps between
+    // segments, says "high-water" without any explanation. It also carries
+    // the true position rather than the nearest segment's, so the number
+    // beneath it and the mark agree.
+    const peak = bar.heldPeakDb <= floor
+      ? null
+      : { pct: dbToPct(bar.heldPeakDb), hot: bar.heldPeakDb >= RED_DB }
+
+    return { bar, segments, peak }
   })
 })
 
@@ -339,7 +338,7 @@ function ariaText(bar) {
           <div
             v-for="(ladder, ch) in ladders"
             :key="ch"
-            class="flex flex-col"
+            class="relative flex flex-col"
             :style="{ gap: SEG_GAP + 'px', height: ladderHeight + 'px' }"
             role="meter"
             :aria-valuemin="floorDb"
@@ -352,6 +351,17 @@ function ariaText(bar) {
                  above, and a transition restarting every frame never reaches
                  its target. -->
             <div v-for="(seg, i) in ladder.segments" :key="i" :style="segStyle(seg)"></div>
+
+            <!-- Peak hold. Last child so it paints over the ladder. -->
+            <div
+              v-if="ladder.peak"
+              class="absolute left-0 right-0 pointer-events-none"
+              :style="{
+                bottom: `calc(${ladder.peak.pct}% - 1px)`,
+                height: '2px',
+                background: ladder.peak.hot ? '#ff8a7a' : 'rgba(255,255,255,.85)',
+              }"
+            ></div>
           </div>
         </div>
       </div>

--- a/src/components/meters/LevelMeter.vue
+++ b/src/components/meters/LevelMeter.vue
@@ -2,18 +2,19 @@
 import { computed, onMounted, onUnmounted, ref } from 'vue'
 
 /**
- * Vertical level meter — a bar per channel, a peak-hold line, an over lamp
- * and a labelled scale. Shared by the plugin panels for their IN and OUT
- * readouts.
+ * Vertical level meter — a segmented LED ladder per channel, a peak-hold
+ * segment, a clip lamp and a labelled scale. Shared by the plugin panels for
+ * their IN and OUT readouts.
  *
- * The bar is RMS and the readout is peak, which is the split that makes a
- * meter this size useful: the bar shows how loud the passage sits, the
- * number and the hold line show how close the transients are to the ceiling.
+ * The ladder is RMS and the readout is peak, which is the split that makes a
+ * meter this size useful: the ladder shows how loud the passage sits, the
+ * number and the held segment show how close the transients are to the
+ * ceiling.
  */
 const props = defineProps({
   /**
    * One `{ rmsDb, peakDb }` per channel, in dBFS, refreshed every frame by
-   * the caller. Length sets how many bars are drawn, so it must be the
+   * the caller. Length sets how many ladders are drawn, so it must be the
    * source's real channel count — see `createLevelTap`. Empty means the
    * graph is not running.
    */
@@ -22,7 +23,7 @@ const props = defineProps({
   height: { type: Number, default: 150 },
   // Bottom of the scale. The top is always 0 dBFS.
   floorDb: { type: Number, default: -60 },
-  // Peak at or above this latches the over lamp. 0 dBFS is the point a float
+  // Peak at or above this latches the clip lamp. 0 dBFS is the point a float
   // sample can no longer survive the trip to an integer file.
   clipDb: { type: Number, default: 0 },
   showScale: { type: Boolean, default: true },
@@ -30,18 +31,39 @@ const props = defineProps({
   showOver: { type: Boolean, default: true },
 })
 
-const BAR_WIDTH = 9
-const BAR_GAP = 3
+// Ladder geometry. A segment and the gap under it are one pitch, so the
+// segment count follows from the height the caller asked for rather than the
+// other way round — panels keep setting a pixel height and the ladder fills
+// as much of it as whole segments allow.
+const SEG_W = 6
+const SEG_H = 6
+const SEG_GAP = 3
+const PITCH = SEG_H + SEG_GAP
+const CH_GAP = 2
+const MIN_ROWS = 8
+
+const rows = computed(() =>
+  Math.max(MIN_ROWS, Math.floor((props.height + SEG_GAP) / PITCH)))
+const ladderHeight = computed(() => rows.value * PITCH - SEG_GAP)
 
 // Marks worth engraving, in dBFS. Only some carry a numeral — the rest are
 // bare ticks, so the scale stays readable on the shortest panel that uses it.
 const TICKS = [-6, -12, -18, -24, -36, -48]
 const LABELLED = new Set([-6, -18, -36])
 
-// Zone edges in dBFS. Round numbers that land on ticks, so the colour change
-// and the engraving agree.
+// Zone edges in dBFS. Round numbers that land on labelled ticks, so the
+// colour change and the engraving agree. Four zones rather than three: the
+// cool band gives the bottom of the ladder somewhere to live other than
+// "green", which at this segment count was reading as one undifferentiated
+// mass across the whole quiet half.
+const CYAN_DB = -36
 const AMBER_DB = -18
 const RED_DB = -6
+
+const COOL = '#3FD0DE'
+const MID = '#8FD48A'
+const WARM = '#E8A33D'
+const HOT = '#FF5A4E'
 
 /**
  * Scale shape. A linear dBFS scale spends most of its height on the range
@@ -55,8 +77,8 @@ const KNEE_DB = -24
 const KNEE_PCT = 35
 
 // Meter ballistics. Instant attack so nothing is missed, timed release so the
-// eye can follow. The bar falls faster than the hold line, which is what keeps
-// the hold line visible above it.
+// eye can follow. The ladder falls faster than the hold segment, which is what
+// keeps the hold segment visible above it.
 const BAR_RELEASE_DB_PER_S = 26
 const PEAK_RELEASE_DB_PER_S = 20
 const PEAK_HOLD_MS = 1200
@@ -88,7 +110,7 @@ let rafId = null
  *
  * A release is a function of elapsed time, not of the input changing. Driven
  * by a watcher it advances only when a new value differs from the last, so a
- * steady tone — or any signal that momentarily plateaus — freezes the bar
+ * steady tone — or any signal that momentarily plateaus — freezes the ladder
  * part-way down. The loop keeps falling whatever the input does.
  */
 function advance() {
@@ -96,7 +118,8 @@ function advance() {
   const now = performance.now()
 
   // No channels means the graph is not running. Clear rather than decay, so
-  // a torn-down meter cannot strand a bar or a hold line at its last reading.
+  // a torn-down meter cannot strand a segment or a hold line at its last
+  // reading.
   if (!src || src.length === 0) {
     if (bars.value.length) bars.value = []
     clipped.value = false
@@ -113,27 +136,36 @@ function advance() {
   const next = new Array(src.length)
   if (holdUntil.length !== src.length) holdUntil = new Array(src.length).fill(0)
 
+  // The release is a fixed slope, and over a digitally silent passage the
+  // input it is racing against is -Infinity — so nothing ever stops it. Left
+  // unbounded the readout walks off into four figures of negative dB. The
+  // floor is the bottom of the scale, so anything at or under it is reported
+  // as silence rather than as a number.
+  const floor = props.floorDb
+
   for (let ch = 0; ch < src.length; ch++) {
     const rms = src[ch].rmsDb
     const peak = src[ch].peakDb
-    const last = prev[ch] ?? { displayDb: -Infinity, heldPeakDb: -Infinity }
+    const last = prev[ch] ?? { displayDb: floor, heldPeakDb: floor }
 
-    const displayDb = (!Number.isFinite(last.displayDb) || rms >= last.displayDb)
+    const displayDb = Math.max(floor, rms >= last.displayDb
       ? rms
-      : Math.max(rms, last.displayDb - BAR_RELEASE_DB_PER_S * elapsedS)
+      : last.displayDb - BAR_RELEASE_DB_PER_S * elapsedS)
 
     // An over on any channel lights the one lamp.
     if (peak >= props.clipDb) clipped.value = true
 
     let heldPeakDb = last.heldPeakDb
-    if (!Number.isFinite(heldPeakDb) || peak >= heldPeakDb) {
+    if (peak >= heldPeakDb) {
       heldPeakDb = peak
       holdUntil[ch] = now + PEAK_HOLD_MS
     } else if (now >= holdUntil[ch]) {
-      // Math.max against a -Infinity peak still decays, so a hold line over a
-      // digitally silent passage falls away instead of hanging there.
-      heldPeakDb = Math.max(peak, heldPeakDb - PEAK_RELEASE_DB_PER_S * elapsedS)
+      // Decays against the floor rather than against the peak, so a hold
+      // segment over a digitally silent passage falls away and settles
+      // instead of either hanging there or running off the bottom.
+      heldPeakDb = heldPeakDb - PEAK_RELEASE_DB_PER_S * elapsedS
     }
+    heldPeakDb = Math.max(floor, Math.max(peak, heldPeakDb))
 
     next[ch] = { displayDb, heldPeakDb }
   }
@@ -149,33 +181,75 @@ onUnmounted(() => {
 })
 
 /**
- * The gradient is sized to the full track and pinned to its bottom edge, so
- * the zones stay at fixed dB positions. Left to resolve against the fill —
- * which is what a plain `background` on a percentage-height element does —
- * they would scale with the reading, and every level would render with a red
- * tip. Stops come from dbToPct, so the zones follow the knee automatically.
+ * Where each segment sits and what colour it burns when lit. Fixed for a
+ * given height and floor, so it is computed once rather than per frame — the
+ * frame loop only decides which of these are currently alight.
+ *
+ * Zone edges are compared against the segment's midpoint, so a segment takes
+ * the colour of the level it reports rather than of the boundary it happens
+ * to straddle.
  */
-const fillBackground = computed(() => ({
-  backgroundImage: `linear-gradient(to top,
-    #2ec96b 0 ${dbToPct(AMBER_DB)}%,
-    #e9c63b ${dbToPct(AMBER_DB)}% ${dbToPct(RED_DB)}%,
-    #e35d4f ${dbToPct(RED_DB)}%)`,
-  backgroundSize: `100% ${props.height}px`,
-  backgroundPosition: 'left bottom',
-  backgroundRepeat: 'no-repeat',
-}))
+const segMeta = computed(() => {
+  const h = ladderHeight.value
+  const redPct = dbToPct(RED_DB)
+  const amberPct = dbToPct(AMBER_DB)
+  const greenPct = dbToPct(CYAN_DB)
+  return Array.from({ length: rows.value }, (_, i) => {
+    // i counts from the bottom; the column is drawn top-down and reversed.
+    const centerPct = ((i * PITCH + SEG_H / 2) / h) * 100
+    const color = centerPct >= redPct ? HOT
+      : centerPct >= amberPct ? WARM
+        : centerPct >= greenPct ? MID
+          : COOL
+    return { centerPct, color }
+  })
+})
 
-function fillStyle(bar) {
-  return {
-    height: (Number.isFinite(bar.displayDb) ? dbToPct(bar.displayDb) : 0) + '%',
-    ...fillBackground.value,
-  }
-}
+/**
+ * Per-channel segment state for this frame. Before the first frame the ladder
+ * is still drawn, fully dark, so the panel does not reflow as metering starts.
+ */
+const ladders = computed(() => {
+  const meta = segMeta.value
+  const h = ladderHeight.value
+  const floor = props.floorDb
+  const source = bars.value.length
+    ? bars.value
+    : [{ displayDb: floor, heldPeakDb: floor }]
+
+  return source.map((bar) => {
+    const levelPct = dbToPct(bar.displayDb)
+
+    // The hold reads as one segment, so snap it to the nearest one rather
+    // than letting it fall between two and light neither. At the floor there
+    // is nothing to hold, so no segment is claimed.
+    const peakIndex = bar.heldPeakDb <= floor
+      ? -1
+      : Math.max(0, Math.min(meta.length - 1,
+        Math.round((dbToPct(bar.heldPeakDb) / 100 * h - SEG_H / 2) / PITCH)))
+
+    const segments = meta.map((seg, i) => {
+      const on = seg.centerPct <= levelPct
+      const held = i === peakIndex
+      return {
+        color: seg.color,
+        // Lit runs at full; a hold sitting above the run is dimmed so the two
+        // stay tellable apart, and everything else is the dark faceplate.
+        opacity: on ? 1 : held ? 0.85 : 0.1,
+        glow: on || held,
+      }
+    })
+    // Drawn top-down.
+    segments.reverse()
+    return { bar, segments }
+  })
+})
 
 const channelCount = computed(() => Math.max(1, props.levels.length))
 
-// Channel identity is carried in the label rather than drawn: at 9 px a bar
-// has no room for a caption, and a stereo pair reads as left-then-right.
+// Channel identity is carried in the label rather than drawn: at 6 px a
+// segment has no room for a caption, and a stereo pair reads as
+// left-then-right.
 function channelName(index) {
   if (channelCount.value < 2) return ''
   return index === 0 ? 'left' : 'right'
@@ -183,93 +257,104 @@ function channelName(index) {
 
 /** Loudest peak across channels — one number over a pair means the hotter. */
 const readoutDb = computed(() => {
-  let max = -Infinity
+  let max = props.floorDb
   for (const bar of bars.value) {
     if (bar.heldPeakDb > max) max = bar.heldPeakDb
   }
   return max
 })
 
+// At the floor the meter is off the bottom of its own scale, and a number
+// there would be a reading the scale cannot show.
 const readout = computed(() =>
-  Number.isFinite(readoutDb.value) ? readoutDb.value.toFixed(1) : '-∞')
+  readoutDb.value <= props.floorDb ? '-∞' : readoutDb.value.toFixed(1))
 
-// The lamp belongs to the bars, not to the whole component — the scale gutter
-// and the caption are both wider, and stretching to them left it floating
-// unaligned above the thing it reports on.
-const barBlockWidth = computed(() =>
-  channelCount.value * BAR_WIDTH + (channelCount.value - 1) * BAR_GAP)
+// The lamp belongs to the ladders, not to the whole component — the scale
+// gutter and the caption are both wider, and stretching to them left it
+// floating unaligned above the thing it reports on.
+const ladderBlockWidth = computed(() =>
+  channelCount.value * SEG_W + (channelCount.value - 1) * CH_GAP)
 
 const visibleTicks = computed(() => TICKS.filter(t => t > props.floorDb))
 
+function segStyle(seg) {
+  return {
+    width: SEG_W + 'px',
+    height: SEG_H + 'px',
+    borderRadius: '1px',
+    background: seg.color,
+    opacity: seg.opacity,
+    boxShadow: seg.glow ? `0 0 6px ${seg.color}` : 'none',
+  }
+}
+
 function ariaText(bar) {
-  return Number.isFinite(bar.displayDb) ? `${bar.displayDb.toFixed(1)} dBFS` : 'silent'
+  return bar.displayDb <= props.floorDb ? 'silent' : `${bar.displayDb.toFixed(1)} dBFS`
 }
 </script>
 
 <template>
   <div class="flex flex-col items-center gap-[7px]">
-    <!-- Over lamp. Latches, and clears on click the way a console does: the
-         readout decays within a second or two, so without the latch a peak
-         that overshot ten seconds ago leaves no trace. -->
-    <div
-      v-if="showOver"
-      :style="{ width: barBlockWidth + 'px' }"
-      :class="clipped ? 'cursor-pointer' : ''"
-      :role="clipped ? 'button' : 'status'"
-      :tabindex="clipped ? 0 : -1"
-      :title="clipped ? 'Peak reached 0 dBFS — click to reset' : 'No overs'"
-      :aria-label="clipped ? 'Over, click to reset' : 'No overs'"
-      @click="clipped = false"
-      @keydown.enter.space.prevent="clipped = false"
-    >
-      <div :style="{
-        height: '5px',
-        borderRadius: '2px',
-        border: '1px solid rgba(255,255,255,.07)',
-        background: clipped ? '#e35d4f' : 'rgba(255,255,255,.04)',
-        boxShadow: clipped ? '0 0 8px rgba(227,93,79,.7)' : 'none',
-      }"></div>
-    </div>
-
     <div class="flex items-end" :style="{ gap: showScale ? '5px' : '0' }">
-      <div class="flex" :style="{ gap: BAR_GAP + 'px' }">
-        <!-- Before the first frame there are no bars yet; draw the empty
-             tracks so the panel does not reflow as metering starts. -->
+      <!-- Ladder housing. The lamp lives inside it, on the faceplate, rather
+           than floating above the component. -->
+      <div
+        class="flex flex-col items-center"
+        style="padding:5px;border-radius:5px;background:#0b0e13;border:1px solid #1c222c"
+      >
+        <!-- Clip lamp. Latches, and clears on click the way a console does:
+             the readout decays within a second or two, so without the latch a
+             peak that overshot ten seconds ago leaves no trace. -->
         <div
-          v-for="(bar, ch) in (bars.length ? bars : [{ displayDb: -Infinity, heldPeakDb: -Infinity }])"
-          :key="ch"
-          class="relative rounded-[3px]"
-          :style="{ width: BAR_WIDTH + 'px', height: height + 'px' }"
-          style="background:#07090c;box-shadow:inset 0 0 0 1px rgba(255,255,255,.05)"
-          role="meter"
-          :aria-valuemin="floorDb"
-          :aria-valuemax="0"
-          :aria-valuenow="Number.isFinite(bar.displayDb) ? Number(bar.displayDb.toFixed(1)) : floorDb"
-          :aria-valuetext="ariaText(bar)"
-          :aria-label="[label, channelName(ch), 'level'].filter(Boolean).join(' ')"
+          v-if="showOver"
+          class="mb-[6px]"
+          :style="{ width: ladderBlockWidth + 'px' }"
+          :class="clipped ? 'cursor-pointer' : ''"
+          :role="clipped ? 'button' : 'status'"
+          :tabindex="clipped ? 0 : -1"
+          :title="clipped ? 'Peak reached 0 dBFS — click to reset' : 'No overs'"
+          :aria-label="clipped ? 'Over, click to reset' : 'No overs'"
+          @click="clipped = false"
+          @keydown.enter.space.prevent="clipped = false"
         >
-          <!-- No CSS transition: ballistics are applied above, and a
-               transition restarting every frame never reaches its target. -->
-          <div class="absolute bottom-0 left-0 right-0 rounded-[3px]" :style="fillStyle(bar)"></div>
+          <div :style="{
+            height: '5px',
+            borderRadius: '1.5px',
+            background: clipped ? HOT : '#262c37',
+            boxShadow: clipped ? `0 0 10px ${HOT}, 0 0 3px ${HOT}` : 'none',
+            transition: 'background .12s, box-shadow .12s',
+          }"></div>
+        </div>
 
-          <!-- Segment ruling, purely cosmetic — the scale is the ticks. -->
-          <div class="absolute inset-0" style="background:repeating-linear-gradient(to top,#0000 0 4px,#07090c 4px 6px)"></div>
-
+        <div class="flex" :style="{ gap: CH_GAP + 'px' }">
           <div
-            v-if="Number.isFinite(bar.heldPeakDb)"
-            class="absolute left-0 right-0"
-            :style="{
-              bottom: `calc(${dbToPct(bar.heldPeakDb)}% - 1px)`,
-              height: '2px',
-              background: bar.heldPeakDb >= RED_DB ? '#ff8a7a' : 'rgba(255,255,255,.85)',
-            }"
-          ></div>
+            v-for="(ladder, ch) in ladders"
+            :key="ch"
+            class="flex flex-col"
+            :style="{ gap: SEG_GAP + 'px', height: ladderHeight + 'px' }"
+            role="meter"
+            :aria-valuemin="floorDb"
+            :aria-valuemax="0"
+            :aria-valuenow="Number(ladder.bar.displayDb.toFixed(1))"
+            :aria-valuetext="ariaText(ladder.bar)"
+            :aria-label="[label, channelName(ch), 'level'].filter(Boolean).join(' ')"
+          >
+            <!-- No CSS transition on the segments: ballistics are applied
+                 above, and a transition restarting every frame never reaches
+                 its target. -->
+            <div v-for="(seg, i) in ladder.segments" :key="i" :style="segStyle(seg)"></div>
+          </div>
         </div>
       </div>
 
       <!-- Scale. Ticks sit at their true positions; the gutter is sized for
-           the widest numeral so the bars do not shift between panels. -->
-      <div v-if="showScale" class="relative" :style="{ height: height + 'px', width: '18px' }">
+           the widest numeral so the ladders do not shift between panels, and
+           inset by the housing padding so it lines up with the segments. -->
+      <div
+        v-if="showScale"
+        class="relative mb-[5px]"
+        :style="{ height: ladderHeight + 'px', width: '18px' }"
+      >
         <div
           v-for="tick in visibleTicks" :key="tick"
           class="absolute left-0 flex items-center gap-[4px]"
@@ -278,11 +363,11 @@ function ariaText(bar) {
           <span :style="{
             width: LABELLED.has(tick) ? '4px' : '2.5px',
             height: '1px',
-            background: 'rgba(255,255,255,.22)',
+            background: 'rgba(255,255,255,.18)',
           }"></span>
           <span
             v-if="LABELLED.has(tick)"
-            style="font:600 7px 'JetBrains Mono',monospace;color:rgba(255,255,255,.3);line-height:1"
+            style="font:500 9px 'JetBrains Mono',monospace;color:#5d6472;line-height:1"
           >{{ tick }}</span>
         </div>
       </div>
@@ -291,11 +376,11 @@ function ariaText(bar) {
     <span
       v-if="showReadout"
       :style="{
-        font: `700 9.5px 'JetBrains Mono',monospace`,
-        color: clipped ? '#ff9d90' : 'rgba(255,255,255,.62)',
+        font: `600 12px 'JetBrains Mono',monospace`,
+        color: clipped ? '#ff9d90' : '#cfd4de',
       }"
     >{{ readout }}</span>
 
-    <span v-if="label" style="font:700 9px 'JetBrains Mono',monospace;letter-spacing:.16em;color:rgba(255,255,255,.45)">{{ label }}</span>
+    <span v-if="label" style="font:600 9px 'JetBrains Mono',monospace;letter-spacing:.2em;color:#6f7787">{{ label }}</span>
   </div>
 </template>

--- a/src/components/meters/LevelMeter.vue
+++ b/src/components/meters/LevelMeter.vue
@@ -60,8 +60,8 @@ const CYAN_DB = -36
 const AMBER_DB = -18
 const RED_DB = -6
 
-const COOL = '#3FD0DE'
-const MID = '#8FD48A'
+const COOL = '#7CE0A8' // '#3FD0DE' blue
+const MID = '#6FD6C0'// '#8FD48A' green
 const WARM = '#E8A33D'
 const HOT = '#FF5A4E'
 

--- a/src/components/meters/LevelMeter.vue
+++ b/src/components/meters/LevelMeter.vue
@@ -275,6 +275,15 @@ const readout = computed(() =>
 const ladderBlockWidth = computed(() =>
   channelCount.value * SEG_W + (channelCount.value - 1) * CH_GAP)
 
+// Outer width of the housing: the ladders, its padding, its border. The
+// readout and the caption are centred on this rather than on the component,
+// which includes the scale gutter off to one side and so would sit them
+// visibly off to that side of the thing they label.
+const HOUSING_PAD = 5
+const HOUSING_BORDER = 1
+const housingWidth = computed(() =>
+  ladderBlockWidth.value + 2 * (HOUSING_PAD + HOUSING_BORDER))
+
 const visibleTicks = computed(() => TICKS.filter(t => t > props.floorDb))
 
 function segStyle(seg) {
@@ -294,7 +303,7 @@ function ariaText(bar) {
 </script>
 
 <template>
-  <div class="flex flex-col items-center gap-[7px]">
+  <div class="flex flex-col items-start gap-[7px]">
     <div class="flex items-end" :style="{ gap: showScale ? '5px' : '0' }">
       <!-- Ladder housing. The lamp lives inside it, on the faceplate, rather
            than floating above the component. -->
@@ -363,24 +372,30 @@ function ariaText(bar) {
           <span :style="{
             width: LABELLED.has(tick) ? '4px' : '2.5px',
             height: '1px',
-            background: 'rgba(255,255,255,.18)',
+            background: 'rgba(255,255,255,.22)',
           }"></span>
           <span
             v-if="LABELLED.has(tick)"
-            style="font:500 9px 'JetBrains Mono',monospace;color:#5d6472;line-height:1"
+            style="font:600 7px 'JetBrains Mono',monospace;color:rgba(255,255,255,.3);line-height:1"
           >{{ tick }}</span>
         </div>
       </div>
     </div>
 
-    <span
-      v-if="showReadout"
-      :style="{
-        font: `600 12px 'JetBrains Mono',monospace`,
-        color: clipped ? '#ff9d90' : '#cfd4de',
-      }"
-    >{{ readout }}</span>
+    <div
+      v-if="showReadout || label"
+      class="flex flex-col items-center gap-[7px]"
+      :style="{ width: housingWidth + 'px' }"
+    >
+      <span
+        v-if="showReadout"
+        :style="{
+          font: `700 9.5px 'JetBrains Mono',monospace`,
+          color: clipped ? '#ff9d90' : 'rgba(255,255,255,.62)',
+        }"
+      >{{ readout }}</span>
 
-    <span v-if="label" style="font:600 9px 'JetBrains Mono',monospace;letter-spacing:.2em;color:#6f7787">{{ label }}</span>
+      <span v-if="label" style="font:700 9px 'JetBrains Mono',monospace;letter-spacing:.16em;color:rgba(255,255,255,.45)">{{ label }}</span>
+    </div>
   </div>
 </template>

--- a/src/components/meters/LevelMeter.vue
+++ b/src/components/meters/LevelMeter.vue
@@ -35,7 +35,7 @@ const props = defineProps({
 // other way round — panels keep setting a pixel height and the ladder fills
 // as much of it as whole segments allow.
 const SEG_W = 6
-const SEG_H = 6
+const SEG_H = 4
 const SEG_GAP = 3
 const PITCH = SEG_H + SEG_GAP
 const CH_GAP = 2
@@ -358,8 +358,13 @@ function ariaText(bar) {
               class="absolute left-0 right-0 pointer-events-none"
               :style="{
                 bottom: `calc(${ladder.peak.pct}% - 1px)`,
-                height: '2px',
                 background: ladder.peak.hot ? '#ff8a7a' : 'rgba(255,255,255,.85)',
+                width: SEG_W + 'px',
+                height: '3px',
+                borderRadius: '1px',
+                opacity: 1,
+                boxShadow: `0 0 6px ` + ladder.peak.hot ? '#ff8a7a' : 'rgba(255,255,255,.85)',
+
               }"
             ></div>
           </div>

--- a/src/components/meters/LevelMeter.vue
+++ b/src/components/meters/LevelMeter.vue
@@ -1,10 +1,10 @@
 <script setup>
-import { computed, ref, watch } from 'vue'
+import { computed, onMounted, onUnmounted, ref } from 'vue'
 
 /**
- * Vertical segmented level meter — a column per channel, a peak-hold line,
- * an over indicator and a labelled scale. Shared by the plugin panels for
- * their IN and OUT readouts.
+ * Vertical level meter — a bar per channel, a peak-hold line, an over lamp
+ * and a labelled scale. Shared by the plugin panels for their IN and OUT
+ * readouts.
  *
  * The bar is RMS and the readout is peak, which is the split that makes a
  * meter this size useful: the bar shows how loud the passage sits, the
@@ -13,21 +13,30 @@ import { computed, ref, watch } from 'vue'
 const props = defineProps({
   // RMS level in dBFS, the bar reading.
   db: { type: Number, required: true },
-  // Sample peak in dBFS. Drives the hold line, the readout and the over
-  // indicator. Callers without a peak source can omit it and get the old
-  // bar-only meter.
+  // Sample peak in dBFS. Drives the hold line, the readout and the over lamp.
+  // Callers without a peak source can omit it and get a bar-only meter.
   peakDb: { type: Number, default: -Infinity },
   label: { type: String, default: '' },
-  channels: { type: Number, default: 2 },
+  /**
+   * Bars to draw. One per independent reading the caller actually has — the
+   * level tap measures the analyser's mono downmix, so one is the honest
+   * answer for every current caller. Drawing two from a single number was
+   * a stereo meter that could not show a channel imbalance if there was one.
+   */
+  channels: { type: Number, default: 1 },
   height: { type: Number, default: 150 },
   // Bottom of the scale. The top is always 0 dBFS.
   floorDb: { type: Number, default: -60 },
-  // Peak at or above this latches the over indicator. 0 dBFS is the point a
-  // float sample can no longer survive the trip to an integer file.
+  // Peak at or above this latches the over lamp. 0 dBFS is the point a float
+  // sample can no longer survive the trip to an integer file.
   clipDb: { type: Number, default: 0 },
   showScale: { type: Boolean, default: true },
   showReadout: { type: Boolean, default: true },
+  showOver: { type: Boolean, default: true },
 })
+
+const BAR_WIDTH = 9
+const BAR_GAP = 3
 
 // Marks worth engraving, in dBFS. Only some carry a numeral — the rest are
 // bare ticks, so the scale stays readable on the shortest panel that uses it.
@@ -39,24 +48,109 @@ const LABELLED = new Set([-6, -18, -36])
 const AMBER_DB = -18
 const RED_DB = -6
 
-// Peak-hold ballistics: dwell, then fall at a constant rate.
-const HOLD_MS = 1200
-const DECAY_DB_PER_S = 20
+/**
+ * Scale shape. A linear dBFS scale spends most of its height on the range
+ * below -24, where nothing happens, and crushes the -24..0 working range into
+ * the remainder. Give the top 24 dB the majority of the travel instead —
+ * roughly doubling the resolution where the reading is actually read — and
+ * let the quiet end compress. The VU meter face already establishes that a
+ * non-linear scale is fair game here.
+ */
+const KNEE_DB = -24
+const KNEE_PCT = 35
+
+// Meter ballistics. Instant attack so nothing is missed, timed release so the
+// eye can follow. The bar falls faster than the hold line, which is what keeps
+// the hold line visible above it.
+const BAR_RELEASE_DB_PER_S = 26
+const PEAK_RELEASE_DB_PER_S = 20
+const PEAK_HOLD_MS = 1200
 
 /** Position of a dB value on the scale, 0-100 from the floor up. */
 function dbToPct(db) {
-  const span = -props.floorDb
-  return Math.max(0, Math.min(100, ((db - props.floorDb) / span) * 100))
+  const floor = props.floorDb
+  let pct
+  if (floor >= KNEE_DB) {
+    // Scale too short for a knee — the whole thing is working range.
+    pct = ((db - floor) / -floor) * 100
+  } else if (db <= KNEE_DB) {
+    pct = ((db - floor) / (KNEE_DB - floor)) * KNEE_PCT
+  } else {
+    pct = KNEE_PCT + ((db - KNEE_DB) / -KNEE_DB) * (100 - KNEE_PCT)
+  }
+  return Math.max(0, Math.min(100, pct))
 }
 
-const fillPct = computed(() => (Number.isFinite(props.db) ? dbToPct(props.db) : 0))
+const displayDb = ref(-Infinity)
+const heldPeakDb = ref(-Infinity)
+const clipped = ref(false)
+let holdUntil = 0
+let lastTs = 0
+
+/**
+ * Ballistics run on their own frame loop rather than off a watcher.
+ *
+ * A release is a function of elapsed time, not of the input changing. Driven
+ * by a watcher it advances only when a new value differs from the last, so a
+ * steady tone — or any signal that momentarily plateaus — freezes the bar
+ * part-way down. The loop keeps falling whatever the input does.
+ */
+let rafId = null
+
+function advance() {
+  const rms = props.db
+  const peak = props.peakDb
+
+  // A non-finite reading means the graph is not running — no real recording
+  // reaches digital silence. Clear rather than decay, so a torn-down meter
+  // cannot strand a bar or a hold line at whatever it last saw.
+  if (!Number.isFinite(rms) && !Number.isFinite(peak)) {
+    displayDb.value = -Infinity
+    heldPeakDb.value = -Infinity
+    clipped.value = false
+    lastTs = 0
+    rafId = requestAnimationFrame(advance)
+    return
+  }
+
+  const now = performance.now()
+  const elapsedS = lastTs ? (now - lastTs) / 1000 : 0
+  lastTs = now
+
+  if (!Number.isFinite(displayDb.value) || rms >= displayDb.value) {
+    displayDb.value = rms
+  } else {
+    displayDb.value = Math.max(rms, displayDb.value - BAR_RELEASE_DB_PER_S * elapsedS)
+  }
+
+  if (Number.isFinite(peak)) {
+    if (peak >= props.clipDb) clipped.value = true
+    if (!Number.isFinite(heldPeakDb.value) || peak >= heldPeakDb.value) {
+      heldPeakDb.value = peak
+      holdUntil = now + PEAK_HOLD_MS
+    } else if (now >= holdUntil) {
+      heldPeakDb.value = Math.max(peak, heldPeakDb.value - PEAK_RELEASE_DB_PER_S * elapsedS)
+    }
+  }
+
+  rafId = requestAnimationFrame(advance)
+}
+
+onMounted(() => { advance() })
+onUnmounted(() => {
+  if (rafId !== null) cancelAnimationFrame(rafId)
+  rafId = null
+})
+
+const fillPct = computed(() =>
+  Number.isFinite(displayDb.value) ? dbToPct(displayDb.value) : 0)
 
 /**
  * The gradient is sized to the full track and pinned to its bottom edge, so
  * the zones stay at fixed dB positions. Left to resolve against the fill —
  * which is what a plain `background` on a percentage-height element does —
  * they would scale with the reading, and every level would render with a red
- * tip.
+ * tip. Stops come from dbToPct, so the zones follow the knee automatically.
  */
 const fillStyle = computed(() => ({
   height: fillPct.value + '%',
@@ -69,44 +163,19 @@ const fillStyle = computed(() => ({
   backgroundRepeat: 'no-repeat',
 }))
 
-const heldPeakDb = ref(-Infinity)
-const clipped = ref(false)
-let holdUntil = 0
-let lastTs = 0
-
-watch(() => props.peakDb, (peak) => {
-  // A non-finite peak means the graph is not running — no real recording
-  // reaches digital silence. Clear rather than decay, so a torn-down meter
-  // cannot strand a hold line at whatever it last saw.
-  if (!Number.isFinite(peak)) {
-    heldPeakDb.value = -Infinity
-    clipped.value = false
-    lastTs = 0
-    return
-  }
-
-  const now = performance.now()
-  const elapsedS = lastTs ? (now - lastTs) / 1000 : 0
-  lastTs = now
-
-  if (peak >= props.clipDb) clipped.value = true
-
-  if (peak >= heldPeakDb.value || !Number.isFinite(heldPeakDb.value)) {
-    heldPeakDb.value = peak
-    holdUntil = now + HOLD_MS
-  } else if (now >= holdUntil) {
-    heldPeakDb.value = Math.max(peak, heldPeakDb.value - DECAY_DB_PER_S * elapsedS)
-  }
-// Immediate, so a peak that is already set at mount — or one that arrives and
-// then holds perfectly steady — still registers. A plain watcher only sees
-// changes, which would leave the readout at -∞ and the over lamp dark.
-}, { immediate: true })
-
 const heldPeakPct = computed(() =>
   Number.isFinite(heldPeakDb.value) ? dbToPct(heldPeakDb.value) : 0)
 
 const readout = computed(() =>
   Number.isFinite(heldPeakDb.value) ? heldPeakDb.value.toFixed(1) : '-∞')
+
+// The lamp belongs to the bars, not to the whole component — the scale gutter
+// and the caption are both wider, and stretching to them left it floating
+// unaligned above the thing it reports on.
+const barBlockWidth = computed(() =>
+  props.channels * BAR_WIDTH + (props.channels - 1) * BAR_GAP)
+
+const visibleTicks = computed(() => TICKS.filter(t => t > props.floorDb))
 
 const ariaText = computed(() =>
   Number.isFinite(props.db) ? `${props.db.toFixed(1)} dBFS` : 'silent')
@@ -114,30 +183,35 @@ const ariaText = computed(() =>
 
 <template>
   <div class="flex flex-col items-center gap-[7px]">
-    <!-- Over indicator. Latches, and clears on click the way a console does. -->
-    <button
-      v-if="showReadout"
-      type="button"
-      class="rounded-[2px] cursor-pointer"
-      :style="{
-        width: '100%',
-        minWidth: '30px',
-        height: '7px',
+    <!-- Over lamp. Latches, and clears on click the way a console does: the
+         readout decays within a second or two, so without the latch a peak
+         that overshot ten seconds ago leaves no trace. -->
+    <div
+      v-if="showOver"
+      :style="{ width: barBlockWidth + 'px' }"
+      :class="clipped ? 'cursor-pointer' : ''"
+      :role="clipped ? 'button' : 'status'"
+      :tabindex="clipped ? 0 : -1"
+      :title="clipped ? 'Peak reached 0 dBFS — click to reset' : 'No overs'"
+      :aria-label="clipped ? 'Over, click to reset' : 'No overs'"
+      @click="clipped = false"
+      @keydown.enter.space.prevent="clipped = false"
+    >
+      <div :style="{
+        height: '5px',
+        borderRadius: '2px',
         border: '1px solid rgba(255,255,255,.07)',
         background: clipped ? '#e35d4f' : 'rgba(255,255,255,.04)',
         boxShadow: clipped ? '0 0 8px rgba(227,93,79,.7)' : 'none',
-      }"
-      :aria-label="clipped ? 'Over — click to reset' : 'No overs'"
-      :aria-pressed="clipped"
-      @click="clipped = false"
-    ></button>
+      }"></div>
+    </div>
 
-    <div class="flex items-end gap-[5px]">
-      <div class="flex gap-[3px]">
+    <div class="flex items-end" :style="{ gap: showScale ? '5px' : '0' }">
+      <div class="flex" :style="{ gap: BAR_GAP + 'px' }">
         <div
           v-for="ch in channels" :key="ch"
-          class="relative w-[9px] rounded-[3px]"
-          :style="{ height: height + 'px' }"
+          class="relative rounded-[3px]"
+          :style="{ width: BAR_WIDTH + 'px', height: height + 'px' }"
           style="background:#07090c;box-shadow:inset 0 0 0 1px rgba(255,255,255,.05)"
           role="meter"
           :aria-valuemin="floorDb"
@@ -146,9 +220,8 @@ const ariaText = computed(() =>
           :aria-valuetext="ariaText"
           :aria-label="label ? `${label} level` : 'Level'"
         >
-          <!-- No CSS transition: the source already updates every frame, and a
-               transition that restarts each frame never lands on its target.
-               Designed ballistics are a separate job from drawing the bar. -->
+          <!-- No CSS transition: ballistics are applied above, and a
+               transition restarting every frame never reaches its target. -->
           <div class="absolute bottom-0 left-0 right-0 rounded-[3px]" :style="fillStyle"></div>
 
           <!-- Segment ruling, purely cosmetic — the scale is the ticks. -->
@@ -167,10 +240,10 @@ const ariaText = computed(() =>
       </div>
 
       <!-- Scale. Ticks sit at their true positions; the gutter is sized for
-           the widest numeral so the columns do not shift between panels. -->
-      <div v-if="showScale" class="relative" :style="{ height: height + 'px', width: '17px' }">
+           the widest numeral so the bars do not shift between panels. -->
+      <div v-if="showScale" class="relative" :style="{ height: height + 'px', width: '18px' }">
         <div
-          v-for="tick in TICKS.filter(t => t > floorDb)" :key="tick"
+          v-for="tick in visibleTicks" :key="tick"
           class="absolute left-0 flex items-center gap-[4px]"
           :style="{ bottom: `calc(${dbToPct(tick)}% - 3px)`, height: '6px' }"
         >

--- a/src/components/meters/LevelMeter.vue
+++ b/src/components/meters/LevelMeter.vue
@@ -1,40 +1,200 @@
 <script setup>
-import { computed } from 'vue'
+import { computed, ref, watch } from 'vue'
 
 /**
- * Vertical segmented level meter — a column per channel plus a caption.
- * Shared by the plugin panels for their IN and OUT readouts.
+ * Vertical segmented level meter — a column per channel, a peak-hold line,
+ * an over indicator and a labelled scale. Shared by the plugin panels for
+ * their IN and OUT readouts.
+ *
+ * The bar is RMS and the readout is peak, which is the split that makes a
+ * meter this size useful: the bar shows how loud the passage sits, the
+ * number and the hold line show how close the transients are to the ceiling.
  */
 const props = defineProps({
+  // RMS level in dBFS, the bar reading.
   db: { type: Number, required: true },
+  // Sample peak in dBFS. Drives the hold line, the readout and the over
+  // indicator. Callers without a peak source can omit it and get the old
+  // bar-only meter.
+  peakDb: { type: Number, default: -Infinity },
   label: { type: String, default: '' },
   channels: { type: Number, default: 2 },
   height: { type: Number, default: 150 },
   // Bottom of the scale. The top is always 0 dBFS.
   floorDb: { type: Number, default: -60 },
+  // Peak at or above this latches the over indicator. 0 dBFS is the point a
+  // float sample can no longer survive the trip to an integer file.
+  clipDb: { type: Number, default: 0 },
+  showScale: { type: Boolean, default: true },
+  showReadout: { type: Boolean, default: true },
 })
 
-const fillPct = computed(() => {
-  if (!Number.isFinite(props.db)) return 0
+// Marks worth engraving, in dBFS. Only some carry a numeral — the rest are
+// bare ticks, so the scale stays readable on the shortest panel that uses it.
+const TICKS = [-6, -12, -18, -24, -36, -48]
+const LABELLED = new Set([-6, -18, -36])
+
+// Zone edges in dBFS. Round numbers that land on ticks, so the colour change
+// and the engraving agree.
+const AMBER_DB = -18
+const RED_DB = -6
+
+// Peak-hold ballistics: dwell, then fall at a constant rate.
+const HOLD_MS = 1200
+const DECAY_DB_PER_S = 20
+
+/** Position of a dB value on the scale, 0-100 from the floor up. */
+function dbToPct(db) {
   const span = -props.floorDb
-  return Math.max(0, Math.min(100, ((props.db - props.floorDb) / span) * 100))
-})
+  return Math.max(0, Math.min(100, ((db - props.floorDb) / span) * 100))
+}
+
+const fillPct = computed(() => (Number.isFinite(props.db) ? dbToPct(props.db) : 0))
+
+/**
+ * The gradient is sized to the full track and pinned to its bottom edge, so
+ * the zones stay at fixed dB positions. Left to resolve against the fill —
+ * which is what a plain `background` on a percentage-height element does —
+ * they would scale with the reading, and every level would render with a red
+ * tip.
+ */
+const fillStyle = computed(() => ({
+  height: fillPct.value + '%',
+  backgroundImage: `linear-gradient(to top,
+    #2ec96b 0 ${dbToPct(AMBER_DB)}%,
+    #e9c63b ${dbToPct(AMBER_DB)}% ${dbToPct(RED_DB)}%,
+    #e35d4f ${dbToPct(RED_DB)}%)`,
+  backgroundSize: `100% ${props.height}px`,
+  backgroundPosition: 'left bottom',
+  backgroundRepeat: 'no-repeat',
+}))
+
+const heldPeakDb = ref(-Infinity)
+const clipped = ref(false)
+let holdUntil = 0
+let lastTs = 0
+
+watch(() => props.peakDb, (peak) => {
+  // A non-finite peak means the graph is not running — no real recording
+  // reaches digital silence. Clear rather than decay, so a torn-down meter
+  // cannot strand a hold line at whatever it last saw.
+  if (!Number.isFinite(peak)) {
+    heldPeakDb.value = -Infinity
+    clipped.value = false
+    lastTs = 0
+    return
+  }
+
+  const now = performance.now()
+  const elapsedS = lastTs ? (now - lastTs) / 1000 : 0
+  lastTs = now
+
+  if (peak >= props.clipDb) clipped.value = true
+
+  if (peak >= heldPeakDb.value || !Number.isFinite(heldPeakDb.value)) {
+    heldPeakDb.value = peak
+    holdUntil = now + HOLD_MS
+  } else if (now >= holdUntil) {
+    heldPeakDb.value = Math.max(peak, heldPeakDb.value - DECAY_DB_PER_S * elapsedS)
+  }
+// Immediate, so a peak that is already set at mount — or one that arrives and
+// then holds perfectly steady — still registers. A plain watcher only sees
+// changes, which would leave the readout at -∞ and the over lamp dark.
+}, { immediate: true })
+
+const heldPeakPct = computed(() =>
+  Number.isFinite(heldPeakDb.value) ? dbToPct(heldPeakDb.value) : 0)
+
+const readout = computed(() =>
+  Number.isFinite(heldPeakDb.value) ? heldPeakDb.value.toFixed(1) : '-∞')
+
+const ariaText = computed(() =>
+  Number.isFinite(props.db) ? `${props.db.toFixed(1)} dBFS` : 'silent')
 </script>
 
 <template>
-  <div class="flex flex-col items-center gap-[9px]">
-    <div class="flex gap-[3px]">
-      <div
-        v-for="ch in channels" :key="ch"
-        class="relative w-[9px] rounded-[3px]"
-        :style="{ height: height + 'px' }"
-        style="background:#07090c;box-shadow:inset 0 0 0 1px rgba(255,255,255,.05)"
-      >
-        <div class="absolute bottom-0 left-0 right-0 rounded-[3px] transition-all duration-100"
-             :style="{ height: fillPct + '%', background: 'linear-gradient(to top,#2ec96b 0 62%,#e9c63b 62% 84%,#e35d4f 84%)' }"></div>
-        <div class="absolute inset-0" style="background:repeating-linear-gradient(to top,#0000 0 4px,#07090c 4px 6px)"></div>
+  <div class="flex flex-col items-center gap-[7px]">
+    <!-- Over indicator. Latches, and clears on click the way a console does. -->
+    <button
+      v-if="showReadout"
+      type="button"
+      class="rounded-[2px] cursor-pointer"
+      :style="{
+        width: '100%',
+        minWidth: '30px',
+        height: '7px',
+        border: '1px solid rgba(255,255,255,.07)',
+        background: clipped ? '#e35d4f' : 'rgba(255,255,255,.04)',
+        boxShadow: clipped ? '0 0 8px rgba(227,93,79,.7)' : 'none',
+      }"
+      :aria-label="clipped ? 'Over — click to reset' : 'No overs'"
+      :aria-pressed="clipped"
+      @click="clipped = false"
+    ></button>
+
+    <div class="flex items-end gap-[5px]">
+      <div class="flex gap-[3px]">
+        <div
+          v-for="ch in channels" :key="ch"
+          class="relative w-[9px] rounded-[3px]"
+          :style="{ height: height + 'px' }"
+          style="background:#07090c;box-shadow:inset 0 0 0 1px rgba(255,255,255,.05)"
+          role="meter"
+          :aria-valuemin="floorDb"
+          :aria-valuemax="0"
+          :aria-valuenow="Number.isFinite(db) ? Number(db.toFixed(1)) : floorDb"
+          :aria-valuetext="ariaText"
+          :aria-label="label ? `${label} level` : 'Level'"
+        >
+          <!-- No CSS transition: the source already updates every frame, and a
+               transition that restarts each frame never lands on its target.
+               Designed ballistics are a separate job from drawing the bar. -->
+          <div class="absolute bottom-0 left-0 right-0 rounded-[3px]" :style="fillStyle"></div>
+
+          <!-- Segment ruling, purely cosmetic — the scale is the ticks. -->
+          <div class="absolute inset-0" style="background:repeating-linear-gradient(to top,#0000 0 4px,#07090c 4px 6px)"></div>
+
+          <div
+            v-if="Number.isFinite(heldPeakDb)"
+            class="absolute left-0 right-0"
+            :style="{
+              bottom: `calc(${heldPeakPct}% - 1px)`,
+              height: '2px',
+              background: heldPeakDb >= RED_DB ? '#ff8a7a' : 'rgba(255,255,255,.85)',
+            }"
+          ></div>
+        </div>
+      </div>
+
+      <!-- Scale. Ticks sit at their true positions; the gutter is sized for
+           the widest numeral so the columns do not shift between panels. -->
+      <div v-if="showScale" class="relative" :style="{ height: height + 'px', width: '17px' }">
+        <div
+          v-for="tick in TICKS.filter(t => t > floorDb)" :key="tick"
+          class="absolute left-0 flex items-center gap-[4px]"
+          :style="{ bottom: `calc(${dbToPct(tick)}% - 3px)`, height: '6px' }"
+        >
+          <span :style="{
+            width: LABELLED.has(tick) ? '4px' : '2.5px',
+            height: '1px',
+            background: 'rgba(255,255,255,.22)',
+          }"></span>
+          <span
+            v-if="LABELLED.has(tick)"
+            style="font:600 7px 'JetBrains Mono',monospace;color:rgba(255,255,255,.3);line-height:1"
+          >{{ tick }}</span>
+        </div>
       </div>
     </div>
+
+    <span
+      v-if="showReadout"
+      :style="{
+        font: `700 9.5px 'JetBrains Mono',monospace`,
+        color: clipped ? '#ff9d90' : 'rgba(255,255,255,.62)',
+      }"
+    >{{ readout }}</span>
+
     <span v-if="label" style="font:700 9px 'JetBrains Mono',monospace;letter-spacing:.16em;color:rgba(255,255,255,.45)">{{ label }}</span>
   </div>
 </template>

--- a/src/components/panels/AirBandModal.vue
+++ b/src/components/panels/AirBandModal.vue
@@ -12,7 +12,7 @@ import ApplyAction from '../ui/ApplyAction.vue'
 defineProps({ z: { type: Number, default: 500 } })
 
 const {
-  airBandAir, airBandOutput, airBandPreview, airBandInputDb, airBandOutputDb, airBandInputPeakDb, airBandOutputPeakDb,
+  airBandAir, airBandOutput, airBandPreview, airBandInputLevels, airBandOutputLevels,
   hasSelection, togglePreview, syncAir, syncOutput, apply, teardown, closeModal,
 } = useAirBand()
 
@@ -126,7 +126,7 @@ async function applyAndClose() {
   >
     <div class="px-[26px] pt-[22px] pb-[26px]">
       <div class="flex items-center justify-between gap-[22px]">
-        <LevelMeter :db="airBandInputDb" :peak-db="airBandInputPeakDb" label="IN" :height="120" />
+        <LevelMeter :levels="airBandInputLevels" label="IN" :height="120" />
 
         <div class="flex-1 flex flex-col items-center">
           <!-- Response curve -->
@@ -185,7 +185,7 @@ async function applyAndClose() {
           </div>
         </div>
 
-        <LevelMeter :db="airBandOutputDb" :peak-db="airBandOutputPeakDb" label="OUT" :height="120" />
+        <LevelMeter :levels="airBandOutputLevels" label="OUT" :height="120" />
       </div>
 
       <p

--- a/src/components/panels/AirBandModal.vue
+++ b/src/components/panels/AirBandModal.vue
@@ -12,7 +12,7 @@ import ApplyAction from '../ui/ApplyAction.vue'
 defineProps({ z: { type: Number, default: 500 } })
 
 const {
-  airBandAir, airBandOutput, airBandPreview, airBandInputDb, airBandOutputDb,
+  airBandAir, airBandOutput, airBandPreview, airBandInputDb, airBandOutputDb, airBandInputPeakDb, airBandOutputPeakDb,
   hasSelection, togglePreview, syncAir, syncOutput, apply, teardown, closeModal,
 } = useAirBand()
 
@@ -126,7 +126,7 @@ async function applyAndClose() {
   >
     <div class="px-[26px] pt-[22px] pb-[26px]">
       <div class="flex items-center justify-between gap-[22px]">
-        <LevelMeter :db="airBandInputDb" label="IN" :height="120" />
+        <LevelMeter :db="airBandInputDb" :peak-db="airBandInputPeakDb" label="IN" :height="120" />
 
         <div class="flex-1 flex flex-col items-center">
           <!-- Response curve -->
@@ -185,7 +185,7 @@ async function applyAndClose() {
           </div>
         </div>
 
-        <LevelMeter :db="airBandOutputDb" label="OUT" :height="120" />
+        <LevelMeter :db="airBandOutputDb" :peak-db="airBandOutputPeakDb" label="OUT" :height="120" />
       </div>
 
       <p

--- a/src/components/panels/DeEsserModal.vue
+++ b/src/components/panels/DeEsserModal.vue
@@ -22,7 +22,7 @@ defineProps({ z: { type: Number, default: 500 } })
 
 const {
   params, preview, analysis, analyzing, measuredEvents,
-  treatedCount, maxReductionDb, reductionDb, inputDb, outputDb,
+  treatedCount, maxReductionDb, reductionDb, inputDb, outputDb, inputPeakDb, outputPeakDb,
   tuning, syncTuning, resetTuning,
   hasAnalysis, hasSelection, isStale, envelopeValid, analyzedRegion,
   togglePreview, syncParam, analyze, apply, teardown, closeModal,
@@ -147,7 +147,7 @@ async function applyAndClose() {
       />
 
       <div class="flex items-start justify-between gap-[20px] mt-[20px]">
-        <LevelMeter :db="inputDb" label="IN" :height="164" />
+        <LevelMeter :db="inputDb" :peak-db="inputPeakDb" label="IN" :height="164" />
 
         <div class="flex-1">
           <!-- Analyse: the frozen half -->
@@ -230,7 +230,7 @@ async function applyAndClose() {
           >{{ statusLine }}</p>
         </div>
 
-        <LevelMeter :db="outputDb" label="OUT" :height="164" />
+        <LevelMeter :db="outputDb" :peak-db="outputPeakDb" label="OUT" :height="164" />
       </div>
 
       <!-- Fade shaping -->

--- a/src/components/panels/DeEsserModal.vue
+++ b/src/components/panels/DeEsserModal.vue
@@ -22,7 +22,7 @@ defineProps({ z: { type: Number, default: 500 } })
 
 const {
   params, preview, analysis, analyzing, measuredEvents,
-  treatedCount, maxReductionDb, reductionDb, inputDb, outputDb, inputPeakDb, outputPeakDb,
+  treatedCount, maxReductionDb, reductionDb, inputLevels, outputLevels,
   tuning, syncTuning, resetTuning,
   hasAnalysis, hasSelection, isStale, envelopeValid, analyzedRegion,
   togglePreview, syncParam, analyze, apply, teardown, closeModal,
@@ -147,7 +147,7 @@ async function applyAndClose() {
       />
 
       <div class="flex items-start justify-between gap-[20px] mt-[20px]">
-        <LevelMeter :db="inputDb" :peak-db="inputPeakDb" label="IN" :height="164" />
+        <LevelMeter :levels="inputLevels" label="IN" :height="164" />
 
         <div class="flex-1">
           <!-- Analyse: the frozen half -->
@@ -230,7 +230,7 @@ async function applyAndClose() {
           >{{ statusLine }}</p>
         </div>
 
-        <LevelMeter :db="outputDb" :peak-db="outputPeakDb" label="OUT" :height="164" />
+        <LevelMeter :levels="outputLevels" label="OUT" :height="164" />
       </div>
 
       <!-- Fade shaping -->

--- a/src/components/panels/EqModal.vue
+++ b/src/components/panels/EqModal.vue
@@ -100,7 +100,7 @@ async function applyAndClose() {
       </div>
 
       <div class="flex gap-[16px]">
-        <LevelMeter :db="eq.inputDb.value" label="IN" :height="PLOT_HEIGHT" />
+        <LevelMeter :db="eq.inputDb.value" :peak-db="eq.inputPeakDb.value" label="IN" :height="PLOT_HEIGHT" />
 
         <div class="flex-1 min-w-0">
           <GeneralView
@@ -109,7 +109,7 @@ async function applyAndClose() {
           />
         </div>
 
-        <LevelMeter :db="eq.outputDb.value" label="OUT" :height="PLOT_HEIGHT" />
+        <LevelMeter :db="eq.outputDb.value" :peak-db="eq.outputPeakDb.value" label="OUT" :height="PLOT_HEIGHT" />
       </div>
 
       <div class="mt-[16px] pt-[14px]" style="border-top:1px solid rgba(255,255,255,.06)">

--- a/src/components/panels/EqModal.vue
+++ b/src/components/panels/EqModal.vue
@@ -100,7 +100,7 @@ async function applyAndClose() {
       </div>
 
       <div class="flex gap-[16px]">
-        <LevelMeter :db="eq.inputDb.value" :peak-db="eq.inputPeakDb.value" label="IN" :height="PLOT_HEIGHT" />
+        <LevelMeter :levels="eq.inputLevels.value" label="IN" :height="PLOT_HEIGHT" />
 
         <div class="flex-1 min-w-0">
           <GeneralView
@@ -109,7 +109,7 @@ async function applyAndClose() {
           />
         </div>
 
-        <LevelMeter :db="eq.outputDb.value" :peak-db="eq.outputPeakDb.value" label="OUT" :height="PLOT_HEIGHT" />
+        <LevelMeter :levels="eq.outputLevels.value" label="OUT" :height="PLOT_HEIGHT" />
       </div>
 
       <div class="mt-[16px] pt-[14px]" style="border-top:1px solid rgba(255,255,255,.06)">

--- a/src/components/panels/FET1176Modal.vue
+++ b/src/components/panels/FET1176Modal.vue
@@ -14,7 +14,7 @@ defineProps({ z: { type: Number, default: 500 } })
 
 const {
   fetInput, fetOutput, fetAttack, fetRelease, fetRatio, fetDrive, fetScHpf, fetMix,
-  fetAutoMakeup, fetPreview, fetReduction, fetInputDb, fetOutputDb, hasSelection,
+  fetAutoMakeup, fetPreview, fetReduction, fetInputDb, fetOutputDb, fetInputPeakDb, fetOutputPeakDb, hasSelection,
   togglePreview, syncInput, syncOutput, syncAttack, syncRelease, syncRatio,
   syncDrive, syncScHpf, syncMix, toggleAutoMakeup, refreshAutoMakeup,
   apply, teardown, closeModal,
@@ -151,7 +151,7 @@ const releaseTime = computed(() => formatMs(releaseSecondsForDial(fetRelease.val
         </div>
 
         <div class="flex-1 flex items-center justify-between gap-[14px]">
-          <LevelMeter :db="fetInputDb" label="IN" :height="132" />
+          <LevelMeter :db="fetInputDb" :peak-db="fetInputPeakDb" label="IN" :height="132" />
 
           <div class="flex-1 flex justify-center gap-[26px]">
             <div class="w-[118px]">
@@ -212,7 +212,7 @@ const releaseTime = computed(() => formatMs(releaseSecondsForDial(fetRelease.val
             </div>
           </div>
 
-          <LevelMeter :db="fetOutputDb" label="OUT" :height="132" />
+          <LevelMeter :db="fetOutputDb" :peak-db="fetOutputPeakDb" label="OUT" :height="132" />
         </div>
       </div>
 

--- a/src/components/panels/FET1176Modal.vue
+++ b/src/components/panels/FET1176Modal.vue
@@ -14,13 +14,26 @@ defineProps({ z: { type: Number, default: 500 } })
 
 const {
   fetInput, fetOutput, fetAttack, fetRelease, fetRatio, fetDrive, fetScHpf, fetMix,
-  fetAutoMakeup, fetPreview, fetReduction, fetInputDb, fetOutputDb, fetInputPeakDb, fetOutputPeakDb, hasSelection,
+  fetAutoMakeup, fetPreview, fetReduction, fetInputLevels, fetOutputLevels, hasSelection,
   togglePreview, syncInput, syncOutput, syncAttack, syncRelease, syncRatio,
   syncDrive, syncScHpf, syncMix, toggleAutoMakeup, refreshAutoMakeup,
   apply, teardown, closeModal,
 } = useFET1176()
 
 const { state } = useEditorState()
+
+/**
+ * One needle over a stereo pair follows the louder channel, matching what the
+ * level meters' single readout reports. RMS rather than peak — the movement
+ * is a VU, and it is scaled for an averaged level.
+ */
+const fetOutputVuDb = computed(() => {
+  let loudest = -Infinity
+  for (const channel of fetOutputLevels.value) {
+    if (channel.rmsDb > loudest) loudest = channel.rmsDb
+  }
+  return loudest
+})
 
 // Default to engaged when the panel opens
 onMounted(() => {
@@ -138,7 +151,7 @@ const releaseTime = computed(() => formatMs(releaseSecondsForDial(fetRelease.val
             class="w-full"
             :mode="meterMode === 'gr' ? 'gr' : 'vu'"
             :reduction-db="Math.abs(fetReduction)"
-            :level-db="fetOutputDb"
+            :level-db="fetOutputVuDb"
             :reference-dbfs="vuReference"
             :accent="ACCENT"
           />
@@ -151,7 +164,7 @@ const releaseTime = computed(() => formatMs(releaseSecondsForDial(fetRelease.val
         </div>
 
         <div class="flex-1 flex items-center justify-between gap-[14px]">
-          <LevelMeter :db="fetInputDb" :peak-db="fetInputPeakDb" label="IN" :height="132" />
+          <LevelMeter :levels="fetInputLevels" label="IN" :height="132" />
 
           <div class="flex-1 flex justify-center gap-[26px]">
             <div class="w-[118px]">
@@ -212,7 +225,7 @@ const releaseTime = computed(() => formatMs(releaseSecondsForDial(fetRelease.val
             </div>
           </div>
 
-          <LevelMeter :db="fetOutputDb" :peak-db="fetOutputPeakDb" label="OUT" :height="132" />
+          <LevelMeter :levels="fetOutputLevels" label="OUT" :height="132" />
         </div>
       </div>
 

--- a/src/components/panels/HumRemoverModal.vue
+++ b/src/components/panels/HumRemoverModal.vue
@@ -12,7 +12,7 @@ defineProps({ z: { type: Number, default: 500 } })
 
 const {
   humFundamental, humQ, humDepth, humHarmonics, humAnalysis, humAnalyzing,
-  humPreview, humInputDb, humOutputDb, isStale, hasEnabledNotches, hasSelection,
+  humPreview, humInputDb, humOutputDb, humInputPeakDb, humOutputPeakDb, isStale, hasEnabledNotches, hasSelection,
   togglePreview, analyze, toggleHarmonic, setFundamental, syncQ, syncDepth,
   apply, teardown, closeModal,
 } = useHumRemover()
@@ -145,7 +145,7 @@ async function applyAndClose() {
   >
     <div class="px-[26px] pt-[22px] pb-[24px]">
       <div class="flex items-start justify-between gap-[20px]">
-        <LevelMeter :db="humInputDb" label="IN" :height="176" />
+        <LevelMeter :db="humInputDb" :peak-db="humInputPeakDb" label="IN" :height="176" />
 
         <div class="flex-1">
           <!-- Mains frequency + analyse -->
@@ -259,7 +259,7 @@ async function applyAndClose() {
           >{{ statusLine }}</p>
         </div>
 
-        <LevelMeter :db="humOutputDb" label="OUT" :height="176" />
+        <LevelMeter :db="humOutputDb" :peak-db="humOutputPeakDb" label="OUT" :height="176" />
       </div>
 
       <!-- Notch shape -->

--- a/src/components/panels/HumRemoverModal.vue
+++ b/src/components/panels/HumRemoverModal.vue
@@ -12,7 +12,7 @@ defineProps({ z: { type: Number, default: 500 } })
 
 const {
   humFundamental, humQ, humDepth, humHarmonics, humAnalysis, humAnalyzing,
-  humPreview, humInputDb, humOutputDb, humInputPeakDb, humOutputPeakDb, isStale, hasEnabledNotches, hasSelection,
+  humPreview, humInputLevels, humOutputLevels, isStale, hasEnabledNotches, hasSelection,
   togglePreview, analyze, toggleHarmonic, setFundamental, syncQ, syncDepth,
   apply, teardown, closeModal,
 } = useHumRemover()
@@ -145,7 +145,7 @@ async function applyAndClose() {
   >
     <div class="px-[26px] pt-[22px] pb-[24px]">
       <div class="flex items-start justify-between gap-[20px]">
-        <LevelMeter :db="humInputDb" :peak-db="humInputPeakDb" label="IN" :height="176" />
+        <LevelMeter :levels="humInputLevels" label="IN" :height="176" />
 
         <div class="flex-1">
           <!-- Mains frequency + analyse -->
@@ -259,7 +259,7 @@ async function applyAndClose() {
           >{{ statusLine }}</p>
         </div>
 
-        <LevelMeter :db="humOutputDb" :peak-db="humOutputPeakDb" label="OUT" :height="176" />
+        <LevelMeter :levels="humOutputLevels" label="OUT" :height="176" />
       </div>
 
       <!-- Notch shape -->

--- a/src/components/panels/LA2AModal.vue
+++ b/src/components/panels/LA2AModal.vue
@@ -14,7 +14,7 @@ defineProps({ z: { type: Number, default: 500 } })
 const {
   la2aMode, la2aPeakReduction, la2aGain, la2aTubeDrive, la2aEmphasis,
   la2aAutoMakeup, la2aAutoMakeupBusy,
-  la2aPreview, la2aReduction, la2aInputDb, la2aOutputDb, la2aInputPeakDb, la2aOutputPeakDb, hasSelection,
+  la2aPreview, la2aReduction, la2aInputLevels, la2aOutputLevels, hasSelection,
   togglePreview, syncMode, syncPeakReduction, syncGain, syncTubeDrive,
   syncEmphasis, toggleAutoMakeup, refreshAutoMakeup, apply, teardown, closeModal,
 } = useLA2A()
@@ -131,7 +131,7 @@ function selectMockPreset(name) {
 
       <!-- IN meter · knobs · OUT meter -->
       <div class="flex items-center justify-between gap-[22px] mt-[24px]">
-        <LevelMeter :db="la2aInputDb" :peak-db="la2aInputPeakDb" label="IN" />
+        <LevelMeter :levels="la2aInputLevels" label="IN" />
 
         <div class="flex-1 flex justify-center gap-[40px]">
           <div class="w-[130px]">
@@ -182,7 +182,7 @@ function selectMockPreset(name) {
           </div>
         </div>
 
-        <LevelMeter :db="la2aOutputDb" :peak-db="la2aOutputPeakDb" label="OUT" />
+        <LevelMeter :levels="la2aOutputLevels" label="OUT" />
       </div>
 
       <!-- Secondary row: Comp/Limit mode + small knobs (tube drive, R37 emphasis) -->

--- a/src/components/panels/LA2AModal.vue
+++ b/src/components/panels/LA2AModal.vue
@@ -14,7 +14,7 @@ defineProps({ z: { type: Number, default: 500 } })
 const {
   la2aMode, la2aPeakReduction, la2aGain, la2aTubeDrive, la2aEmphasis,
   la2aAutoMakeup, la2aAutoMakeupBusy,
-  la2aPreview, la2aReduction, la2aInputDb, la2aOutputDb, hasSelection,
+  la2aPreview, la2aReduction, la2aInputDb, la2aOutputDb, la2aInputPeakDb, la2aOutputPeakDb, hasSelection,
   togglePreview, syncMode, syncPeakReduction, syncGain, syncTubeDrive,
   syncEmphasis, toggleAutoMakeup, refreshAutoMakeup, apply, teardown, closeModal,
 } = useLA2A()
@@ -131,7 +131,7 @@ function selectMockPreset(name) {
 
       <!-- IN meter · knobs · OUT meter -->
       <div class="flex items-center justify-between gap-[22px] mt-[24px]">
-        <LevelMeter :db="la2aInputDb" label="IN" />
+        <LevelMeter :db="la2aInputDb" :peak-db="la2aInputPeakDb" label="IN" />
 
         <div class="flex-1 flex justify-center gap-[40px]">
           <div class="w-[130px]">
@@ -182,7 +182,7 @@ function selectMockPreset(name) {
           </div>
         </div>
 
-        <LevelMeter :db="la2aOutputDb" label="OUT" />
+        <LevelMeter :db="la2aOutputDb" :peak-db="la2aOutputPeakDb" label="OUT" />
       </div>
 
       <!-- Secondary row: Comp/Limit mode + small knobs (tube drive, R37 emphasis) -->

--- a/src/components/panels/ResonanceModal.vue
+++ b/src/components/panels/ResonanceModal.vue
@@ -16,7 +16,7 @@ defineProps({ z: { type: Number, default: 500 } })
 const {
   resDepth, resSharpness, resSelectivity, resAttack, resRelease,
   resMaxReduction, resFreqFloor, resFreqCeil, resMode, resPreserveHarmonics,
-  resPitchRange, resPreview, resReduction, resInputDb, resOutputDb, hasSelection,
+  resPitchRange, resPreview, resReduction, resInputDb, resOutputDb, resInputPeakDb, resOutputPeakDb, hasSelection,
   togglePreview, syncDepth, syncSharpness, syncSelectivity, syncAttack,
   syncRelease, syncMaxReduction, syncFreqFloor, syncFreqCeil, syncMode,
   syncPitchRange, togglePreserveHarmonics, apply, teardown, closeModal,
@@ -92,7 +92,7 @@ async function applyAndClose() {
       <GainReductionBar :reduction-db="resReduction" :accent="ACCENT" />
 
       <div class="flex items-center justify-between gap-[22px] mt-[22px]">
-        <LevelMeter :db="resInputDb" label="IN" :height="150" />
+        <LevelMeter :db="resInputDb" :peak-db="resInputPeakDb" label="IN" :height="150" />
 
         <div class="flex-1 flex justify-center gap-[34px]">
           <div class="w-[124px]">
@@ -121,7 +121,7 @@ async function applyAndClose() {
           </div>
         </div>
 
-        <LevelMeter :db="resOutputDb" label="OUT" :height="150" />
+        <LevelMeter :db="resOutputDb" :peak-db="resOutputPeakDb" label="OUT" :height="150" />
       </div>
 
       <!-- Timing + ceiling -->

--- a/src/components/panels/ResonanceModal.vue
+++ b/src/components/panels/ResonanceModal.vue
@@ -16,7 +16,7 @@ defineProps({ z: { type: Number, default: 500 } })
 const {
   resDepth, resSharpness, resSelectivity, resAttack, resRelease,
   resMaxReduction, resFreqFloor, resFreqCeil, resMode, resPreserveHarmonics,
-  resPitchRange, resPreview, resReduction, resInputDb, resOutputDb, resInputPeakDb, resOutputPeakDb, hasSelection,
+  resPitchRange, resPreview, resReduction, resInputLevels, resOutputLevels, hasSelection,
   togglePreview, syncDepth, syncSharpness, syncSelectivity, syncAttack,
   syncRelease, syncMaxReduction, syncFreqFloor, syncFreqCeil, syncMode,
   syncPitchRange, togglePreserveHarmonics, apply, teardown, closeModal,
@@ -92,7 +92,7 @@ async function applyAndClose() {
       <GainReductionBar :reduction-db="resReduction" :accent="ACCENT" />
 
       <div class="flex items-center justify-between gap-[22px] mt-[22px]">
-        <LevelMeter :db="resInputDb" :peak-db="resInputPeakDb" label="IN" :height="150" />
+        <LevelMeter :levels="resInputLevels" label="IN" :height="150" />
 
         <div class="flex-1 flex justify-center gap-[34px]">
           <div class="w-[124px]">
@@ -121,7 +121,7 @@ async function applyAndClose() {
           </div>
         </div>
 
-        <LevelMeter :db="resOutputDb" :peak-db="resOutputPeakDb" label="OUT" :height="150" />
+        <LevelMeter :levels="resOutputLevels" label="OUT" :height="150" />
       </div>
 
       <!-- Timing + ceiling -->

--- a/src/components/panels/VoiceRxModal.vue
+++ b/src/components/panels/VoiceRxModal.vue
@@ -275,7 +275,7 @@ async function applyAndClose() {
       </p>
 
       <div class="flex gap-[16px]">
-        <LevelMeter :db="vox.inputDb.value" label="IN" :height="200" />
+        <LevelMeter :db="vox.inputDb.value" :peak-db="vox.inputPeakDb.value" label="IN" :height="200" />
 
         <div class="flex-1 min-w-0">
           <VoiceRxView
@@ -287,7 +287,7 @@ async function applyAndClose() {
           />
         </div>
 
-        <LevelMeter :db="vox.outputDb.value" label="OUT" :height="200" />
+        <LevelMeter :db="vox.outputDb.value" :peak-db="vox.outputPeakDb.value" label="OUT" :height="200" />
       </div>
 
       <div class="flex items-center justify-end mt-[14px] gap-[14px]">

--- a/src/components/panels/VoiceRxModal.vue
+++ b/src/components/panels/VoiceRxModal.vue
@@ -275,7 +275,7 @@ async function applyAndClose() {
       </p>
 
       <div class="flex gap-[16px]">
-        <LevelMeter :db="vox.inputDb.value" :peak-db="vox.inputPeakDb.value" label="IN" :height="200" />
+        <LevelMeter :levels="vox.inputLevels.value" label="IN" :height="200" />
 
         <div class="flex-1 min-w-0">
           <VoiceRxView
@@ -287,7 +287,7 @@ async function applyAndClose() {
           />
         </div>
 
-        <LevelMeter :db="vox.outputDb.value" :peak-db="vox.outputPeakDb.value" label="OUT" :height="200" />
+        <LevelMeter :levels="vox.outputLevels.value" label="OUT" :height="200" />
       </div>
 
       <div class="flex items-center justify-end mt-[14px] gap-[14px]">

--- a/src/components/panels/windows/VocalSaturationWindow.vue
+++ b/src/components/panels/windows/VocalSaturationWindow.vue
@@ -14,7 +14,7 @@ const {
   vsDrive, vsWetDry, vsBias, vsSoftness,
   vsLowCrossover, vsMidCrossover,
   vsLowDriveMult, vsMidDriveMult, vsHighDriveMult,
-  vsPreview, vsInputDb, vsOutputDb, hasSelection,
+  vsPreview, vsInputDb, vsOutputDb, vsInputPeakDb, vsOutputPeakDb, hasSelection,
   togglePreview,
   syncDrive, syncWetDry, syncBias, syncSoftness,
   syncLowCrossover, syncMidCrossover,
@@ -65,7 +65,7 @@ async function applyAndClose() {
   >
     <div class="px-[26px] pt-[22px] pb-[24px]">
       <div class="flex items-center justify-between gap-[20px]">
-        <LevelMeter :db="vsInputDb" label="IN" :height="132" />
+        <LevelMeter :db="vsInputDb" :peak-db="vsInputPeakDb" label="IN" :height="132" />
 
         <!-- The four you dial by ear get knobs. -->
         <div class="flex-1 flex items-start justify-center gap-[30px]">
@@ -95,7 +95,7 @@ async function applyAndClose() {
           </div>
         </div>
 
-        <LevelMeter :db="vsOutputDb" label="OUT" :height="132" />
+        <LevelMeter :db="vsOutputDb" :peak-db="vsOutputPeakDb" label="OUT" :height="132" />
       </div>
 
       <!-- Band shaping: wide numeric ranges you read rather than feel, so

--- a/src/components/panels/windows/VocalSaturationWindow.vue
+++ b/src/components/panels/windows/VocalSaturationWindow.vue
@@ -14,7 +14,7 @@ const {
   vsDrive, vsWetDry, vsBias, vsSoftness,
   vsLowCrossover, vsMidCrossover,
   vsLowDriveMult, vsMidDriveMult, vsHighDriveMult,
-  vsPreview, vsInputDb, vsOutputDb, vsInputPeakDb, vsOutputPeakDb, hasSelection,
+  vsPreview, vsInputLevels, vsOutputLevels, hasSelection,
   togglePreview,
   syncDrive, syncWetDry, syncBias, syncSoftness,
   syncLowCrossover, syncMidCrossover,
@@ -65,7 +65,7 @@ async function applyAndClose() {
   >
     <div class="px-[26px] pt-[22px] pb-[24px]">
       <div class="flex items-center justify-between gap-[20px]">
-        <LevelMeter :db="vsInputDb" :peak-db="vsInputPeakDb" label="IN" :height="132" />
+        <LevelMeter :levels="vsInputLevels" label="IN" :height="132" />
 
         <!-- The four you dial by ear get knobs. -->
         <div class="flex-1 flex items-start justify-center gap-[30px]">
@@ -95,7 +95,7 @@ async function applyAndClose() {
           </div>
         </div>
 
-        <LevelMeter :db="vsOutputDb" :peak-db="vsOutputPeakDb" label="OUT" :height="132" />
+        <LevelMeter :levels="vsOutputLevels" label="OUT" :height="132" />
       </div>
 
       <!-- Band shaping: wide numeric ranges you read rather than feel, so

--- a/src/composables/useAirBand.js
+++ b/src/composables/useAirBand.js
@@ -4,6 +4,7 @@ import { useWindows } from './useWindows.js'
 import { applyAirBandRegion, computePeakCache } from '../audio/processing.js'
 import { getEffectChain } from '../audio/effectChain.js'
 import { airBandEffect, AIR_BAND_DEFAULTS } from '../audio/effects/airBand.js'
+import { snapshotLevels } from '../audio/effects/levelTap.js'
 
 // Registry id of this plugin's window. Must match the entry in src/ui/registry.js.
 export const AIR_BAND_WINDOW_ID = 'air-band'
@@ -12,10 +13,8 @@ export const AIR_BAND_WINDOW_ID = 'air-band'
 const airBandAir = ref(AIR_BAND_DEFAULTS.air)
 const airBandOutput = ref(AIR_BAND_DEFAULTS.output)
 const airBandPreview = ref(false)
-const airBandInputDb = ref(-Infinity)
-const airBandOutputDb = ref(-Infinity)
-const airBandInputPeakDb = ref(-Infinity)
-const airBandOutputPeakDb = ref(-Infinity)
+const airBandInputLevels = ref([])
+const airBandOutputLevels = ref([])
 let meterId = null
 
 function currentParams() {
@@ -46,12 +45,11 @@ export function useAirBand() {
     function tick() {
       const nodes = chain.effects.find(e => e.id === airBandEffect.id)?.nodes
       if (nodes) {
-        const inLevels = nodes.getInputLevels()
-        airBandInputDb.value = inLevels.rmsDb
-        airBandInputPeakDb.value = inLevels.peakDb
-        const outLevels = nodes.getOutputLevels()
-        airBandOutputDb.value = outLevels.rmsDb
-        airBandOutputPeakDb.value = outLevels.peakDb
+        // Only meter channels the source really has: the splitter is
+        // discrete, so asking for stereo on a mono file adds a dead bar.
+        const chCount = state.currentFile?.channels ?? 1
+        airBandInputLevels.value = snapshotLevels(nodes.getInputLevels(chCount))
+        airBandOutputLevels.value = snapshotLevels(nodes.getOutputLevels(chCount))
       }
       meterId = requestAnimationFrame(tick)
     }
@@ -63,10 +61,8 @@ export function useAirBand() {
       cancelAnimationFrame(meterId)
       meterId = null
     }
-    airBandInputDb.value = -Infinity
-    airBandOutputDb.value = -Infinity
-    airBandInputPeakDb.value = -Infinity
-    airBandOutputPeakDb.value = -Infinity
+    airBandInputLevels.value = []
+    airBandOutputLevels.value = []
   }
 
   function pushAllParams(chain) {
@@ -151,10 +147,8 @@ export function useAirBand() {
     airBandAir,
     airBandOutput,
     airBandPreview,
-    airBandInputDb,
-    airBandOutputDb,
-    airBandInputPeakDb,
-    airBandOutputPeakDb,
+    airBandInputLevels,
+    airBandOutputLevels,
     hasSelection,
     togglePreview,
     syncAir,

--- a/src/composables/useAirBand.js
+++ b/src/composables/useAirBand.js
@@ -14,6 +14,8 @@ const airBandOutput = ref(AIR_BAND_DEFAULTS.output)
 const airBandPreview = ref(false)
 const airBandInputDb = ref(-Infinity)
 const airBandOutputDb = ref(-Infinity)
+const airBandInputPeakDb = ref(-Infinity)
+const airBandOutputPeakDb = ref(-Infinity)
 let meterId = null
 
 function currentParams() {
@@ -44,8 +46,12 @@ export function useAirBand() {
     function tick() {
       const nodes = chain.effects.find(e => e.id === airBandEffect.id)?.nodes
       if (nodes) {
-        airBandInputDb.value = nodes.getInputLevelDb()
-        airBandOutputDb.value = nodes.getOutputLevelDb()
+        const inLevels = nodes.getInputLevels()
+        airBandInputDb.value = inLevels.rmsDb
+        airBandInputPeakDb.value = inLevels.peakDb
+        const outLevels = nodes.getOutputLevels()
+        airBandOutputDb.value = outLevels.rmsDb
+        airBandOutputPeakDb.value = outLevels.peakDb
       }
       meterId = requestAnimationFrame(tick)
     }
@@ -59,6 +65,8 @@ export function useAirBand() {
     }
     airBandInputDb.value = -Infinity
     airBandOutputDb.value = -Infinity
+    airBandInputPeakDb.value = -Infinity
+    airBandOutputPeakDb.value = -Infinity
   }
 
   function pushAllParams(chain) {
@@ -145,6 +153,8 @@ export function useAirBand() {
     airBandPreview,
     airBandInputDb,
     airBandOutputDb,
+    airBandInputPeakDb,
+    airBandOutputPeakDb,
     hasSelection,
     togglePreview,
     syncAir,

--- a/src/composables/useDeEsser.js
+++ b/src/composables/useDeEsser.js
@@ -50,6 +50,8 @@ const preview = ref(false)
 const reductionDb = ref(0)
 const inputDb = ref(-Infinity)
 const outputDb = ref(-Infinity)
+const inputPeakDb = ref(-Infinity)
+const outputPeakDb = ref(-Infinity)
 const treatedCount = ref(0)
 const maxReductionDb = ref(0)
 let meterId = null
@@ -122,8 +124,12 @@ export function useDeEsser() {
     function tick(nowMs) {
       const nodes = chain.effects.find(e => e.id === clipGainDeEsserEffect.id)?.nodes
       if (nodes) {
-        inputDb.value = nodes.getInputLevelDb()
-        outputDb.value = nodes.getOutputLevelDb()
+        const inLevels = nodes.getInputLevels()
+        inputDb.value = inLevels.rmsDb
+        inputPeakDb.value = inLevels.peakDb
+        const outLevels = nodes.getOutputLevels()
+        outputDb.value = outLevels.rmsDb
+        outputPeakDb.value = outLevels.peakDb
 
         // Both values are <= 0, so "more reduction" is more negative. Attack is
         // instantaneous — the peak the node reports for this frame is shown in
@@ -152,6 +158,8 @@ export function useDeEsser() {
     meterLastMs = 0
     inputDb.value = -Infinity
     outputDb.value = -Infinity
+    inputPeakDb.value = -Infinity
+    outputPeakDb.value = -Infinity
     reductionDb.value = 0
   }
 
@@ -324,7 +332,7 @@ export function useDeEsser() {
 
   return {
     params, preview, analysis, analyzing, measuredEvents,
-    treatedCount, maxReductionDb, reductionDb, inputDb, outputDb,
+    treatedCount, maxReductionDb, reductionDb, inputDb, outputDb, inputPeakDb, outputPeakDb,
     tuning, syncTuning, resetTuning,
     hasAnalysis, hasSelection, isStale, envelopeValid, analyzedRegion,
     togglePreview, syncParam, analyze, apply, teardown,

--- a/src/composables/useDeEsser.js
+++ b/src/composables/useDeEsser.js
@@ -10,6 +10,7 @@ import {
   renderDeEsserEnvelope,
 } from '../audio/effects/clipGainDeEss.js'
 import { regionCovers } from '../audio/dsp/clipGainDecision.js'
+import { snapshotLevels } from '../audio/effects/levelTap.js'
 
 export const DEESSER_WINDOW_ID = 'clip-gain-deesser'
 
@@ -48,10 +49,8 @@ const tuning = ref({})
 const params = ref({ ...DEESSER_DEFAULTS })
 const preview = ref(false)
 const reductionDb = ref(0)
-const inputDb = ref(-Infinity)
-const outputDb = ref(-Infinity)
-const inputPeakDb = ref(-Infinity)
-const outputPeakDb = ref(-Infinity)
+const inputLevels = ref([])
+const outputLevels = ref([])
 const treatedCount = ref(0)
 const maxReductionDb = ref(0)
 let meterId = null
@@ -124,12 +123,11 @@ export function useDeEsser() {
     function tick(nowMs) {
       const nodes = chain.effects.find(e => e.id === clipGainDeEsserEffect.id)?.nodes
       if (nodes) {
-        const inLevels = nodes.getInputLevels()
-        inputDb.value = inLevels.rmsDb
-        inputPeakDb.value = inLevels.peakDb
-        const outLevels = nodes.getOutputLevels()
-        outputDb.value = outLevels.rmsDb
-        outputPeakDb.value = outLevels.peakDb
+        // Only meter channels the source really has: the splitter is
+        // discrete, so asking for stereo on a mono file adds a dead bar.
+        const chCount = state.currentFile?.channels ?? 1
+        inputLevels.value = snapshotLevels(nodes.getInputLevels(chCount))
+        outputLevels.value = snapshotLevels(nodes.getOutputLevels(chCount))
 
         // Both values are <= 0, so "more reduction" is more negative. Attack is
         // instantaneous — the peak the node reports for this frame is shown in
@@ -156,10 +154,8 @@ export function useDeEsser() {
       meterId = null
     }
     meterLastMs = 0
-    inputDb.value = -Infinity
-    outputDb.value = -Infinity
-    inputPeakDb.value = -Infinity
-    outputPeakDb.value = -Infinity
+    inputLevels.value = []
+    outputLevels.value = []
     reductionDb.value = 0
   }
 
@@ -332,7 +328,7 @@ export function useDeEsser() {
 
   return {
     params, preview, analysis, analyzing, measuredEvents,
-    treatedCount, maxReductionDb, reductionDb, inputDb, outputDb, inputPeakDb, outputPeakDb,
+    treatedCount, maxReductionDb, reductionDb, inputLevels, outputLevels,
     tuning, syncTuning, resetTuning,
     hasAnalysis, hasSelection, isStale, envelopeValid, analyzedRegion,
     togglePreview, syncParam, analyze, apply, teardown,

--- a/src/composables/useEqInstance.js
+++ b/src/composables/useEqInstance.js
@@ -3,6 +3,7 @@ import { useEditorState } from './useEditorState.js'
 import { useWindows } from './useWindows.js'
 import { applyManualEqRegion, computePeakCache } from '../audio/processing.js'
 import { getEffectChain } from '../audio/effectChain.js'
+import { snapshotLevels } from '../audio/effects/levelTap.js'
 import {
   MAX_BANDS, createBand, applyForfeiture, setBandFrequency, setBandQ,
   resetBandQ, isBandActive, PARAM_RANGES, clamp, qRangeFor, clampBandToRole,
@@ -46,10 +47,8 @@ export function createEqInstance({
    * Mutually exclusive with soloBandId — setting either clears the other.
    */
   const soloProbe = ref(null)
-  const inputDb = ref(-Infinity)
-  const outputDb = ref(-Infinity)
-  const inputPeakDb = ref(-Infinity)
-  const outputPeakDb = ref(-Infinity)
+  const inputLevels = ref([])
+  const outputLevels = ref([])
 
   let meterId = null
 
@@ -95,12 +94,11 @@ export function createEqInstance({
       function tick() {
         const n = chain.effects.find(e => e.id === effect.id)?.nodes
         if (n) {
-          const inLevels = n.getInputLevels()
-          inputDb.value = inLevels.rmsDb
-          inputPeakDb.value = inLevels.peakDb
-          const outLevels = n.getOutputLevels()
-          outputDb.value = outLevels.rmsDb
-          outputPeakDb.value = outLevels.peakDb
+          // Only meter channels the source really has: the splitter is
+          // discrete, so asking for stereo on a mono file adds a dead bar.
+          const chCount = state.currentFile?.channels ?? 1
+          inputLevels.value = snapshotLevels(n.getInputLevels(chCount))
+          outputLevels.value = snapshotLevels(n.getOutputLevels(chCount))
         }
         meterId = requestAnimationFrame(tick)
       }
@@ -112,10 +110,8 @@ export function createEqInstance({
         cancelAnimationFrame(meterId)
         meterId = null
       }
-      inputDb.value = -Infinity
-      outputDb.value = -Infinity
-      inputPeakDb.value = -Infinity
-      outputPeakDb.value = -Infinity
+      inputLevels.value = []
+      outputLevels.value = []
     }
 
     function togglePreview() {
@@ -293,7 +289,7 @@ export function createEqInstance({
 
     return {
       // state
-      bands, eqPreview, outputTrim, soloBandId, soloProbe, inputDb, outputDb, inputPeakDb, outputPeakDb,
+      bands, eqPreview, outputTrim, soloBandId, soloProbe, inputLevels, outputLevels,
       hasSelection, atBandLimit, maxBands,
       activeBands: computed(() => bands.value.filter(isBandActive)),
 

--- a/src/composables/useEqInstance.js
+++ b/src/composables/useEqInstance.js
@@ -48,6 +48,8 @@ export function createEqInstance({
   const soloProbe = ref(null)
   const inputDb = ref(-Infinity)
   const outputDb = ref(-Infinity)
+  const inputPeakDb = ref(-Infinity)
+  const outputPeakDb = ref(-Infinity)
 
   let meterId = null
 
@@ -93,8 +95,12 @@ export function createEqInstance({
       function tick() {
         const n = chain.effects.find(e => e.id === effect.id)?.nodes
         if (n) {
-          inputDb.value = n.getInputLevelDb()
-          outputDb.value = n.getOutputLevelDb()
+          const inLevels = n.getInputLevels()
+          inputDb.value = inLevels.rmsDb
+          inputPeakDb.value = inLevels.peakDb
+          const outLevels = n.getOutputLevels()
+          outputDb.value = outLevels.rmsDb
+          outputPeakDb.value = outLevels.peakDb
         }
         meterId = requestAnimationFrame(tick)
       }
@@ -108,6 +114,8 @@ export function createEqInstance({
       }
       inputDb.value = -Infinity
       outputDb.value = -Infinity
+      inputPeakDb.value = -Infinity
+      outputPeakDb.value = -Infinity
     }
 
     function togglePreview() {
@@ -285,7 +293,7 @@ export function createEqInstance({
 
     return {
       // state
-      bands, eqPreview, outputTrim, soloBandId, soloProbe, inputDb, outputDb,
+      bands, eqPreview, outputTrim, soloBandId, soloProbe, inputDb, outputDb, inputPeakDb, outputPeakDb,
       hasSelection, atBandLimit, maxBands,
       activeBands: computed(() => bands.value.filter(isBandActive)),
 

--- a/src/composables/useFET1176.js
+++ b/src/composables/useFET1176.js
@@ -35,6 +35,8 @@ const fetPreview = ref(false)
 const fetReduction = ref(0)
 const fetInputDb = ref(-Infinity)
 const fetOutputDb = ref(-Infinity)
+const fetInputPeakDb = ref(-Infinity)
+const fetOutputPeakDb = ref(-Infinity)
 let meterId = null
 
 // Debounce + supersede state for the auto-makeup measurement, shared across
@@ -91,8 +93,12 @@ export function useFET1176() {
       const nodes = chain.effects.find(e => e.id === fet1176Effect.id)?.nodes
       if (nodes) {
         fetReduction.value = nodes.getReduction()
-        fetInputDb.value = nodes.getInputLevelDb()
-        fetOutputDb.value = nodes.getOutputLevelDb()
+        const inLevels = nodes.getInputLevels()
+        fetInputDb.value = inLevels.rmsDb
+        fetInputPeakDb.value = inLevels.peakDb
+        const outLevels = nodes.getOutputLevels()
+        fetOutputDb.value = outLevels.rmsDb
+        fetOutputPeakDb.value = outLevels.peakDb
       }
       meterId = requestAnimationFrame(tick)
     }
@@ -107,6 +113,8 @@ export function useFET1176() {
     fetReduction.value = 0
     fetInputDb.value = -Infinity
     fetOutputDb.value = -Infinity
+    fetInputPeakDb.value = -Infinity
+    fetOutputPeakDb.value = -Infinity
   }
 
   function pushAllParams(chain) {
@@ -294,6 +302,8 @@ export function useFET1176() {
     fetReduction,
     fetInputDb,
     fetOutputDb,
+    fetInputPeakDb,
+    fetOutputPeakDb,
     hasSelection,
     togglePreview,
     syncInput,

--- a/src/composables/useFET1176.js
+++ b/src/composables/useFET1176.js
@@ -4,6 +4,7 @@ import { useWindows } from './useWindows.js'
 import { applyFET1176Region, computeFET1176AutoMakeup, computePeakCache } from '../audio/processing.js'
 import { getEffectChain } from '../audio/effectChain.js'
 import { fet1176Effect, FET1176_DEFAULTS } from '../audio/effects/fet1176Compressor.js'
+import { snapshotLevels } from '../audio/effects/levelTap.js'
 
 // Registry id of this plugin's window. Must match the entry in src/ui/registry.js.
 export const FET1176_WINDOW_ID = 'fet-punch'
@@ -33,10 +34,8 @@ const OUTPUT_MAX_DB = 24
 
 const fetPreview = ref(false)
 const fetReduction = ref(0)
-const fetInputDb = ref(-Infinity)
-const fetOutputDb = ref(-Infinity)
-const fetInputPeakDb = ref(-Infinity)
-const fetOutputPeakDb = ref(-Infinity)
+const fetInputLevels = ref([])
+const fetOutputLevels = ref([])
 let meterId = null
 
 // Debounce + supersede state for the auto-makeup measurement, shared across
@@ -93,12 +92,11 @@ export function useFET1176() {
       const nodes = chain.effects.find(e => e.id === fet1176Effect.id)?.nodes
       if (nodes) {
         fetReduction.value = nodes.getReduction()
-        const inLevels = nodes.getInputLevels()
-        fetInputDb.value = inLevels.rmsDb
-        fetInputPeakDb.value = inLevels.peakDb
-        const outLevels = nodes.getOutputLevels()
-        fetOutputDb.value = outLevels.rmsDb
-        fetOutputPeakDb.value = outLevels.peakDb
+        // Only meter channels the source really has: the splitter is
+        // discrete, so asking for stereo on a mono file adds a dead bar.
+        const chCount = state.currentFile?.channels ?? 1
+        fetInputLevels.value = snapshotLevels(nodes.getInputLevels(chCount))
+        fetOutputLevels.value = snapshotLevels(nodes.getOutputLevels(chCount))
       }
       meterId = requestAnimationFrame(tick)
     }
@@ -111,10 +109,8 @@ export function useFET1176() {
       meterId = null
     }
     fetReduction.value = 0
-    fetInputDb.value = -Infinity
-    fetOutputDb.value = -Infinity
-    fetInputPeakDb.value = -Infinity
-    fetOutputPeakDb.value = -Infinity
+    fetInputLevels.value = []
+    fetOutputLevels.value = []
   }
 
   function pushAllParams(chain) {
@@ -300,10 +296,8 @@ export function useFET1176() {
     fetAutoMakeupBusy,
     fetPreview,
     fetReduction,
-    fetInputDb,
-    fetOutputDb,
-    fetInputPeakDb,
-    fetOutputPeakDb,
+    fetInputLevels,
+    fetOutputLevels,
     hasSelection,
     togglePreview,
     syncInput,

--- a/src/composables/useHumRemover.js
+++ b/src/composables/useHumRemover.js
@@ -37,6 +37,8 @@ const analyzedKey = ref(null)
 const humPreview = ref(false)
 const humInputDb = ref(-Infinity)
 const humOutputDb = ref(-Infinity)
+const humInputPeakDb = ref(-Infinity)
+const humOutputPeakDb = ref(-Infinity)
 let meterId = null
 
 /** Frequencies the user currently has ticked. */
@@ -88,8 +90,12 @@ export function useHumRemover() {
     function tick() {
       const nodes = chain.effects.find(e => e.id === humNotchEffect.id)?.nodes
       if (nodes) {
-        humInputDb.value = nodes.getInputLevelDb()
-        humOutputDb.value = nodes.getOutputLevelDb()
+        const inLevels = nodes.getInputLevels()
+        humInputDb.value = inLevels.rmsDb
+        humInputPeakDb.value = inLevels.peakDb
+        const outLevels = nodes.getOutputLevels()
+        humOutputDb.value = outLevels.rmsDb
+        humOutputPeakDb.value = outLevels.peakDb
       }
       meterId = requestAnimationFrame(tick)
     }
@@ -103,6 +109,8 @@ export function useHumRemover() {
     }
     humInputDb.value = -Infinity
     humOutputDb.value = -Infinity
+    humInputPeakDb.value = -Infinity
+    humOutputPeakDb.value = -Infinity
   }
 
   function pushAllParams(chain) {
@@ -270,6 +278,8 @@ export function useHumRemover() {
     humPreview,
     humInputDb,
     humOutputDb,
+    humInputPeakDb,
+    humOutputPeakDb,
     isStale,
     hasEnabledNotches,
     hasSelection,

--- a/src/composables/useHumRemover.js
+++ b/src/composables/useHumRemover.js
@@ -8,6 +8,7 @@ import {
 } from '../audio/processing.js'
 import { getEffectChain } from '../audio/effectChain.js'
 import { humNotchEffect, HUM_NOTCH_DEFAULTS } from '../audio/effects/humNotch.js'
+import { snapshotLevels } from '../audio/effects/levelTap.js'
 
 // Registry id of this plugin's window. Must match the entry in src/ui/registry.js.
 export const HUM_REMOVER_WINDOW_ID = 'hum-remover'
@@ -35,10 +36,8 @@ const humAnalyzing = ref(false)
 const analyzedKey = ref(null)
 
 const humPreview = ref(false)
-const humInputDb = ref(-Infinity)
-const humOutputDb = ref(-Infinity)
-const humInputPeakDb = ref(-Infinity)
-const humOutputPeakDb = ref(-Infinity)
+const humInputLevels = ref([])
+const humOutputLevels = ref([])
 let meterId = null
 
 /** Frequencies the user currently has ticked. */
@@ -90,12 +89,11 @@ export function useHumRemover() {
     function tick() {
       const nodes = chain.effects.find(e => e.id === humNotchEffect.id)?.nodes
       if (nodes) {
-        const inLevels = nodes.getInputLevels()
-        humInputDb.value = inLevels.rmsDb
-        humInputPeakDb.value = inLevels.peakDb
-        const outLevels = nodes.getOutputLevels()
-        humOutputDb.value = outLevels.rmsDb
-        humOutputPeakDb.value = outLevels.peakDb
+        // Only meter channels the source really has: the splitter is
+        // discrete, so asking for stereo on a mono file adds a dead bar.
+        const chCount = state.currentFile?.channels ?? 1
+        humInputLevels.value = snapshotLevels(nodes.getInputLevels(chCount))
+        humOutputLevels.value = snapshotLevels(nodes.getOutputLevels(chCount))
       }
       meterId = requestAnimationFrame(tick)
     }
@@ -107,10 +105,8 @@ export function useHumRemover() {
       cancelAnimationFrame(meterId)
       meterId = null
     }
-    humInputDb.value = -Infinity
-    humOutputDb.value = -Infinity
-    humInputPeakDb.value = -Infinity
-    humOutputPeakDb.value = -Infinity
+    humInputLevels.value = []
+    humOutputLevels.value = []
   }
 
   function pushAllParams(chain) {
@@ -276,10 +272,8 @@ export function useHumRemover() {
     humAnalysis,
     humAnalyzing,
     humPreview,
-    humInputDb,
-    humOutputDb,
-    humInputPeakDb,
-    humOutputPeakDb,
+    humInputLevels,
+    humOutputLevels,
     isStale,
     hasEnabledNotches,
     hasSelection,

--- a/src/composables/useLA2A.js
+++ b/src/composables/useLA2A.js
@@ -4,6 +4,7 @@ import { useWindows } from './useWindows.js'
 import { applyLA2ARegion, computeLA2AAutoMakeup, computePeakCache } from '../audio/processing.js'
 import { getEffectChain } from '../audio/effectChain.js'
 import { la2aEffect, LA2A_DEFAULTS } from '../audio/effects/la2aCompressor.js'
+import { snapshotLevels } from '../audio/effects/levelTap.js'
 
 // Registry id of this plugin's window. Must match the entry in src/ui/registry.js.
 export const LA2A_WINDOW_ID = 'opto-smooth'
@@ -28,10 +29,8 @@ const GAIN_MIN_DB = -12
 const GAIN_MAX_DB = 24
 const la2aPreview = ref(false)
 const la2aReduction = ref(0)
-const la2aInputDb = ref(-Infinity)
-const la2aOutputDb = ref(-Infinity)
-const la2aInputPeakDb = ref(-Infinity)
-const la2aOutputPeakDb = ref(-Infinity)
+const la2aInputLevels = ref([])
+const la2aOutputLevels = ref([])
 let meterId = null
 
 // Debounce + supersede state for the auto-makeup measurement, shared across
@@ -84,12 +83,11 @@ export function useLA2A() {
       const nodes = chain.effects.find(e => e.id === la2aEffect.id)?.nodes
       if (nodes) {
         la2aReduction.value = nodes.getReduction()
-        const inLevels = nodes.getInputLevels()
-        la2aInputDb.value = inLevels.rmsDb
-        la2aInputPeakDb.value = inLevels.peakDb
-        const outLevels = nodes.getOutputLevels()
-        la2aOutputDb.value = outLevels.rmsDb
-        la2aOutputPeakDb.value = outLevels.peakDb
+        // Only meter channels the source really has: the splitter is
+        // discrete, so asking for stereo on a mono file adds a dead bar.
+        const chCount = state.currentFile?.channels ?? 1
+        la2aInputLevels.value = snapshotLevels(nodes.getInputLevels(chCount))
+        la2aOutputLevels.value = snapshotLevels(nodes.getOutputLevels(chCount))
       }
       meterId = requestAnimationFrame(tick)
     }
@@ -102,10 +100,8 @@ export function useLA2A() {
       meterId = null
     }
     la2aReduction.value = 0
-    la2aInputDb.value = -Infinity
-    la2aOutputDb.value = -Infinity
-    la2aInputPeakDb.value = -Infinity
-    la2aOutputPeakDb.value = -Infinity
+    la2aInputLevels.value = []
+    la2aOutputLevels.value = []
   }
 
   function pushAllParams(chain) {
@@ -285,10 +281,8 @@ export function useLA2A() {
     la2aAutoMakeupBusy,
     la2aPreview,
     la2aReduction,
-    la2aInputDb,
-    la2aOutputDb,
-    la2aInputPeakDb,
-    la2aOutputPeakDb,
+    la2aInputLevels,
+    la2aOutputLevels,
     hasSelection,
     togglePreview,
     syncMode,

--- a/src/composables/useLA2A.js
+++ b/src/composables/useLA2A.js
@@ -30,6 +30,8 @@ const la2aPreview = ref(false)
 const la2aReduction = ref(0)
 const la2aInputDb = ref(-Infinity)
 const la2aOutputDb = ref(-Infinity)
+const la2aInputPeakDb = ref(-Infinity)
+const la2aOutputPeakDb = ref(-Infinity)
 let meterId = null
 
 // Debounce + supersede state for the auto-makeup measurement, shared across
@@ -82,8 +84,12 @@ export function useLA2A() {
       const nodes = chain.effects.find(e => e.id === la2aEffect.id)?.nodes
       if (nodes) {
         la2aReduction.value = nodes.getReduction()
-        la2aInputDb.value = nodes.getInputLevelDb()
-        la2aOutputDb.value = nodes.getOutputLevelDb()
+        const inLevels = nodes.getInputLevels()
+        la2aInputDb.value = inLevels.rmsDb
+        la2aInputPeakDb.value = inLevels.peakDb
+        const outLevels = nodes.getOutputLevels()
+        la2aOutputDb.value = outLevels.rmsDb
+        la2aOutputPeakDb.value = outLevels.peakDb
       }
       meterId = requestAnimationFrame(tick)
     }
@@ -98,6 +104,8 @@ export function useLA2A() {
     la2aReduction.value = 0
     la2aInputDb.value = -Infinity
     la2aOutputDb.value = -Infinity
+    la2aInputPeakDb.value = -Infinity
+    la2aOutputPeakDb.value = -Infinity
   }
 
   function pushAllParams(chain) {
@@ -279,6 +287,8 @@ export function useLA2A() {
     la2aReduction,
     la2aInputDb,
     la2aOutputDb,
+    la2aInputPeakDb,
+    la2aOutputPeakDb,
     hasSelection,
     togglePreview,
     syncMode,

--- a/src/composables/useResonance.js
+++ b/src/composables/useResonance.js
@@ -4,6 +4,7 @@ import { useWindows } from './useWindows.js'
 import { applyResonanceRegion, computePeakCache } from '../audio/processing.js'
 import { getEffectChain } from '../audio/effectChain.js'
 import { resonanceEffect, RESONANCE_DEFAULTS } from '../audio/effects/resonance.js'
+import { snapshotLevels } from '../audio/effects/levelTap.js'
 
 // Registry id of this plugin's window. Must match the entry in src/ui/registry.js.
 export const RESONANCE_WINDOW_ID = 'resonance-suppressor'
@@ -23,10 +24,8 @@ const resPitchRange = ref(RESONANCE_DEFAULTS.pitchRange)
 
 const resPreview = ref(false)
 const resReduction = ref(0)
-const resInputDb = ref(-Infinity)
-const resOutputDb = ref(-Infinity)
-const resInputPeakDb = ref(-Infinity)
-const resOutputPeakDb = ref(-Infinity)
+const resInputLevels = ref([])
+const resOutputLevels = ref([])
 let meterId = null
 
 function currentParams() {
@@ -67,12 +66,11 @@ export function useResonance() {
       const nodes = chain.effects.find(e => e.id === resonanceEffect.id)?.nodes
       if (nodes) {
         resReduction.value = nodes.getReduction()
-        const inLevels = nodes.getInputLevels()
-        resInputDb.value = inLevels.rmsDb
-        resInputPeakDb.value = inLevels.peakDb
-        const outLevels = nodes.getOutputLevels()
-        resOutputDb.value = outLevels.rmsDb
-        resOutputPeakDb.value = outLevels.peakDb
+        // Only meter channels the source really has: the splitter is
+        // discrete, so asking for stereo on a mono file adds a dead bar.
+        const chCount = state.currentFile?.channels ?? 1
+        resInputLevels.value = snapshotLevels(nodes.getInputLevels(chCount))
+        resOutputLevels.value = snapshotLevels(nodes.getOutputLevels(chCount))
       }
       meterId = requestAnimationFrame(tick)
     }
@@ -85,10 +83,8 @@ export function useResonance() {
       meterId = null
     }
     resReduction.value = 0
-    resInputDb.value = -Infinity
-    resOutputDb.value = -Infinity
-    resInputPeakDb.value = -Infinity
-    resOutputPeakDb.value = -Infinity
+    resInputLevels.value = []
+    resOutputLevels.value = []
   }
 
   function pushAllParams(chain) {
@@ -193,10 +189,8 @@ export function useResonance() {
     resPitchRange,
     resPreview,
     resReduction,
-    resInputDb,
-    resOutputDb,
-    resInputPeakDb,
-    resOutputPeakDb,
+    resInputLevels,
+    resOutputLevels,
     hasSelection,
     togglePreview,
     syncDepth,

--- a/src/composables/useResonance.js
+++ b/src/composables/useResonance.js
@@ -25,6 +25,8 @@ const resPreview = ref(false)
 const resReduction = ref(0)
 const resInputDb = ref(-Infinity)
 const resOutputDb = ref(-Infinity)
+const resInputPeakDb = ref(-Infinity)
+const resOutputPeakDb = ref(-Infinity)
 let meterId = null
 
 function currentParams() {
@@ -65,8 +67,12 @@ export function useResonance() {
       const nodes = chain.effects.find(e => e.id === resonanceEffect.id)?.nodes
       if (nodes) {
         resReduction.value = nodes.getReduction()
-        resInputDb.value = nodes.getInputLevelDb()
-        resOutputDb.value = nodes.getOutputLevelDb()
+        const inLevels = nodes.getInputLevels()
+        resInputDb.value = inLevels.rmsDb
+        resInputPeakDb.value = inLevels.peakDb
+        const outLevels = nodes.getOutputLevels()
+        resOutputDb.value = outLevels.rmsDb
+        resOutputPeakDb.value = outLevels.peakDb
       }
       meterId = requestAnimationFrame(tick)
     }
@@ -81,6 +87,8 @@ export function useResonance() {
     resReduction.value = 0
     resInputDb.value = -Infinity
     resOutputDb.value = -Infinity
+    resInputPeakDb.value = -Infinity
+    resOutputPeakDb.value = -Infinity
   }
 
   function pushAllParams(chain) {
@@ -187,6 +195,8 @@ export function useResonance() {
     resReduction,
     resInputDb,
     resOutputDb,
+    resInputPeakDb,
+    resOutputPeakDb,
     hasSelection,
     togglePreview,
     syncDepth,

--- a/src/composables/useVocalSaturation.js
+++ b/src/composables/useVocalSaturation.js
@@ -22,6 +22,8 @@ const vsHighDriveMult = ref(VOCAL_SAT_DEFAULTS.highDriveMult)
 const vsPreview = ref(false)
 const vsInputDb = ref(-Infinity)
 const vsOutputDb = ref(-Infinity)
+const vsInputPeakDb = ref(-Infinity)
+const vsOutputPeakDb = ref(-Infinity)
 let meterId = null
 
 function currentParams() {
@@ -59,8 +61,12 @@ export function useVocalSaturation() {
     function tick() {
       const nodes = chain.effects.find(e => e.id === vocalSatEffect.id)?.nodes
       if (nodes) {
-        vsInputDb.value = nodes.getInputLevelDb()
-        vsOutputDb.value = nodes.getOutputLevelDb()
+        const inLevels = nodes.getInputLevels()
+        vsInputDb.value = inLevels.rmsDb
+        vsInputPeakDb.value = inLevels.peakDb
+        const outLevels = nodes.getOutputLevels()
+        vsOutputDb.value = outLevels.rmsDb
+        vsOutputPeakDb.value = outLevels.peakDb
       }
       meterId = requestAnimationFrame(tick)
     }
@@ -74,6 +80,8 @@ export function useVocalSaturation() {
     }
     vsInputDb.value = -Infinity
     vsOutputDb.value = -Infinity
+    vsInputPeakDb.value = -Infinity
+    vsOutputPeakDb.value = -Infinity
   }
 
   function pushAllParams(chain) {
@@ -172,6 +180,8 @@ export function useVocalSaturation() {
     vsPreview,
     vsInputDb,
     vsOutputDb,
+    vsInputPeakDb,
+    vsOutputPeakDb,
     hasSelection,
     togglePreview,
     syncDrive,

--- a/src/composables/useVocalSaturation.js
+++ b/src/composables/useVocalSaturation.js
@@ -4,6 +4,7 @@ import { useWindows } from './useWindows.js'
 import { applyVocalSatRegion, computePeakCache } from '../audio/processing.js'
 import { getEffectChain } from '../audio/effectChain.js'
 import { vocalSatEffect, VOCAL_SAT_DEFAULTS } from '../audio/effects/vocalSat.js'
+import { snapshotLevels } from '../audio/effects/levelTap.js'
 
 // Registry id of this plugin's window. Must match the entry in src/ui/registry.js.
 export const VOCAL_SAT_WINDOW_ID = 'vocal-saturation'
@@ -20,10 +21,8 @@ const vsMidDriveMult = ref(VOCAL_SAT_DEFAULTS.midDriveMult)
 const vsHighDriveMult = ref(VOCAL_SAT_DEFAULTS.highDriveMult)
 
 const vsPreview = ref(false)
-const vsInputDb = ref(-Infinity)
-const vsOutputDb = ref(-Infinity)
-const vsInputPeakDb = ref(-Infinity)
-const vsOutputPeakDb = ref(-Infinity)
+const vsInputLevels = ref([])
+const vsOutputLevels = ref([])
 let meterId = null
 
 function currentParams() {
@@ -61,12 +60,11 @@ export function useVocalSaturation() {
     function tick() {
       const nodes = chain.effects.find(e => e.id === vocalSatEffect.id)?.nodes
       if (nodes) {
-        const inLevels = nodes.getInputLevels()
-        vsInputDb.value = inLevels.rmsDb
-        vsInputPeakDb.value = inLevels.peakDb
-        const outLevels = nodes.getOutputLevels()
-        vsOutputDb.value = outLevels.rmsDb
-        vsOutputPeakDb.value = outLevels.peakDb
+        // Only meter channels the source really has: the splitter is
+        // discrete, so asking for stereo on a mono file adds a dead bar.
+        const chCount = state.currentFile?.channels ?? 1
+        vsInputLevels.value = snapshotLevels(nodes.getInputLevels(chCount))
+        vsOutputLevels.value = snapshotLevels(nodes.getOutputLevels(chCount))
       }
       meterId = requestAnimationFrame(tick)
     }
@@ -78,10 +76,8 @@ export function useVocalSaturation() {
       cancelAnimationFrame(meterId)
       meterId = null
     }
-    vsInputDb.value = -Infinity
-    vsOutputDb.value = -Infinity
-    vsInputPeakDb.value = -Infinity
-    vsOutputPeakDb.value = -Infinity
+    vsInputLevels.value = []
+    vsOutputLevels.value = []
   }
 
   function pushAllParams(chain) {
@@ -178,10 +174,8 @@ export function useVocalSaturation() {
     vsMidDriveMult,
     vsHighDriveMult,
     vsPreview,
-    vsInputDb,
-    vsOutputDb,
-    vsInputPeakDb,
-    vsOutputPeakDb,
+    vsInputLevels,
+    vsOutputLevels,
     hasSelection,
     togglePreview,
     syncDrive,


### PR DESCRIPTION
…cale

The colour zones were being applied to the fill element, whose height is the reading, so the gradient stops resolved against the fill rather than the track. Every level rendered with a red tip regardless of how quiet it was. Pin the gradient to the full track height and anchor it to the bottom edge, and put the zone edges on round numbers (-18, -6) that land on tick marks.

Extend the level tap to return sample peak alongside RMS. One window is 1024 samples and a 60 Hz caller advances 735, so consecutive windows overlap and no sample goes unseen — enough to drive an over indicator honestly. The bar stays RMS; peak feeds a hold line, the numeric readout and a latching over lamp that clears on click. Clipping was previously invisible, since the scale hard-clamps at 0 dBFS.

Add a calibrated scale. The existing segment ruling is pixel-based against a caller-supplied height, so one segment meant 2.4 dB in Resonance, 1.8 dB in VoiceRx and 3.0 dB in AirBand — same-looking meter, three scales. Ticks now sit at true dB positions, numbered where they stay legible, following the approach already used on the VU meter face.

Also drop smoothingTimeConstant from the level tap, which only affects the FFT behind getFloatFrequencyData and did nothing on a time-domain-only read, and drop the CSS transition on the fill: at 60 fps updates it restarted every frame and never reached its target. Designed ballistics are a separate job.

Meters render role="meter" with value and text for assistive tech.


Claude-Session: https://claude.ai/code/session_01Xhjxz48V7EWgKZQ7iunwnB